### PR TITLE
Pin xsref version in clone-xsref command

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -44,7 +44,7 @@ libarrow-all = ">=19.0.1,<20"
 # clean xsref dir
 clean-xsref = { cwd = ".", cmd = "rm -rf xsref" }
 # clone xsref
-clone-xsref.cmd = "git clone --branch v0.0.0 https://github.com/scipy/xsref.git"
+clone-xsref.cmd = "git clone --depth 1 --branch v0.0.0 https://github.com/scipy/xsref.git"
 clone-xsref.cwd = "."
 clone-xsref.depends-on = ["clean-xsref"]
 # configure cmake for tests

--- a/pixi.toml
+++ b/pixi.toml
@@ -44,7 +44,7 @@ libarrow-all = ">=19.0.1,<20"
 # clean xsref dir
 clean-xsref = { cwd = ".", cmd = "rm -rf xsref" }
 # clone xsref
-clone-xsref.cmd = "git clone https://github.com/scipy/xsref.git"
+clone-xsref.cmd = "git clone --branch v0.0.0 https://github.com/scipy/xsref.git"
 clone-xsref.cwd = "."
 clone-xsref.depends-on = ["clean-xsref"]
 # configure cmake for tests


### PR DESCRIPTION
This PR pins the version of `xref` in the `clone-xsref` command to `v0.0.0`, which I just created it seems like a good idea to pin to a tag to make it easier to keep things in sync. I can imagine a situation where we add a new batch of tests, but don't want to pin to the newest `xsref` version on `main` until we have them all passing. Also, this will keep tests for old versions failing if parquet files get removed, renamed, or restructured.