### PR TITLE
MAINT: Incorporate relevant updates which have been made in SciPy since migration

### DIFF
--- a/include/xsf/amos.h
+++ b/include/xsf/amos.h
@@ -5,9 +5,12 @@
 
 namespace xsf {
 
+//
+// Return sf_error equivalents for AMOS ierr values.
+// 'ierr' refers to the last parameter of the AMOS functions
+// airy(), besh(), besi(), besj(), besk(), besy(), and biry().
+//
 inline sf_error_t ierr_to_sferr(int nz, int ierr) {
-    /* Return sf_error equivalents for amos ierr values */
-
     if (nz != 0) {
         return SF_ERROR_UNDERFLOW;
     }
@@ -23,6 +26,8 @@ inline sf_error_t ierr_to_sferr(int nz, int ierr) {
         return SF_ERROR_NO_RESULT;
     case 5: /* Algorithm termination condition not met */
         return SF_ERROR_NO_RESULT;
+    case 6: /* Memory allocation failed */
+        return SF_ERROR_MEMORY;
     }
 
     return SF_ERROR_OK;

--- a/include/xsf/cephes/chdtr.h
+++ b/include/xsf/cephes/chdtr.h
@@ -162,9 +162,10 @@ namespace xsf {
 namespace cephes {
 
     XSF_HOST_DEVICE inline double chdtrc(double df, double x) {
-
-        if (x < 0.0)
-            return 1.0; /* modified by T. Oliphant */
+        if (x < 0.0) {
+            set_error("chdtr", SF_ERROR_DOMAIN, NULL);
+            return (std::numeric_limits<double>::quiet_NaN());
+	}
         return (igamc(df / 2.0, x / 2.0));
     }
 

--- a/include/xsf/cephes/igam.h
+++ b/include/xsf/cephes/igam.h
@@ -328,6 +328,10 @@ namespace cephes {
     XSF_HOST_DEVICE inline double igam(double a, double x) {
         double absxma_a;
 
+	if (std::isnan(a) || std::isnan(x)) {
+	    return std::numeric_limits<double>::quiet_NaN();
+	}
+
         if (x < 0 || a < 0) {
             set_error("gammainc", SF_ERROR_DOMAIN, NULL);
             return std::numeric_limits<double>::quiet_NaN();
@@ -366,6 +370,10 @@ namespace cephes {
 
     XSF_HOST_DEVICE double igamc(double a, double x) {
         double absxma_a;
+
+	if (std::isnan(a) || std::isnan(x)) {
+	    return std::numeric_limits<double>::quiet_NaN();
+	}
 
         if (x < 0 || a < 0) {
             set_error("gammaincc", SF_ERROR_DOMAIN, NULL);

--- a/include/xsf/error.h
+++ b/include/xsf/error.h
@@ -11,6 +11,7 @@ typedef enum {
     SF_ERROR_DOMAIN,    /* out of domain */
     SF_ERROR_ARG,       /* invalid input parameter */
     SF_ERROR_OTHER,     /* unclassified error */
+    SF_ERROR_MEMORY,    /* memory allocation failed */
     SF_ERROR__LAST
 } sf_error_t;
 

--- a/include/xsf/log_exp.h
+++ b/include/xsf/log_exp.h
@@ -3,6 +3,7 @@
 #include <cmath>
 
 #include "config.h"
+#include "error.h"
 
 namespace xsf {
 
@@ -64,5 +65,23 @@ T log_expit(T x) {
 
     return -std::log1p(std::exp(-x));
 };
+
+
+/* Compute log(1 - exp(x)). */
+template <typename T>
+T log1mexp(T x) {
+    if (x > 0) {
+	set_error("_log1mexp", SF_ERROR_DOMAIN, NULL);
+	return std::numeric_limits<T>::quiet_NaN();
+    }
+    if (x == 0) {
+	set_error("_log1mexp", SF_ERROR_SINGULAR, NULL);
+	return -std::numeric_limits<T>::infinity();
+    }
+    if (x < -1) {
+	return std::log1p(-std::exp(x));
+    }
+    return std::log(-std::expm1(x));
+}
 
 } // namespace xsf

--- a/include/xsf/mathieu.h
+++ b/include/xsf/mathieu.h
@@ -17,7 +17,7 @@ T cem_cva(T m, T q) {
     int int_m, kd = 1;
 
     if ((m < 0) || (m != floor(m))) {
-        set_error("cem_cva", SF_ERROR_DOMAIN, NULL);
+        set_error("mathieu_a", SF_ERROR_DOMAIN, NULL);
         return std::numeric_limits<T>::quiet_NaN();
     }
     int_m = (int) m;
@@ -41,7 +41,7 @@ T sem_cva(T m, T q) {
     int int_m, kd = 4;
 
     if ((m <= 0) || (m != floor(m))) {
-        set_error("cem_cva", SF_ERROR_DOMAIN, NULL);
+        set_error("mathieu_b", SF_ERROR_DOMAIN, NULL);
         return std::numeric_limits<T>::quiet_NaN();
     }
     int_m = (int) m;
@@ -67,7 +67,7 @@ void cem(T m, T q, T x, T &csf, T &csd) {
     if ((m < 0) || (m != floor(m))) {
         csf = std::numeric_limits<T>::quiet_NaN();
         csd = std::numeric_limits<T>::quiet_NaN();
-        set_error("cem", SF_ERROR_DOMAIN, NULL);
+        set_error("mathieu_cem", SF_ERROR_DOMAIN, NULL);
     } else {
         int_m = (int) m;
         if (q < 0) {
@@ -85,7 +85,15 @@ void cem(T m, T q, T x, T &csf, T &csd) {
                 csd = -sgn * d;
             }
         } else {
-            specfun::mtu0(kf, int_m, q, x, &csf, &csd);
+            using specfun::Status;
+            Status status = specfun::mtu0(kf, int_m, q, x, &csf, &csd);
+            if (status != Status::OK) {
+                csf = std::numeric_limits<T>::quiet_NaN();
+                csd = std::numeric_limits<T>::quiet_NaN();
+                sf_error_t sf_error = status == Status::NoMemory ? SF_ERROR_MEMORY
+                                                                 : SF_ERROR_OTHER;
+                set_error("mathieu_cem", sf_error, NULL);
+            }
         }
     }
 }
@@ -97,7 +105,7 @@ void sem(T m, T q, T x, T &csf, T &csd) {
     if ((m < 0) || (m != floor(m))) {
         csf = std::numeric_limits<T>::quiet_NaN();
         csd = std::numeric_limits<T>::quiet_NaN();
-        set_error("sem", SF_ERROR_DOMAIN, NULL);
+        set_error("mathieu_sem", SF_ERROR_DOMAIN, NULL);
     } else {
         int_m = (int) m;
         if (int_m == 0) {
@@ -117,7 +125,15 @@ void sem(T m, T q, T x, T &csf, T &csd) {
                 csd = -sgn * d;
             }
         } else {
-            specfun::mtu0(kf, int_m, q, x, &csf, &csd);
+            using specfun::Status;
+            Status status = specfun::mtu0(kf, int_m, q, x, &csf, &csd);
+            if (status != Status::OK) {
+                csf = std::numeric_limits<T>::quiet_NaN();
+                csd = std::numeric_limits<T>::quiet_NaN();
+                sf_error_t sf_error = status == Status::NoMemory ? SF_ERROR_MEMORY
+                                                                 : SF_ERROR_OTHER;
+                set_error("mathieu_sem", sf_error, NULL);
+            }
         }
     }
 }
@@ -130,10 +146,18 @@ void mcm1(T m, T q, T x, T &f1r, T &d1r) {
     if ((m < 0) || (m != floor(m)) || (q < 0)) {
         f1r = std::numeric_limits<T>::quiet_NaN();
         d1r = std::numeric_limits<T>::quiet_NaN();
-        set_error("mcm1", SF_ERROR_DOMAIN, NULL);
+        set_error("mathieu_modcem1", SF_ERROR_DOMAIN, NULL);
     } else {
+        using specfun::Status;
         int_m = (int) m;
-        specfun::mtu12(kf, kc, int_m, q, x, &f1r, &d1r, &f2r, &d2r);
+        Status status = specfun::mtu12(kf, kc, int_m, q, x, &f1r, &d1r, &f2r, &d2r);
+        if (status != Status::OK) {
+            f1r = std::numeric_limits<T>::quiet_NaN();
+            d1r = std::numeric_limits<T>::quiet_NaN();
+            sf_error_t sf_error = status == Status::NoMemory ? SF_ERROR_MEMORY
+                                                             : SF_ERROR_OTHER;
+            set_error("mathieu_modcem1", sf_error, NULL);
+        }
     }
 }
 
@@ -145,10 +169,18 @@ void msm1(T m, T q, T x, T &f1r, T &d1r) {
     if ((m < 1) || (m != floor(m)) || (q < 0)) {
         f1r = std::numeric_limits<T>::quiet_NaN();
         d1r = std::numeric_limits<T>::quiet_NaN();
-        set_error("msm1", SF_ERROR_DOMAIN, NULL);
+        set_error("mathieu_modsem1", SF_ERROR_DOMAIN, NULL);
     } else {
+        using specfun::Status;
         int_m = (int) m;
-        specfun::mtu12(kf, kc, int_m, q, x, &f1r, &d1r, &f2r, &d2r);
+        Status status = specfun::mtu12(kf, kc, int_m, q, x, &f1r, &d1r, &f2r, &d2r);
+        if (status != Status::OK) {
+            f1r = std::numeric_limits<T>::quiet_NaN();
+            d1r = std::numeric_limits<T>::quiet_NaN();
+            sf_error_t sf_error = status == Status::NoMemory ? SF_ERROR_MEMORY
+                                                             : SF_ERROR_OTHER;
+            set_error("mathieu_modsem1", sf_error, NULL);
+        }
     }
 }
 
@@ -160,10 +192,18 @@ void mcm2(T m, T q, T x, T &f2r, T &d2r) {
     if ((m < 0) || (m != floor(m)) || (q < 0)) {
         f2r = std::numeric_limits<T>::quiet_NaN();
         d2r = std::numeric_limits<T>::quiet_NaN();
-        set_error("mcm2", SF_ERROR_DOMAIN, NULL);
+        set_error("mathieu_modcem2", SF_ERROR_DOMAIN, NULL);
     } else {
+        using specfun::Status;
         int_m = (int) m;
-        specfun::mtu12(kf, kc, int_m, q, x, &f1r, &d1r, &f2r, &d2r);
+        Status status = specfun::mtu12(kf, kc, int_m, q, x, &f1r, &d1r, &f2r, &d2r);
+        if (status != Status::OK) {
+            f2r = std::numeric_limits<T>::quiet_NaN();
+            d2r = std::numeric_limits<T>::quiet_NaN();
+            sf_error_t sf_error = status == Status::NoMemory ? SF_ERROR_MEMORY
+                                                             : SF_ERROR_OTHER;
+            set_error("mathieu_modcem2", sf_error, NULL);
+        }
     }
 }
 
@@ -175,10 +215,18 @@ void msm2(T m, T q, T x, T &f2r, T &d2r) {
     if ((m < 1) || (m != floor(m)) || (q < 0)) {
         f2r = std::numeric_limits<T>::quiet_NaN();
         d2r = std::numeric_limits<T>::quiet_NaN();
-        set_error("msm2", SF_ERROR_DOMAIN, NULL);
+        set_error("mathieu_modsem2", SF_ERROR_DOMAIN, NULL);
     } else {
+        using specfun::Status;
         int_m = (int) m;
-        specfun::mtu12(kf, kc, int_m, q, x, &f1r, &d1r, &f2r, &d2r);
+        Status status = specfun::mtu12(kf, kc, int_m, q, x, &f1r, &d1r, &f2r, &d2r);
+        if (status != Status::OK) {
+            f2r = std::numeric_limits<T>::quiet_NaN();
+            d2r = std::numeric_limits<T>::quiet_NaN();
+            sf_error_t sf_error = status == Status::NoMemory ? SF_ERROR_MEMORY
+                                                             : SF_ERROR_OTHER;
+            set_error("mathieu_modsem2", sf_error, NULL);
+        }
     }
 }
 

--- a/include/xsf/par_cyl.h
+++ b/include/xsf/par_cyl.h
@@ -628,7 +628,7 @@ void pbdv(T v, T x, T &pdf, T &pdd) {
         num = std::abs((int) v) + 2;
         dv = (T *) malloc(sizeof(T) * 2 * num);
         if (dv == NULL) {
-            set_error("pbdv", SF_ERROR_OTHER, "memory allocation error");
+            set_error("pbdv", SF_ERROR_MEMORY, "memory allocation error");
             pdf = std::numeric_limits<T>::quiet_NaN();
             pdd = std::numeric_limits<T>::quiet_NaN();
         } else {
@@ -653,7 +653,7 @@ void pbvv(T v, T x, T &pvf, T &pvd) {
         num = std::abs((int) v) + 2;
         vv = (T *) malloc(sizeof(T) * 2 * num);
         if (vv == NULL) {
-            set_error("pbvv", SF_ERROR_OTHER, "memory allocation error");
+            set_error("pbvv", SF_ERROR_MEMORY, "memory allocation error");
             pvf = std::numeric_limits<T>::quiet_NaN();
             pvd = std::numeric_limits<T>::quiet_NaN();
         } else {

--- a/include/xsf/specfun/specfun.h
+++ b/include/xsf/specfun/specfun.h
@@ -70,10 +70,22 @@
 
 #pragma once
 
+#include <memory>
 #include "../config.h"
 
 namespace xsf {
 namespace specfun {
+
+// The Status enum is the return type of a few private, low-level functions
+// defined here.  Currently the only use is by functions that allocate
+// memory internally.  If the allocation fails, the function returns
+// Status::NoMemory.
+
+enum class Status {
+    OK = 0,
+    NoMemory,
+    Other
+};
 
 void airyb(double, double*, double*, double*, double*);
 void bjndd(double, int, double *, double *, double *);
@@ -114,7 +126,7 @@ template <typename T>
 void sckb(int, int, T, T *, T *);
 
 template <typename T>
-void sdmn(int, int, T, T, int, T *);
+Status sdmn(int, int, T, T, int, T *);
 
 template <typename T>
 void sphj(T, int, int *, T *, T *);
@@ -123,7 +135,7 @@ template <typename T>
 void sphy(T, int, int *, T *, T *);
 
 template <typename T>
-void aswfa(T x, int m, int n, T c, int kd, T cv, T *s1f, T *s1d) {
+Status aswfa(T x, int m, int n, T c, int kd, T cv, T *s1f, T *s1d) {
 
     // ===========================================================
     // Purpose: Compute the prolate and oblate spheroidal angular
@@ -138,22 +150,34 @@ void aswfa(T x, int m, int n, T c, int kd, T cv, T *s1f, T *s1d) {
     // Output:  S1F --- Angular function of the first kind
     //          S1D --- Derivative of the angular function of
     //                  the first kind
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed.
+    //
     // Routine called:
+    //          SDMN for computing expansion coefficients df
     //          SCKB for computing expansion coefficients ck
     // ===========================================================
 
     int ip, k, nm, nm2;
     T a0, d0, d1, r, su1, su2, x0, x1;
-    T *ck = (T *) calloc(200, sizeof(T));
-    T *df = (T *) calloc(200, sizeof(T));
+    auto ck = std::unique_ptr<T[]>{new (std::nothrow) T[200]()};
+    auto df = std::unique_ptr<T[]>{new (std::nothrow) T[200]()};
+    if (ck == nullptr || df == nullptr) {
+        return Status::NoMemory;
+    }
     const T eps = 1e-14;
     x0 = x;
     x = fabs(x);
     ip = ((n-m) % 2 == 0 ? 0 : 1);
     nm = 40 + (int)((n-m)/2 + c);
     nm2 = nm/2 - 2;
-    sdmn(m, n, c, cv, kd, df);
-    sckb(m, n, c, df, ck);
+    if (sdmn(m, n, c, cv, kd, df.get()) == Status::NoMemory) {
+        return Status::NoMemory;
+    }
+    sckb(m, n, c, df.get(), ck.get());
     x1 = 1.0 - x*x;
     if ((m == 0) && (x1 == 0.0)) {
         a0 = 1.0;
@@ -191,8 +215,7 @@ void aswfa(T x, int m, int n, T c, int kd, T cv, T *s1f, T *s1d) {
     if ((x0 < 0.0) && (ip == 0)) { *s1d = -*s1d; }
     if ((x0 < 0.0) && (ip == 1)) { *s1f = -*s1f; }
     x = x0;
-    free(ck); free(df);
-    return;
+    return Status::OK;
 }
 
 
@@ -267,7 +290,16 @@ inline void bjndd(double x, int n, double *bj, double *dj, double *fj) {
 
 
 template <typename T>
-void cbk(int m, int n, T c, T cv, T qt, T *ck, T *bk) {
+Status cbk(int m, int n, T c, T cv, T qt, T *ck, T *bk) {
+
+    // ==========================================================
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed.
+    // ==========================================================
+
     const T eps = 1.0e-14;
 
     int i, i1, ip, j, k, n2, nm;
@@ -275,9 +307,13 @@ void cbk(int m, int n, T c, T cv, T qt, T *ck, T *bk) {
 
     ip = ((n - m) % 2 == 0 ? 0 : 1);
     nm = 25 + (int)(0.5 * (n - m) + c);
-    T *u = (T *) calloc(200, sizeof(T));
-    T *v = (T *) calloc(200, sizeof(T));
-    T *w = (T *) calloc(200, sizeof(T));
+
+    auto u = std::unique_ptr<T[]>{new (std::nothrow) T[200]()};
+    auto v = std::unique_ptr<T[]>{new (std::nothrow) T[200]()};
+    auto w = std::unique_ptr<T[]>{new (std::nothrow) T[200]()};
+    if (u.get() == nullptr || v.get() == nullptr || w.get() == nullptr) {
+        return Status::NoMemory;
+    }
 
     u[0] = 0.0;
     n2 = nm - 2;
@@ -345,8 +381,7 @@ void cbk(int m, int n, T c, T cv, T qt, T *ck, T *bk) {
     for (k = n2 - 1; k >= 1; k--) {
         bk[k - 1] -= w[k - 1] * bk[k];
     }
-    free(u); free(v); free(w);
-    return;
+    return Status::OK;
 }
 
 
@@ -2023,10 +2058,6 @@ inline void cyzo(int nt, int kf, int kc, std::complex<double> *zo, std::complex<
 }
 
 
-
-
-
-
 template <typename T>
 T e1xb(T x) {
 
@@ -2959,7 +2990,7 @@ inline std::complex<double> hygfz(double a, double b, double c, std::complex<dou
     return zhf;
 }
 
-inline void jdzo(int nt, double *zo, int *n, int *m, int *p) {
+inline Status jdzo(int nt, double *zo, int *n, int *m, int *p) {
 
     // ===========================================================
     // Purpose: Compute the zeros of Bessel functions Jn(x) and
@@ -2979,6 +3010,12 @@ inline void jdzo(int nt, double *zo, int *n, int *m, int *p) {
     //                    In the waveguide applications, the zeros
     //                    of Jn(x) correspond to TM modes and
     //                    those of Jn'(x) correspond to TE modes
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed.
+    //
     // Routine called:    BJNDD for computing Jn(x), Jn'(x) and
     //                    Jn''(x)
     // =============================================================
@@ -2986,7 +3023,8 @@ inline void jdzo(int nt, double *zo, int *n, int *m, int *p) {
     int i, j, k, L, L0, L1, L2, mm, nm;
     double x, x0, x1, x2, xm;
 
-    int* p1 = (int *) calloc(70, sizeof(int));
+    auto p1 = std::unique_ptr<int[]>{new (std::nothrow) int[70]()};
+
     // Compared to specfun.f we use a single array instead of separate
     // three arrays and use pointer arithmetic to access. Their usage
     // is pretty much one-shot hence does not complicate the code.
@@ -2994,10 +3032,14 @@ inline void jdzo(int nt, double *zo, int *n, int *m, int *p) {
     // Note: ZO and ZOC arrays are 0-indexed in specfun.f
 
     // m1, n1, zoc -> 70 + 70 + 71
-    double* mnzoc = (double *) calloc(211, sizeof(double));
+    auto mnzoc = std::unique_ptr<double[]>{new (std::nothrow) double[211]()};
 
     // bj, dj, fj -> 101 + 101 + 101
-    double* bdfj = (double *) calloc(303, sizeof(double));
+    auto bdfj = std::unique_ptr<double[]>{new (std::nothrow) double[303]()};
+
+    if (p1.get() == nullptr || mnzoc.get() == nullptr || bdfj.get() == nullptr) {
+        return Status::NoMemory;
+    }
 
     x = 0;
 
@@ -3093,10 +3135,7 @@ L30:
         /* 45 */
         L0 = L2;
     }
-    free(bdfj);
-    free(mnzoc);
-    free(p1);
-    return;
+    return Status::OK;
 }
 
 
@@ -3468,23 +3507,33 @@ L25:
 
 
 template <typename T>
-inline void kmn(int m, int n, T c, T cv, int kd, T *df, T *dn, T *ck1, T *ck2) {
+inline Status kmn(int m, int n, T c, T cv, int kd, T *df, T *dn, T *ck1, T *ck2) {
 
     // ===================================================
     // Purpose: Compute the expansion coefficients of the
     //          prolate and oblate spheroidal functions
     //          and joining factors
+    //
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed.
     // ===================================================
 
     int nm, nn, ip, k, i, l, j;
     T cs, gk0, gk1, gk2, gk3, t, r, dnp, su0, sw, r1, r2, r3, sa0, r4, r5, g0, sb0;
     nm = 25 + (int)(0.5 * (n - m) + c);
     nn = nm + m;
-    T *u =  (T *) malloc((nn + 4) * sizeof(T));
-    T *v =  (T *) malloc((nn + 4) * sizeof(T));
-    T *w =  (T *) malloc((nn + 4) * sizeof(T));
-    T *tp = (T *) malloc((nn + 4) * sizeof(T));
-    T *rk = (T *) malloc((nn + 4) * sizeof(T));
+    auto u = std::unique_ptr<T[]>{new (std::nothrow) T[nn + 4]};
+    auto v = std::unique_ptr<T[]>{new (std::nothrow) T[nn + 4]};
+    auto w = std::unique_ptr<T[]>{new (std::nothrow) T[nn + 4]};
+    auto tp = std::unique_ptr<T[]>{new (std::nothrow) T[nn + 4]};
+    auto rk = std::unique_ptr<T[]>{new (std::nothrow) T[nn + 4]};
+    if (u.get() == nullptr || v.get() == nullptr || w.get() == nullptr
+            || tp.get() == nullptr || rk.get() == nullptr) {
+        return Status::NoMemory;
+    }
 
     const T eps = 1.0e-14;
 
@@ -3569,8 +3618,7 @@ inline void kmn(int m, int n, T c, T cv, int kd, T *df, T *dn, T *ck1, T *ck2) {
         *ck1 = sa0 * su0;
 
         if (kd == -1) {
-            free(u); free(v); free(w); free(tp); free(rk);
-            return;
+            return Status::OK;
         }
     }
 
@@ -3590,8 +3638,7 @@ inline void kmn(int m, int n, T c, T cv, int kd, T *df, T *dn, T *ck1, T *ck2) {
     sb0 = (ip + 1.0) * pow(c, ip + 1) / (2.0 * ip * (m - 2.0) + 1.0) / (2.0 * m - 1.0);
     *ck2 = pow(-1, ip) * sb0 * r4 * r5 * g0 / r1 * su0;
 
-    free(u); free(v); free(w); free(tp); free(rk);
-    return;
+    return Status::OK;
 }
 
 
@@ -4323,7 +4370,7 @@ inline int msta2(double x, int n, int mp) {
 
 
 template <typename T>
-void mtu0(int kf, int m, T q, T x, T *csf, T *csd) {
+Status mtu0(int kf, int m, T q, T x, T *csf, T *csd) {
 
     // ===============================================================
     // Purpose: Compute Mathieu functions cem(x,q) and sem(x,q)
@@ -4336,6 +4383,18 @@ void mtu0(int kf, int m, T q, T x, T *csf, T *csd) {
     //          x   --- Argument of Mathieu functions (in degrees)
     // Output:  CSF --- cem(x,q) or sem(x,q)
     //          CSD --- cem'x,q) or sem'x,q)
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed. The output
+    //              values will be set to nan.
+    //          Status::Other
+    //              An internal check failed. For mtu0, this occurs
+    //              when km (see the code) is too big.  km is a
+    //              function of q and m.  The output values will be
+    //              set to nan.
+    //
     // Routines called:
     //      (1) CVA2 for computing the characteristic values
     //      (2) FCOEF for computing the expansion coefficients
@@ -4364,11 +4423,16 @@ void mtu0(int kf, int m, T q, T x, T *csf, T *csd) {
     if (km > 251) {
         *csf = NAN;
         *csd = NAN;
-        return;
+        return Status::Other;
     }
 
-    T *fg = (T *) calloc(251, sizeof(T));
-    fcoef(kd, m, q, a, fg);
+    auto fg = std::unique_ptr<T[]>{new (std::nothrow) T[251]()};
+    if (fg.get() == nullptr) {
+        *csf = NAN;
+        *csd = NAN;
+        return Status::NoMemory;
+    }
+    fcoef(kd, m, q, a, fg.get());
 
     ic = (int)(m / 2) + 1;
     xr = x * rd;
@@ -4403,13 +4467,12 @@ void mtu0(int kf, int m, T q, T x, T *csf, T *csd) {
             break;
         }
     }
-    free(fg);
-    return;
+    return Status::OK;
 }
 
 
 template <typename T>
-void mtu12(int kf, int kc, int m, T q, T x, T *f1r, T *d1r, T *f2r, T *d2r) {
+Status mtu12(int kf, int kc, int m, T q, T x, T *f1r, T *d1r, T *f2r, T *d2r) {
 
     // ==============================================================
     // Purpose: Compute modified Mathieu functions of the first and
@@ -4431,6 +4494,17 @@ void mtu12(int kf, int kc, int m, T q, T x, T *f1r, T *d1r, T *f2r, T *d2r) {
     //          D1R --- Derivative of Mcm(1)(x,q) or Msm(1)(x,q)
     //          F2R --- Mcm(2)(x,q) or Msm(2)(x,q)
     //          D2R --- Derivative of Mcm(2)(x,q) or Msm(2)(x,q)
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed. The output
+    //              values will be set to nan.
+    //          Status::Other
+    //              An internal check failed. For mtu12, this occurs
+    //              when km (see the code) is too big.  km is a
+    //              function of q and m.  The output values will be
+    //              set to nan.
     // Routines called:
     //      (1) CVA2 for computing the characteristic values
     //      (2) FCOEF for computing expansion coefficients
@@ -4461,21 +4535,32 @@ void mtu12(int kf, int kc, int m, T q, T x, T *f1r, T *d1r, T *f2r, T *d2r) {
         *d1r = NAN;
         *f2r = NAN;
         *d2r = NAN;
-        return;
+        return Status::Other;
     }
 
     // allocate memory after a possible NAN return
-    T *fg = (T *) calloc(251, sizeof(T));
-    T *bj1 = (T *) calloc(252, sizeof(T));
-    T *dj1 = (T *) calloc(252, sizeof(T));
-    T *bj2 = (T *) calloc(252, sizeof(T));
-    T *dj2 = (T *) calloc(252, sizeof(T));
-    T *by1 = (T *) calloc(252, sizeof(T));
-    T *dy1 = (T *) calloc(252, sizeof(T));
-    T *by2 = (T *) calloc(252, sizeof(T));
-    T *dy2 = (T *) calloc(252, sizeof(T));
+    auto fg = std::unique_ptr<T[]>{new (std::nothrow) T[251]()};
+    auto bj1 = std::unique_ptr<T[]>{new (std::nothrow) T[252]()};
+    auto dj1 = std::unique_ptr<T[]>{new (std::nothrow) T[252]()};
+    auto bj2 = std::unique_ptr<T[]>{new (std::nothrow) T[252]()};
+    auto dj2 = std::unique_ptr<T[]>{new (std::nothrow) T[252]()};
+    auto by1 = std::unique_ptr<T[]>{new (std::nothrow) T[252]()};
+    auto dy1 = std::unique_ptr<T[]>{new (std::nothrow) T[252]()};
+    auto by2 = std::unique_ptr<T[]>{new (std::nothrow) T[252]()};
+    auto dy2 = std::unique_ptr<T[]>{new (std::nothrow) T[252]()};
 
-    fcoef(kd, m, q, a, fg);
+    if (fg.get() == nullptr || bj1.get() == nullptr || dj1.get() == nullptr
+                            || bj2.get() == nullptr || dj2.get() == nullptr
+                            || by1.get() == nullptr || dy1.get() == nullptr
+                            || by2.get() == nullptr || dy2.get() == nullptr) {
+        *f1r = NAN;
+        *d1r = NAN;
+        *f2r = NAN;
+        *d2r = NAN;
+        return Status::NoMemory;
+    }
+
+    fcoef(kd, m, q, a, fg.get());
     ic = (int)(m / 2) + 1;
     if (kd == 4) { ic = m / 2; }
 
@@ -4483,8 +4568,8 @@ void mtu12(int kf, int kc, int m, T q, T x, T *f1r, T *d1r, T *f2r, T *d2r) {
     c2 = exp(x);
     u1 = sqrt(q) * c1;
     u2 = sqrt(q) * c2;
-    jynb(km+1, u1, &nm, bj1, dj1, by1, dy1);
-    jynb(km+1, u2, &nm, bj2, dj2, by2, dy2);
+    jynb(km+1, u1, &nm, bj1.get(), dj1.get(), by1.get(), dy1.get());
+    jynb(km+1, u2, &nm, bj2.get(), dj2.get(), by2.get(), dy2.get());
     w1 = 0.0;
     w2 = 0.0;
 
@@ -4522,10 +4607,7 @@ void mtu12(int kf, int kc, int m, T q, T x, T *f1r, T *d1r, T *f2r, T *d2r) {
         }
         *d1r *= sqrt(q) / fg[0];
         if (kc == 1) {
-            free(fg);
-            free(bj1);free(dj1);free(bj2);free(dj2);
-            free(by1);free(dy1);free(by2);free(dy2);
-            return;
+            return Status::OK;
         }
     }
 
@@ -4560,11 +4642,7 @@ void mtu12(int kf, int kc, int m, T q, T x, T *f1r, T *d1r, T *f2r, T *d2r) {
         w2 = *d2r;
     }
     *d2r = *d2r * sqrt(q) / fg[0];
-
-    free(fg);
-    free(bj1);free(dj1);free(bj2);free(dj2);
-    free(by1);free(dy1);free(by2);free(dy2);
-    return;
+    return Status::OK;
 }
 
 
@@ -4626,10 +4704,23 @@ inline double psi_spec(double x) {
 
 
 template <typename T>
-void qstar(int m, int n, T c, T ck1, T *ck, T *qs, T *qt) {
+Status qstar(int m, int n, T c, T ck1, T *ck, T *qs, T *qt) {
+
+    // ==========================================================
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed.
+    // ==========================================================
+
     int ip, i, l, k;
     T r, s, sk, qs0;
-    T *ap = (T *) malloc(200*sizeof(T));
+
+    auto ap = std::unique_ptr<T[]>{new (std::nothrow) T[200]};
+    if (ap.get() == nullptr) {
+        return Status::NoMemory;
+    }
     ip = ((n - m) == 2 * ((n - m) / 2) ? 0 : 1);
     r = 1.0 / pow(ck[0], 2);
     ap[0] = r;
@@ -4655,8 +4746,7 @@ void qstar(int m, int n, T c, T ck1, T *ck, T *qs, T *qt) {
     }
     *qs = pow(-1, ip) * (ck1) * (ck1 * qs0) / c;
     *qt = -2.0 / (ck1) * (*qs);
-    free(ap);
-    return;
+    return Status::OK;
 }
 
 
@@ -4697,12 +4787,19 @@ inline double refine(int kd, int m, double q, double a) {
 
 
 template <typename T>
-inline void rmn1(int m, int n, T c, T x, int kd, T *df, T *r1f, T *r1d) {
+inline Status rmn1(int m, int n, T c, T x, int kd, T *df, T *r1f, T *r1d) {
 
     // =======================================================
     // Purpose: Compute prolate and oblate spheroidal radial
     //          functions of the first kind for given m, n,
     //          c and x
+    //
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed.
+    //
     // Routines called:
     //      (1) SCKB for computing expansion coefficients c2k
     //      (2) SPHJ for computing the spherical Bessel
@@ -4712,9 +4809,12 @@ inline void rmn1(int m, int n, T c, T x, int kd, T *df, T *r1f, T *r1d) {
     T a0, b0, cx, r, r0, r1, r2, r3, reg, sa0, suc, sud, sum, sw, sw1;
     int ip, j, k, l, lg, nm, nm1, nm2, np;
 
-    T *ck = (T *) calloc(200, sizeof(T));
-    T *dj = (T *) calloc(252, sizeof(T));
-    T *sj = (T *) calloc(252, sizeof(T));
+    auto ck = std::unique_ptr<T[]>{new (std::nothrow) T[200]()};
+    auto dj = std::unique_ptr<T[]>{new (std::nothrow) T[252]()};
+    auto sj = std::unique_ptr<T[]>{new (std::nothrow) T[252]()};
+    if (ck.get() == nullptr || dj.get() == nullptr || sj.get() == nullptr) {
+        return Status::NoMemory;
+    }
     const T eps = 1.0e-14;
 
     nm1 = (int)((n - m) / 2);
@@ -4738,7 +4838,7 @@ inline void rmn1(int m, int n, T c, T x, int kd, T *df, T *r1f, T *r1d) {
     }
 
     if (x == 0.0) {
-        sckb(m, n, c, df, ck);
+        sckb(m, n, c, df, ck.get());
 
         sum = 0.0;
         sw1 = 0.0;
@@ -4771,13 +4871,12 @@ inline void rmn1(int m, int n, T c, T x, int kd, T *df, T *r1f, T *r1d) {
             *r1f = 0.0;
             *r1d = sum / (sa0 * suc) * df[0] * reg;
         }
-        free(ck);free(dj);free(sj);
-        return;
+        return Status::OK;
     }
 
     cx = c * x;
     nm2 = 2 * nm + m;
-    sphj(cx, nm2, &nm2, sj, dj);
+    sphj(cx, nm2, &nm2, sj.get(), dj.get());
 
     a0 = pow(1.0 - kd / (x * x), 0.5 * m) / suc;
     *r1f = 0.0;
@@ -4824,18 +4923,27 @@ inline void rmn1(int m, int n, T c, T x, int kd, T *df, T *r1f, T *r1d) {
         sw = sud;
     }
     *r1d = b0 + a0 * c * sud;
-    free(ck);free(dj);free(sj);
-    return;
+    return Status::OK;
 }
 
 
 template <typename T>
-inline void rmn2l(int m, int n, T c, T x, int Kd, T *Df, T *R2f, T *R2d, int *Id) {
+inline Status rmn2l(int m, int n, T c, T x, int Kd, T *Df, T *R2f, T *R2d, int *Id) {
 
     // ========================================================
     // Purpose: Compute prolate and oblate spheroidal radial
     //          functions of the second kind for given m, n,
     //          c and a large cx
+    //
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed.
+    //          Status::Other
+    //              An internal convergence check failed.  When
+    //              this happens, *Id is set to 10 on return.
+    //
     // Routine called:
     //          SPHY for computing the spherical Bessel
     //          functions of the second kind
@@ -4845,8 +4953,12 @@ inline void rmn2l(int m, int n, T c, T x, int Kd, T *Df, T *R2f, T *R2d, int *Id
     int ip, nm1, nm, nm2, np, j, k, l, lg, id1, id2;
     T a0, b0, cx, reg, r0, r, suc, sud, sw, eps1, eps2;
     const T eps = 1.0e-14;
-    T *sy = (T *) calloc(252, sizeof(T));
-    T *dy = (T *) calloc(252, sizeof(T));
+
+    auto sy = std::unique_ptr<T[]>{new (std::nothrow) T[252]()};
+    auto dy = std::unique_ptr<T[]>{new (std::nothrow) T[252]()};
+    if (sy.get() == nullptr || dy.get() == nullptr) {
+        return Status::NoMemory;
+    }
 
     ip = 1;
     nm1 = (int)((n - m) / 2);
@@ -4860,7 +4972,7 @@ inline void rmn2l(int m, int n, T c, T x, int Kd, T *Df, T *R2f, T *R2d, int *Id
     }
     nm2 = 2 * nm + m;
     cx = c * x;
-    sphy(cx, nm2, &nm2, sy, dy);
+    sphy(cx, nm2, &nm2, sy.get(), dy.get());
     r0 = reg;
 
     for (j = 1; j <= 2 * m + ip; ++j) {
@@ -4904,10 +5016,15 @@ inline void rmn2l(int m, int n, T c, T x, int Kd, T *Df, T *R2f, T *R2d, int *Id
     *R2f *= a0;
 
     if (np >= nm2) {
+        // On page 584 of "Computation of Special functions" by Shanjie Zhang
+        // and Jian-Ming Jin, there is a comment next to this code that says
+        // this condition indicates that convergence is not achieved, so we
+        // return Status::Other in addition to setting *Id = 10.  But the
+        // functions that call rmn2l (namely rswfp and rswfo) will actually
+        // look at the value of Id to check for convergence; the returned
+        // Status value is only checked for the occurrence of Status::NoMemory.
         *Id = 10;
-        free(sy);
-        free(dy);
-        return;
+        return Status::Other;
     }
 
     b0 = Kd * m / pow(x, 3) / (1.0 - Kd / (x * x)) * (*R2f);
@@ -4934,18 +5051,23 @@ inline void rmn2l(int m, int n, T c, T x, int Kd, T *Df, T *R2f, T *R2d, int *Id
     *R2d = b0 + a0 * c * sud;
     id2 = (int)log10(eps2 / fabs(sud) + eps);
     *Id = (id1 > id2) ? id1 : id2;
-    free(sy);
-    free(dy);
-    return;
+    return Status::OK;
 }
 
 
 template <typename T>
-inline void rmn2so(int m, int n, T c, T x, T cv, int kd, T *df, T *r2f, T *r2d) {
+inline Status rmn2so(int m, int n, T c, T x, T cv, int kd, T *df, T *r2f, T *r2d) {
 
     // =============================================================
     // Purpose: Compute oblate radial functions of the second kind
     //          with a small argument, Rmn(-ic,ix) & Rmn'(-ic,ix)
+    //
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed.
+    //
     // Routines called:
     //      (1) SCKB for computing the expansion coefficients c2k
     //      (2) KMN for computing the joining factors
@@ -4965,18 +5087,28 @@ inline void rmn2so(int m, int n, T c, T x, T cv, int kd, T *df, T *r2f, T *r2d) 
     if (fabs(df[0]) <= 1.0e-280) {
         *r2f = 1.0e+300;
         *r2d = 1.0e+300;
-        return;
+        return Status::OK;
     }
-    T *bk = (T *) calloc(200, sizeof(double));
-    T *ck = (T *) calloc(200, sizeof(double));
-    T *dn = (T *) calloc(200, sizeof(double));
+
+    auto bk = std::unique_ptr<T[]>{new (std::nothrow) T[200]()};
+    auto ck = std::unique_ptr<T[]>{new (std::nothrow) T[200]()};
+    auto dn = std::unique_ptr<T[]>{new (std::nothrow) T[200]()};
+    if (bk.get() == nullptr || ck.get() == nullptr || dn.get() == nullptr) {
+        return Status::NoMemory;
+    }
 
     nm = 25 + (int)((n - m) / 2 + c);
     ip = (n - m) % 2;
-    sckb(m, n, c, df, ck);
-    kmn(m, n, c, cv, kd, df, dn, &ck1, &ck2);
-    qstar(m, n, c, ck1, ck, &qs, &qt);
-    cbk(m, n, c, cv, qt, ck, bk);
+    sckb(m, n, c, df, ck.get());
+    if (kmn(m, n, c, cv, kd, df, dn.get(), &ck1, &ck2) == Status::NoMemory) {
+        return Status::NoMemory;
+    }
+    if (qstar(m, n, c, ck1, ck.get(), &qs, &qt) == Status::NoMemory) {
+        return Status::NoMemory;
+    }
+    if (cbk(m, n, c, cv, qt, ck.get(), bk.get()) == Status::NoMemory) {
+        return Status::NoMemory;
+    }
 
     if (x == 0.0) {
         sum = 0.0;
@@ -4998,23 +5130,31 @@ inline void rmn2so(int m, int n, T c, T x, T cv, int kd, T *df, T *r2f, T *r2d) 
             *r2d = -0.5 * pi * qs * r1d;
         }
     } else {
-        gmn(m, n, c, x, bk, &gf, &gd);
-        rmn1(m, n, c, x, kd, df, &r1f, &r1d);
+        gmn(m, n, c, x, bk.get(), &gf, &gd);
+        if (rmn1(m, n, c, x, kd, df, &r1f, &r1d) == Status::NoMemory) {
+            return Status::NoMemory;
+        }
         h0 = atan(x) - 0.5 * pi;
         *r2f = qs * r1f * h0 + gf;
         *r2d = qs * (r1d * h0 + r1f / (1.0 + x * x)) + gd;
     }
-    free(bk); free(ck); free(dn);
-    return;
+    return Status::OK;
 }
 
 
 template <typename T>
-void rmn2sp(int m, int n, T c, T x, T cv, int kd, T *df, T *r2f, T *r2d) {
+Status rmn2sp(int m, int n, T c, T x, T cv, int kd, T *df, T *r2f, T *r2d) {
 
     // ======================================================
     // Purpose: Compute prolate spheroidal radial function
     //          of the second kind with a small argument
+    //
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed.
+    //
     // Routines called:
     //      (1) LPMNS for computing the associated Legendre
     //          functions of the first kind
@@ -5024,15 +5164,23 @@ void rmn2sp(int m, int n, T c, T x, T cv, int kd, T *df, T *r2f, T *r2d) {
     //          and joining factors
     // ======================================================
 
-    int k, j, j1, j2, l1, ki, nm3, sum, sdm;
-    T ip, nm1, nm, nm2, su0, sw, sd0, su1, sd1, sd2, ga, r1, r2, r3,\
-           sf, gb, spl, gc, sd, r4, spd1, spd2, su2, ck1, ck2;
+    int k, j, j1, j2, l1, ki, nm3;
+    T ip, nm1, nm, nm2, su0, sw, sd0, su1, sd1, sd2, ga, r1, r2, r3,
+           sf, gb, spl, gc, sd, r4, spd1, spd2, su2, ck1, ck2, sum, sdm;
 
-    T *pm = (T *) malloc(252*sizeof(T));
-    T *pd = (T *) malloc(252*sizeof(T));
-    T *qm = (T *) malloc(252*sizeof(T));
-    T *qd = (T *) malloc(252*sizeof(T));
-    T *dn = (T *) malloc(201*sizeof(T));
+    // fortran index start from 0
+    auto pm = std::unique_ptr<T[]>{new (std::nothrow) T[252]};
+    auto pd = std::unique_ptr<T[]>{new (std::nothrow) T[252]};
+    auto qm = std::unique_ptr<T[]>{new (std::nothrow) T[252]};
+    auto qd = std::unique_ptr<T[]>{new (std::nothrow) T[252]};
+    // fortran index start from 1
+    auto dn = std::unique_ptr<T[]>{new (std::nothrow) T[201]};
+
+    if (pm.get() == nullptr || pd.get() == nullptr || qm.get() == nullptr
+           || qd.get() == nullptr || dn.get() == nullptr) {
+        return Status::NoMemory;
+    }
+
     const T eps = 1.0e-14;
 
     nm1 = (n - m) / 2;
@@ -5040,9 +5188,11 @@ void rmn2sp(int m, int n, T c, T x, T cv, int kd, T *df, T *r2f, T *r2d) {
     nm2 = 2 * nm + m;
     ip = (n - m) % 2;
 
-    kmn(m, n, c, cv, kd, df, dn, &ck1, &ck2);
-    lpmns(m, nm2, x, pm, pd);
-    lqmns(m, nm2, x, qm, qd);
+    if (kmn(m, n, c, cv, kd, df, dn.get(), &ck1, &ck2) == Status::NoMemory) {
+        return Status::NoMemory;
+    }
+    lpmns(m, nm2, x, pm.get(), pd.get());
+    lqmns(m, nm2, x, qm.get(), qd.get());
 
     su0 = 0.0;
     sw = 0.0;
@@ -5130,13 +5280,12 @@ void rmn2sp(int m, int n, T c, T x, T cv, int kd, T *df, T *r2f, T *r2d) {
     sdm = sd0 + sd1 + sd2;
     *r2f = sum / ck2;
     *r2d = sdm / ck2;
-    free(pm); free(pd); free(qm); free(qd); free(dn);
-    return;
+    return Status::OK;
 }
 
 
 template <typename T>
-inline void rswfp(int m, int n, T c, T x, T cv, int kf, T *r1f, T *r1d, T *r2f, T *r2d) {
+inline Status rswfp(int m, int n, T c, T x, T cv, int kf, T *r1f, T *r1d, T *r2f, T *r2d) {
 
     // ==============================================================
     // Purpose: Compute prolate spheriodal radial functions of the
@@ -5156,6 +5305,12 @@ inline void rswfp(int m, int n, T c, T x, T cv, int kf, T *r1f, T *r1d, T *r2f, 
     //          R2F --- Radial function of the second kind
     //          R2D --- Derivative of the radial function of
     //                  the second kind
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed.
+    //
     // Routines called:
     //      (1) SDMN for computing expansion coefficients dk
     //      (2) RMN1 for computing prolate and oblate radial
@@ -5166,27 +5321,37 @@ inline void rswfp(int m, int n, T c, T x, T cv, int kf, T *r1f, T *r1d, T *r2f, 
     //          of the second kind for a small argument
     // ==============================================================
 
-    T *df = (T *) malloc(200*sizeof(double));
+    auto df = std::unique_ptr<T[]>{new (std::nothrow) T[200]};
+    if (df.get() == nullptr) {
+        return Status::NoMemory;
+    }
     int id, kd = 1;
 
-    sdmn(m, n, c, cv, kd, df);
+    if (sdmn(m, n, c, cv, kd, df.get()) == Status::NoMemory) {
+        return Status::NoMemory;
+    }
 
     if (kf != 2) {
-        rmn1(m, n, c, x, kd, df, r1f, r1d);
-    }
-    if (kf > 1) {
-        rmn2l(m, n, c, x, kd, df, r2f, r2d, &id);
-        if (id > -8) {
-            rmn2sp(m, n, c, x, cv, kd, df, r2f, r2d);
+        if (rmn1(m, n, c, x, kd, df.get(), r1f, r1d) == Status::NoMemory) {
+            return Status::NoMemory;
         }
     }
-    free(df);
-    return;
+    if (kf > 1) {
+        if (rmn2l(m, n, c, x, kd, df.get(), r2f, r2d, &id) == Status::NoMemory) {
+            return Status::NoMemory;
+        }
+        if (id > -8) {
+            if (rmn2sp(m, n, c, x, cv, kd, df.get(), r2f, r2d) == Status::NoMemory) {
+                return Status::NoMemory;
+            }
+        }
+    }
+    return Status::OK;
 }
 
 
 template <typename T>
-void rswfo(int m, int n, T c, T x, T cv, int kf, T *r1f, T *r1d, T *r2f, T *r2d) {
+Status rswfo(int m, int n, T c, T x, T cv, int kf, T *r1f, T *r1d, T *r2f, T *r2d) {
 
     // ==========================================================
     // Purpose: Compute oblate radial functions of the first
@@ -5206,6 +5371,12 @@ void rswfo(int m, int n, T c, T x, T cv, int kf, T *r1f, T *r1d, T *r2f, T *r2d)
     //          R2F --- Radial function of the second kind
     //          R2D --- Derivative of the radial function of
     //                  the second kind
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed.
+    //
     // Routines called:
     //      (1) SDMN for computing expansion coefficients dk
     //      (2) RMN1 for computing prolate or oblate radial
@@ -5216,25 +5387,35 @@ void rswfo(int m, int n, T c, T x, T cv, int kf, T *r1f, T *r1d, T *r2f, T *r2d)
     //          the second kind for a small argument
     // ==========================================================
 
-    T *df = (T *) malloc(200*sizeof(T));
+    auto df = std::unique_ptr<T[]>{new (std::nothrow) T[200]};
+    if (df.get() == nullptr) {
+        return Status::NoMemory;
+    }
     int id, kd = -1;
 
-    sdmn(m, n, c, cv, kd, df);
+    if (sdmn(m, n, c, cv, kd, df.get()) == Status::NoMemory) {
+        return Status::NoMemory;
+    }
 
     if (kf != 2) {
-        rmn1(m, n, c, x, kd, df, r1f, r1d);
+        if (rmn1(m, n, c, x, kd, df.get(), r1f, r1d) == Status::NoMemory) {
+            return Status::NoMemory;
+        }
     }
     if (kf > 1) {
         id = 10;
         if (x > 1e-8) {
-            rmn2l(m, n, c, x, kd, df, r2f, r2d, &id);
+            if (rmn2l(m, n, c, x, kd, df.get(), r2f, r2d, &id) == Status::NoMemory) {
+                return Status::NoMemory;
+            }
         }
         if (id > -1) {
-            rmn2so(m, n, c, x, cv, kd, df, r2f, r2d);
+            if (rmn2so(m, n, c, x, cv, kd, df.get(), r2f, r2d) == Status::NoMemory) {
+                return Status::NoMemory;
+            }
         }
     }
-    free(df);
-    return;
+    return Status::OK;
 }
 
 
@@ -5295,7 +5476,7 @@ void sckb(int m, int n, T c, T *df, T *ck) {
 
 
 template <typename T>
-void sdmn(int m, int n, T c, T cv, int kd, T *df) {
+Status sdmn(int m, int n, T c, T cv, int kd, T *df) {
 
     // =====================================================
     // Purpose: Compute the expansion coefficients of the
@@ -5310,6 +5491,11 @@ void sdmn(int m, int n, T c, T cv, int kd, T *df) {
     //                    DF(1), DF(2), ... correspond to
     //                    d0, d2, ... for even n-m and d1,
     //                    d3, ... for odd n-m
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed.
     // =====================================================
 
     int nm, ip, k, kb;
@@ -5323,12 +5509,15 @@ void sdmn(int m, int n, T c, T cv, int kd, T *df) {
             df[i-1] = 0.0;
         }
         df[(n - m) / 2] = 1.0;
-        return;
+        return Status::OK;
     }
 
-    T *a = (T *) calloc(nm + 2, sizeof(double));
-    T *d = (T *) calloc(nm + 2, sizeof(double));
-    T *g = (T *) calloc(nm + 2, sizeof(double));
+    auto a = std::unique_ptr<T[]>{new (std::nothrow) T[nm + 2]()};
+    auto d = std::unique_ptr<T[]>{new (std::nothrow) T[nm + 2]()};
+    auto g = std::unique_ptr<T[]>{new (std::nothrow) T[nm + 2]()};
+    if (a.get() == nullptr || d.get() == nullptr || g.get() == nullptr) {
+        return Status::NoMemory;
+    }
     cs = c*c*kd;
     ip = (n - m) % 2;
 
@@ -5445,13 +5634,12 @@ void sdmn(int m, int n, T c, T cv, int kd, T *df) {
     for (int k = kb + 1; k <= nm; ++k) {
         df[k - 1] *= s0;
     }
-    free(a);free(d);free(g);
-    return;
+    return Status::OK;
 }
 
 
 template <typename T>
-void segv(int m, int n, T c, int kd, T *cv, T *eg) {
+Status segv(int m, int n, T c, int kd, T *cv, T *eg) {
 
     // =========================================================
     // Purpose: Compute the characteristic values of spheroidal
@@ -5464,6 +5652,11 @@ void segv(int m, int n, T c, int kd, T *cv, T *eg) {
     // Output:  CV --- Characteristic value for given m, n and c
     //          EG(L) --- Characteristic value for mode m and n'
     //                    ( L = n' - m + 1 )
+    // Return value:
+    //          Status::OK
+    //              Normal return.
+    //          Status::NoMemory
+    //              An internal memory allocation failed.
     // =========================================================
 
 
@@ -5476,18 +5669,24 @@ void segv(int m, int n, T c, int kd, T *cv, T *eg) {
             eg[i-1] = (i+m) * (i + m -1);
         }
         *cv = eg[n-m];
-        return;
+        return Status::OK;
     }
 
     // TODO: Following array sizes should be decided dynamically
-    T *a = (T *) calloc(300, sizeof(T));
-    T *b = (T *) calloc(100, sizeof(T));
-    T *cv0 = (T *) calloc(100, sizeof(T));
-    T *d = (T *) calloc(300, sizeof(T));
-    T *e = (T *) calloc(300, sizeof(T));
-    T *f = (T *) calloc(300, sizeof(T));
-    T *g = (T *) calloc(300, sizeof(T));
-    T *h = (T *) calloc(100, sizeof(T));
+    auto a = std::unique_ptr<T[]>{new (std::nothrow) T[300]()};
+    auto b = std::unique_ptr<T[]>{new (std::nothrow) T[100]()};
+    auto cv0 = std::unique_ptr<T[]>{new (std::nothrow) T[100]()};
+    auto d = std::unique_ptr<T[]>{new (std::nothrow) T[300]()};
+    auto e = std::unique_ptr<T[]>{new (std::nothrow) T[300]()};
+    auto f = std::unique_ptr<T[]>{new (std::nothrow) T[300]()};
+    auto g = std::unique_ptr<T[]>{new (std::nothrow) T[300]()};
+    auto h = std::unique_ptr<T[]>{new (std::nothrow) T[100]()};
+
+    if (a.get() == nullptr || b.get() == nullptr || cv0.get() == nullptr
+             || d.get() == nullptr || e.get() == nullptr || f.get() == nullptr
+             || g.get() == nullptr || h.get() == nullptr) {
+        return Status::NoMemory;
+    }
     icm = (n-m+2)/2;
     nm = 10 + (int)(0.5*(n-m)+c);
     cs = c*c*kd;
@@ -5563,8 +5762,7 @@ void segv(int m, int n, T c, int kd, T *cv, T *eg) {
         }
     }
     *cv = eg[n-m];
-    free(a);free(b);free(cv0);free(d);free(e);free(f);free(g);free(h);
-    return;
+    return Status::OK;
 }
 
 

--- a/include/xsf/sphd_wave.h
+++ b/include/xsf/sphd_wave.h
@@ -17,11 +17,15 @@ T prolate_segv(T m, T n, T c) {
     int_n = (int) n;
     eg = (T *) malloc(sizeof(T) * (n - m + 2));
     if (eg == NULL) {
-        set_error("prolate_segv", SF_ERROR_OTHER, "memory allocation error");
+        set_error("pro_cv", SF_ERROR_MEMORY, "memory allocation error");
         return std::numeric_limits<T>::quiet_NaN();
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
+    specfun::Status status = specfun::segv(int_m, int_n, c, kd, &cv, eg);
     free(eg);
+    if (status == specfun::Status::NoMemory) {
+        set_error("pro_cv", SF_ERROR_MEMORY, "memory allocation error");
+        return std::numeric_limits<T>::quiet_NaN();
+    }
     return cv;
 }
 
@@ -38,11 +42,15 @@ T oblate_segv(T m, T n, T c) {
     int_n = (int) n;
     eg = (T *) malloc(sizeof(T) * (n - m + 2));
     if (eg == NULL) {
-        set_error("oblate_segv", SF_ERROR_OTHER, "memory allocation error");
+        set_error("obl_cv", SF_ERROR_MEMORY, "memory allocation error");
         return std::numeric_limits<T>::quiet_NaN();
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
+    specfun::Status status = specfun::segv(int_m, int_n, c, kd, &cv, eg);
     free(eg);
+    if (status == specfun::Status::NoMemory) {
+        set_error("obl_cv", SF_ERROR_MEMORY, "memory allocation error");
+        return std::numeric_limits<T>::quiet_NaN();
+    }
     return cv;
 }
 
@@ -53,7 +61,7 @@ void prolate_aswfa_nocv(T m, T n, T c, T x, T &s1f, T &s1d) {
     T cv = 0.0, *eg;
 
     if ((x >= 1) || (x <= -1) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n)) || ((n - m) > 198)) {
-        set_error("prolate_aswfa_nocv", SF_ERROR_DOMAIN, NULL);
+        set_error("pro_ang1", SF_ERROR_DOMAIN, NULL);
         s1d = std::numeric_limits<T>::quiet_NaN();
         s1f = std::numeric_limits<T>::quiet_NaN();
         return;
@@ -62,14 +70,26 @@ void prolate_aswfa_nocv(T m, T n, T c, T x, T &s1f, T &s1d) {
     int_n = (int) n;
     eg = (T *) malloc(sizeof(T) * (n - m + 2));
     if (eg == NULL) {
-        set_error("prolate_aswfa_nocv", SF_ERROR_OTHER, "memory allocation error");
+        set_error("pro_ang1", SF_ERROR_MEMORY, "memory allocation error");
         s1d = std::numeric_limits<T>::quiet_NaN();
         s1f = std::numeric_limits<T>::quiet_NaN();
         return;
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
-    specfun::aswfa(x, int_m, int_n, c, kd, cv, &s1f, &s1d);
+    specfun::Status status = specfun::segv(int_m, int_n, c, kd, &cv, eg);
     free(eg);
+    if (status == specfun::Status::NoMemory) {
+        set_error("pro_ang1", SF_ERROR_MEMORY, "memory allocation error");
+        s1d = std::numeric_limits<T>::quiet_NaN();
+        s1f = std::numeric_limits<T>::quiet_NaN();
+        return;        
+    }
+    if (specfun::aswfa(x, int_m, int_n, c, kd, cv, &s1f, &s1d)
+            == specfun::Status::NoMemory) {
+        set_error("prol_ang1", SF_ERROR_MEMORY, "memory allocation error");
+        s1d = std::numeric_limits<T>::quiet_NaN();
+        s1f = std::numeric_limits<T>::quiet_NaN();
+        return;
+    }
 }
 
 template <typename T>
@@ -79,7 +99,7 @@ void oblate_aswfa_nocv(T m, T n, T c, T x, T &s1f, T &s1d) {
     T cv = 0.0, *eg;
 
     if ((x >= 1) || (x <= -1) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n)) || ((n - m) > 198)) {
-        set_error("oblate_aswfa_nocv", SF_ERROR_DOMAIN, NULL);
+        set_error("obl_ang1", SF_ERROR_DOMAIN, NULL);
         s1d = std::numeric_limits<T>::quiet_NaN();
         s1f = std::numeric_limits<T>::quiet_NaN();
         return;
@@ -88,35 +108,63 @@ void oblate_aswfa_nocv(T m, T n, T c, T x, T &s1f, T &s1d) {
     int_n = (int) n;
     eg = (T *) malloc(sizeof(T) * (n - m + 2));
     if (eg == NULL) {
-        set_error("oblate_aswfa_nocv", SF_ERROR_OTHER, "memory allocation error");
+        set_error("obl_ang1", SF_ERROR_MEMORY, "memory allocation error");
         s1d = std::numeric_limits<T>::quiet_NaN();
         s1f = std::numeric_limits<T>::quiet_NaN();
         return;
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
-    specfun::aswfa(x, int_m, int_n, c, kd, cv, &s1f, &s1d);
+    specfun::Status status = specfun::segv(int_m, int_n, c, kd, &cv, eg);
     free(eg);
+    if (status == specfun::Status::NoMemory) {
+        set_error("obl_ang1", SF_ERROR_MEMORY, "memory allocation error");
+        s1d = std::numeric_limits<T>::quiet_NaN();
+        s1f = std::numeric_limits<T>::quiet_NaN();
+        return;        
+    }
+    if (specfun::aswfa(x, int_m, int_n, c, kd, cv, &s1f, &s1d)
+            == specfun::Status::NoMemory) {
+        set_error("obl_ang1", SF_ERROR_MEMORY, "memory allocation error");
+        s1d = std::numeric_limits<T>::quiet_NaN();
+        s1f = std::numeric_limits<T>::quiet_NaN();
+        return;
+    }
 }
 
 template <typename T>
 void prolate_aswfa(T m, T n, T c, T cv, T x, T &s1f, T &s1d) {
     if ((x >= 1) || (x <= -1) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n))) {
-        set_error("prolate_aswfa", SF_ERROR_DOMAIN, NULL);
+        set_error("pro_ang1_cv", SF_ERROR_DOMAIN, NULL);
         s1f = std::numeric_limits<T>::quiet_NaN();
         s1d = std::numeric_limits<T>::quiet_NaN();
     } else {
-        specfun::aswfa(x, static_cast<int>(m), static_cast<int>(n), c, 1, cv, &s1f, &s1d);
+        specfun::Status status = specfun::aswfa(x, static_cast<int>(m),
+                                                static_cast<int>(n), c, 1, cv,
+                                                &s1f, &s1d);
+        if (status == specfun::Status::NoMemory) {
+            set_error("pro_ang1_cv", SF_ERROR_MEMORY, "memory allocation error");
+            s1d = std::numeric_limits<T>::quiet_NaN();
+            s1f = std::numeric_limits<T>::quiet_NaN();
+            return;
+        }
     }
 }
 
 template <typename T>
 void oblate_aswfa(T m, T n, T c, T cv, T x, T &s1f, T &s1d) {
     if ((x >= 1) || (x <= -1) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n))) {
-        set_error("oblate_aswfa", SF_ERROR_DOMAIN, NULL);
+        set_error("obl_ang1_cv", SF_ERROR_DOMAIN, NULL);
         s1f = std::numeric_limits<T>::quiet_NaN();
         s1d = std::numeric_limits<T>::quiet_NaN();
     } else {
-        specfun::aswfa(x, static_cast<int>(m), static_cast<int>(n), c, -1, cv, &s1f, &s1d);
+        specfun::Status status = specfun::aswfa(x, static_cast<int>(m),
+                                                static_cast<int>(n), c, -1, cv,
+                                                &s1f, &s1d);
+        if (status == specfun::Status::NoMemory) {
+            set_error("obl_ang1_cv", SF_ERROR_MEMORY, "memory allocation error");
+            s1d = std::numeric_limits<T>::quiet_NaN();
+            s1f = std::numeric_limits<T>::quiet_NaN();
+            return;
+        }
     }
 }
 
@@ -127,7 +175,7 @@ void prolate_radial1_nocv(T m, T n, T c, T x, T &r1f, T &r1d) {
     int int_m, int_n;
 
     if ((x <= 1.0) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n)) || ((n - m) > 198)) {
-        set_error("prolate_radial1_nocv", SF_ERROR_DOMAIN, NULL);
+        set_error("pro_rad1", SF_ERROR_DOMAIN, NULL);
         r1d = std::numeric_limits<T>::quiet_NaN();
         r1f = std::numeric_limits<T>::quiet_NaN();
         return;
@@ -136,14 +184,25 @@ void prolate_radial1_nocv(T m, T n, T c, T x, T &r1f, T &r1d) {
     int_n = (int) n;
     eg = (T *) malloc(sizeof(T) * (n - m + 2));
     if (eg == NULL) {
-        set_error("prolate_radial1_nocv", SF_ERROR_OTHER, "memory allocation error");
+        set_error("pro_rad1", SF_ERROR_MEMORY, "memory allocation error");
         r1d = std::numeric_limits<T>::quiet_NaN();
         r1f = std::numeric_limits<T>::quiet_NaN();
         return;
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
-    specfun::rswfp(int_m, int_n, c, x, cv, kf, &r1f, &r1d, &r2f, &r2d);
+    specfun::Status status = specfun::segv(int_m, int_n, c, kd, &cv, eg);
     free(eg);
+    if (status == specfun::Status::NoMemory) {
+        set_error("pro_rad1", SF_ERROR_MEMORY, "memory allocation error");
+        r1d = std::numeric_limits<T>::quiet_NaN();
+        r1f = std::numeric_limits<T>::quiet_NaN();
+        return;        
+    }
+    if (specfun::rswfp(int_m, int_n, c, x, cv, kf, &r1f, &r1d, &r2f, &r2d)
+            == specfun::Status::NoMemory) {
+        set_error("pro_rad1", SF_ERROR_MEMORY, "memory allocation error");
+        r1d = std::numeric_limits<T>::quiet_NaN();
+        r1f = std::numeric_limits<T>::quiet_NaN();
+    }
 }
 
 template <typename T>
@@ -153,7 +212,7 @@ void prolate_radial2_nocv(T m, T n, T c, T x, T &r2f, T &r2d) {
     int int_m, int_n;
 
     if ((x <= 1.0) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n)) || ((n - m) > 198)) {
-        set_error("prolate_radial2_nocv", SF_ERROR_DOMAIN, NULL);
+        set_error("pro_rad2", SF_ERROR_DOMAIN, NULL);
         r2d = std::numeric_limits<T>::quiet_NaN();
         r2f = std::numeric_limits<T>::quiet_NaN();
         return;
@@ -162,14 +221,25 @@ void prolate_radial2_nocv(T m, T n, T c, T x, T &r2f, T &r2d) {
     int_n = (int) n;
     eg = (T *) malloc(sizeof(T) * (n - m + 2));
     if (eg == NULL) {
-        set_error("prolate_radial2_nocv", SF_ERROR_OTHER, "memory allocation error");
+        set_error("pro_rad2", SF_ERROR_MEMORY, "memory allocation error");
         r2d = std::numeric_limits<T>::quiet_NaN();
         r2f = std::numeric_limits<T>::quiet_NaN();
         return;
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
-    specfun::rswfp(int_m, int_n, c, x, cv, kf, &r1f, &r1d, &r2f, &r2d);
+    specfun::Status status = specfun::segv(int_m, int_n, c, kd, &cv, eg);
     free(eg);
+    if (status == specfun::Status::NoMemory) {
+        set_error("pro_rad2", SF_ERROR_MEMORY, "memory allocation error");
+        r2d = std::numeric_limits<T>::quiet_NaN();
+        r2f = std::numeric_limits<T>::quiet_NaN();
+        return;        
+    }
+    if (specfun::rswfp(int_m, int_n, c, x, cv, kf, &r1f, &r1d, &r2f, &r2d)
+            == specfun::Status::NoMemory) {
+        set_error("pro_rad2", SF_ERROR_MEMORY, "memory allocation error");
+        r2d = std::numeric_limits<T>::quiet_NaN();
+        r2f = std::numeric_limits<T>::quiet_NaN();
+    }
 }
 
 template <typename T>
@@ -179,13 +249,18 @@ void prolate_radial1(T m, T n, T c, T cv, T x, T &r1f, T &r1d) {
     int int_m, int_n;
 
     if ((x <= 1.0) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n))) {
-        set_error("prolate_radial1", SF_ERROR_DOMAIN, NULL);
+        set_error("pro_rad1_cv", SF_ERROR_DOMAIN, NULL);
         r1f = std::numeric_limits<T>::quiet_NaN();
         r1d = std::numeric_limits<T>::quiet_NaN();
     } else {
         int_m = (int) m;
         int_n = (int) n;
-        specfun::rswfp(int_m, int_n, c, x, cv, kf, &r1f, &r1d, &r2f, &r2d);
+        if (specfun::rswfp(int_m, int_n, c, x, cv, kf, &r1f, &r1d, &r2f, &r2d)
+                == specfun::Status::NoMemory) {
+            set_error("pro_rad1_cv", SF_ERROR_MEMORY, NULL);
+            r1f = std::numeric_limits<T>::quiet_NaN();
+            r1d = std::numeric_limits<T>::quiet_NaN();
+        }
     }
 }
 
@@ -196,13 +271,18 @@ void prolate_radial2(T m, T n, T c, T cv, T x, T &r2f, T &r2d) {
     int int_m, int_n;
 
     if ((x <= 1.0) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n))) {
-        set_error("prolate_radial2", SF_ERROR_DOMAIN, NULL);
+        set_error("pro_rad2_cv", SF_ERROR_DOMAIN, NULL);
         r2f = std::numeric_limits<double>::quiet_NaN();
         r2d = std::numeric_limits<double>::quiet_NaN();
     } else {
         int_m = (int) m;
         int_n = (int) n;
-        specfun::rswfp(int_m, int_n, c, x, cv, kf, &r1f, &r1d, &r2f, &r2d);
+        if (specfun::rswfp(int_m, int_n, c, x, cv, kf, &r1f, &r1d, &r2f, &r2d)
+                == specfun::Status::NoMemory) {
+            set_error("pro_rad2_cv", SF_ERROR_MEMORY, NULL);
+            r2f = std::numeric_limits<double>::quiet_NaN();
+            r2d = std::numeric_limits<double>::quiet_NaN();
+        }
     }
 }
 
@@ -213,7 +293,7 @@ void oblate_radial1_nocv(T m, T n, T c, T x, T &r1f, T &r1d) {
     int int_m, int_n;
 
     if ((x < 0.0) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n)) || ((n - m) > 198)) {
-        set_error("oblate_radial1_nocv", SF_ERROR_DOMAIN, NULL);
+        set_error("obl_rad1", SF_ERROR_DOMAIN, NULL);
         r1d = std::numeric_limits<T>::quiet_NaN();
         r1f = std::numeric_limits<T>::quiet_NaN();
         return;
@@ -222,14 +302,26 @@ void oblate_radial1_nocv(T m, T n, T c, T x, T &r1f, T &r1d) {
     int_n = (int) n;
     eg = (T *) malloc(sizeof(T) * (n - m + 2));
     if (eg == NULL) {
-        set_error("oblate_radial1_nocv", SF_ERROR_OTHER, "memory allocation error");
+        set_error("obl_rad1", SF_ERROR_MEMORY, "memory allocation error");
         r1d = std::numeric_limits<T>::quiet_NaN();
         r1f = std::numeric_limits<T>::quiet_NaN();
         return;
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
-    specfun::rswfo(int_m, int_n, c, x, cv, kf, &r1f, &r1d, &r2f, &r2d);
+    specfun::Status status = specfun::segv(int_m, int_n, c, kd, &cv, eg);
     free(eg);
+    if (status == specfun::Status::NoMemory) {
+        set_error("obl_rad1", SF_ERROR_MEMORY, "memory allocation error");
+        r1d = std::numeric_limits<T>::quiet_NaN();
+        r1f = std::numeric_limits<T>::quiet_NaN();
+        return;        
+    }
+    if (specfun::rswfo(int_m, int_n, c, x, cv, kf, &r1f, &r1d, &r2f, &r2d)
+            == specfun::Status::NoMemory) {
+        set_error("obl_rad1", SF_ERROR_MEMORY, "memory allocation error");
+        r1d = std::numeric_limits<T>::quiet_NaN();
+        r1f = std::numeric_limits<T>::quiet_NaN();
+        return;
+    }
 }
 
 template <typename T>
@@ -239,7 +331,7 @@ void oblate_radial2_nocv(T m, T n, T c, T x, T &r2f, T &r2d) {
     int int_m, int_n;
 
     if ((x < 0.0) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n)) || ((n - m) > 198)) {
-        set_error("oblate_radial2_nocv", SF_ERROR_DOMAIN, NULL);
+        set_error("obl_rad2", SF_ERROR_DOMAIN, NULL);
         r2d = std::numeric_limits<T>::quiet_NaN();
         r2f = std::numeric_limits<T>::quiet_NaN();
         return;
@@ -248,14 +340,26 @@ void oblate_radial2_nocv(T m, T n, T c, T x, T &r2f, T &r2d) {
     int_n = (int) n;
     eg = (T *) malloc(sizeof(T) * (n - m + 2));
     if (eg == NULL) {
-        set_error("oblate_radial2_nocv", SF_ERROR_OTHER, "memory allocation error");
+        set_error("obl_rad2", SF_ERROR_MEMORY, "memory allocation error");
         r2d = std::numeric_limits<T>::quiet_NaN();
         r2f = std::numeric_limits<T>::quiet_NaN();
         return;
     }
-    specfun::segv(int_m, int_n, c, kd, &cv, eg);
-    specfun::rswfo(int_m, int_n, c, x, cv, kf, &r1f, &r1d, &r2f, &r2d);
+    specfun::Status status = specfun::segv(int_m, int_n, c, kd, &cv, eg);
     free(eg);
+    if (status == specfun::Status::NoMemory) {
+        set_error("obl_rad2", SF_ERROR_MEMORY, "memory allocation error");
+        r2d = std::numeric_limits<T>::quiet_NaN();
+        r2f = std::numeric_limits<T>::quiet_NaN();
+        return;        
+    }
+    if (specfun::rswfo(int_m, int_n, c, x, cv, kf, &r1f, &r1d, &r2f, &r2d)
+            == specfun::Status::NoMemory){
+        set_error("obl_rad2", SF_ERROR_MEMORY, "memory allocation error");
+        r2d = std::numeric_limits<T>::quiet_NaN();
+        r2f = std::numeric_limits<T>::quiet_NaN();
+        return;
+    }
 }
 
 template <typename T>
@@ -264,11 +368,18 @@ void oblate_radial1(T m, T n, T c, T cv, T x, T &r1f, T &r1d) {
     T r2f = 0.0, r2d = 0.0;
 
     if ((x < 0.0) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n))) {
-        set_error("oblate_radial1", SF_ERROR_DOMAIN, NULL);
+        set_error("obl_rad1_cv", SF_ERROR_DOMAIN, NULL);
         r1f = std::numeric_limits<T>::quiet_NaN();
         r1d = std::numeric_limits<T>::quiet_NaN();
     } else {
-        specfun::rswfo(static_cast<int>(m), static_cast<int>(n), c, x, cv, kf, &r1f, &r1d, &r2f, &r2d);
+        if (specfun::rswfo(static_cast<int>(m), static_cast<int>(n),
+                           c, x, cv, kf, &r1f, &r1d, &r2f, &r2d)
+                == specfun::Status::NoMemory) {
+            set_error("obl_rad1_cv", SF_ERROR_MEMORY, "memory allocation error");
+            r1d = std::numeric_limits<T>::quiet_NaN();
+            r1f = std::numeric_limits<T>::quiet_NaN();
+            return;     
+        }
     }
 }
 
@@ -278,11 +389,18 @@ void oblate_radial2(T m, T n, T c, T cv, T x, T &r2f, T &r2d) {
     T r1f = 0.0, r1d = 0.0;
 
     if ((x < 0.0) || (m < 0) || (n < m) || (m != floor(m)) || (n != floor(n))) {
-        set_error("oblate_radial2", SF_ERROR_DOMAIN, NULL);
+        set_error("obl_rad2_cv", SF_ERROR_DOMAIN, NULL);
         r2f = std::numeric_limits<T>::quiet_NaN();
         r2d = std::numeric_limits<T>::quiet_NaN();
     } else {
-        specfun::rswfo(static_cast<int>(m), static_cast<int>(n), c, x, cv, kf, &r1f, &r1d, &r2f, &r2d);
+        if (specfun::rswfo(static_cast<int>(m), static_cast<int>(n),
+                           c, x, cv, kf, &r1f, &r1d, &r2f, &r2d)
+                == specfun::Status::NoMemory) {
+            set_error("obl_rad2_cv", SF_ERROR_MEMORY, "memory allocation error");
+            r2d = std::numeric_limits<T>::quiet_NaN();
+            r2f = std::numeric_limits<T>::quiet_NaN();
+            return; 
+        }
     }
 }
 


### PR DESCRIPTION
This PR cherry picks commits from SciPy to incorporate updates which have been made there in the time since the `xsf` migration took place.