### PR TITLE
BUG: special.hyp2f1: fix for extreme inputs (#22810)

### DIFF
--- a/include/xsf/hyp2f1.h
+++ b/include/xsf/hyp2f1.h
@@ -553,7 +553,7 @@ XSF_HOST_DEVICE inline std::complex<double> hyp2f1(double a, double b, double c,
      * the series at a or b of smaller magnitude. This is to ensure proper
      * handling of situations like a < c < b <= 0, a, b, c all non-positive
      * integers, where terminating at a would lead to a term of the form 0 / 0. */
-    std::uint64_t max_degree;
+    double max_degree;
     if (a_neg_int || b_neg_int) {
         if (a_neg_int && b_neg_int) {
             max_degree = a > b ? std::abs(a) : std::abs(b);
@@ -562,7 +562,7 @@ XSF_HOST_DEVICE inline std::complex<double> hyp2f1(double a, double b, double c,
         } else {
             max_degree = std::abs(b);
         }
-        if (max_degree <= UINT64_MAX) {
+        if (max_degree <= (double) UINT64_MAX) {
             auto series_generator = detail::HypergeometricSeriesGenerator(a, b, c, z);
             return detail::series_eval_fixed_length(series_generator, std::complex<double>{0.0, 0.0}, max_degree + 1);
         } else {
@@ -583,7 +583,7 @@ XSF_HOST_DEVICE inline std::complex<double> hyp2f1(double a, double b, double c,
      * (DLMF 15.8.1) */
     if (c_minus_a_neg_int || c_minus_b_neg_int) {
         max_degree = c_minus_b_neg_int ? std::abs(c - b) : std::abs(c - a);
-        if (max_degree <= UINT64_MAX) {
+        if (max_degree <= (double) UINT64_MAX) {
             result = std::pow(1.0 - z, c - a - b);
             auto series_generator = detail::HypergeometricSeriesGenerator(c - a, c - b, c, z);
             result *=


### PR DESCRIPTION
* Regression testing and patch for extreme input handling in `hyp2f1`. Fixes gh-20988.

Cherry picking https://github.com/scipy/scipy/pull/22810