### PR TITLE
CI: Add a dummy github workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,10 @@
+name: Linux Tests
+
+on:
+  push:
+    branches:
+      - main
+      - catch-test-setup
+    pull_request:
+      - main
+      - catch-test-setup


### PR DESCRIPTION
This PR adds a dummy workflow. It seems that workflows in new PRs will not run unless at least one existing workflow has been merged into main.