### PR TITLE
TST: Add CMake and gtest frameworks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -32,5 +32,11 @@ jobs:
       working-directory: build
       run: ctest
     - name: Generating coverage report
-      run: cmake --build build --target coverage
+      run: cmake --build build --target coverage_html
+
+    - name: Upload HTML coverage report
+      uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
+      with:
+        name: cov-html
+        path: build/coverage_report/**
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,36 @@
+name: Coverage
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+   contents: read  # to fetch code (actions/checkout)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  codecov:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+    - name: Install packages
+      run: sudo apt-get install -y lcov
+
+    - name: Configure
+      run: cmake -DCMAKE_BUILD_TYPE=Coverage -S . -B build
+    - name: Build
+      run: cmake --build build
+    - name: Run Tests
+      working-directory: build
+      run: ctest
+    - name: Generating coverage report
+      run: cmake --build build --target coverage
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+build/
+
 # Prerequisites
 *.d
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.14)
+project(xsf)
+
+# Scipy requ C++17
+# https://docs.scipy.org/doc/scipy/dev/toolchain.html#c-language-standards
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Tests
+enable_testing()
+add_subdirectory(tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project(xsf)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+include_directories(${CMAKE_SOURCE_DIR}/include)
+
 # Tests
 enable_testing()
 add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,8 @@
 include(FetchContent)
 FetchContent_Declare(
   googletest
-  URL https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG        b514bdc898e2951020cbdca1304b75f5950d1f59  # v1.15.2
 )
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,10 @@ FetchContent_MakeAvailable(googletest)
 include(GoogleTest)
 
 # Add Tests
-add_executable(airy airy.cpp)
-target_link_libraries(airy GTest::gtest_main)
-gtest_discover_tests(airy)
+function(add_gtest test_name)
+    add_executable(${test_name} ${test_name}.cpp)
+    target_link_libraries(${test_name} GTest::gtest_main)
+    gtest_discover_tests(${test_name})
+endfunction()
+
+add_gtest(airy)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,9 @@ FetchContent_Declare(
 # For Windows: Prevent overriding the parent project's compiler/linker settings
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
+
 include(GoogleTest)
+include(${CMAKE_SOURCE_DIR}/tests/Coverage.cmake)
 
 # Add Tests
 function(add_gtest test_name)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Get googletest
+# https://google.github.io/googletest/quickstart-cmake.html
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/releases/download/v1.15.2/googletest-1.15.2.tar.gz
+)
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
+include(GoogleTest)
+
+# Add Tests
+add_executable(airy airy.cpp)
+target_link_libraries(airy GTest::gtest_main)
+gtest_discover_tests(airy)

--- a/tests/Coverage.cmake
+++ b/tests/Coverage.cmake
@@ -1,0 +1,30 @@
+if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
+
+# Enable coverage compilation option
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+endif()
+if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /coverage")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /coverage")
+endif()
+
+# Add custom targets for generating coverage reports
+add_custom_target(coverage
+    COMMAND /usr/bin/lcov --capture --directory . --output-file coverage.info
+    COMMAND /usr/bin/lcov --output-file coverage.info --extract coverage.info '*/include/xsf/*'
+    COMMAND /usr/bin/lcov --list coverage.info
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Generating coverage report"
+)
+
+# Generate coverage reports in HTML format
+add_custom_target(coverage_html
+    COMMAND genhtml --demangle-cpp --legend coverage.info --output-directory coverage_report
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Generating HTML coverage report"
+)
+add_dependencies(coverage_html coverage)
+
+endif() # CMAKE_BUILD_TYPE=Coverage

--- a/tests/Coverage.cmake
+++ b/tests/Coverage.cmake
@@ -12,9 +12,9 @@ endif()
 
 # Add custom targets for generating coverage reports
 add_custom_target(coverage
-    COMMAND /usr/bin/lcov --capture --directory . --output-file coverage.info
-    COMMAND /usr/bin/lcov --output-file coverage.info --extract coverage.info '*/include/xsf/*'
-    COMMAND /usr/bin/lcov --list coverage.info
+    COMMAND lcov --capture --directory . --output-file coverage.info
+    COMMAND lcov --output-file coverage.info --extract coverage.info '*/include/xsf/*'
+    COMMAND lcov --list coverage.info
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     COMMENT "Generating coverage report"
 )

--- a/tests/airy.cpp
+++ b/tests/airy.cpp
@@ -1,5 +1,46 @@
+#include <limits>
+#include <complex>
 #include <gtest/gtest.h>
+#include <xsf/airy.h>
 
 TEST(Airy, BasicAssertions) {
-  EXPECT_EQ(7 * 6, 42);
+  const double nan64 = std::numeric_limits<double>::quiet_NaN();
+  const std::complex<double> nan64c(std::nan(""), std::nan(""));
+  double x, ai, aip, bi, bip;
+  
+  x = 0.0;
+  xsf::airy(x, ai, aip, bi, bip);
+  EXPECT_NE(ai, nan64);
+  EXPECT_NE(aip, nan64);
+  EXPECT_NE(bi, nan64);
+  EXPECT_NE(bip, nan64);
+
+  xsf::airye(x, ai, aip, bi, bip);
+  EXPECT_NE(ai, nan64);
+  EXPECT_NE(aip, nan64);
+  EXPECT_NE(bi, nan64);
+  EXPECT_NE(bip, nan64);
+
+  double apt, bpt, ant, bnt;
+  x = 1.0;
+  xsf::itairy(x, apt, bpt, ant, bnt);
+  EXPECT_NE(apt, nan64);
+  EXPECT_NE(bpt, nan64);
+  EXPECT_NE(ant, nan64);
+  EXPECT_NE(bnt, nan64);
+
+  // std::complex
+  std::complex<double> z, cai, caip, cbi, cbip;
+  z = 0.0;
+  xsf::airy(z, cai, caip, cbi, cbip);
+  EXPECT_NE(cai, nan64c);
+  EXPECT_NE(caip, nan64c);
+  EXPECT_NE(cbi, nan64c);
+  EXPECT_NE(cbip, nan64c);
+
+  xsf::airye(z, cai, caip, cbi, cbip);
+  EXPECT_NE(cai, nan64c);
+  EXPECT_NE(caip, nan64c);
+  EXPECT_NE(cbi, nan64c);
+  EXPECT_NE(cbip, nan64c);
 }

--- a/tests/airy.cpp
+++ b/tests/airy.cpp
@@ -1,0 +1,5 @@
+#include <gtest/gtest.h>
+
+TEST(Airy, BasicAssertions) {
+  EXPECT_EQ(7 * 6, 42);
+}


### PR DESCRIPTION
This is a POC that currently sets up a basic CMake + gtest test environment.

- [x] CMake
- [x] gtest
- [x] github CI, Generate and upload coverage report

Build and generating coverage report:
```sh
# sudo apt-get install -y lcov

cmake -DCMAKE_BUILD_TYPE=Coverage -S . -B build
cd build && make && ctest
make coverage_html

# build\coverage_report
```

Sample:
- [Codecov report](https://app.codecov.io/gh/inkydragon/xsf/tree/main/include%2Fxsf)
	- Need to set up codecov CI and patch: [inkydragon/xsf@`73c842f` (#1)](https://github.com/inkydragon/xsf/pull/1/commits/73c842f8c9bcedd8d63aedda8eb0f8d321fd9b6d)
	- Only a small number of files are shown in the report 
	because the test code only calls the airy-related functions
- [HTML coverage report](https://github.com/inkydragon/xsf/actions/runs/11814616780)
