### PR TITLE
Update a header in response to `cephes::cbrt` leaving detail

### DIFF
--- a/include/xsf/alg.h
+++ b/include/xsf/alg.h
@@ -4,7 +4,7 @@
 
 namespace xsf {
 
-XSF_HOST_DEVICE inline double cbrt(double x) { return cephes::detail::cbrt(x); }
+XSF_HOST_DEVICE inline double cbrt(double x) { return cephes::cbrt(x); }
 
 XSF_HOST_DEVICE inline float cbrt(float x) { return cbrt(static_cast<double>(x)); }
 

--- a/tests/scipy_special_tests/test_cbrt.cpp
+++ b/tests/scipy_special_tests/test_cbrt.cpp
@@ -1,6 +1,6 @@
 #include "../testing_utils.h"
 
-#include <xsf/cephes/cbrt.h>
+#include <xsf/alg.h>
 
 namespace fs = std::filesystem;
 
@@ -15,7 +15,7 @@ TEST_CASE("cephes::cbrt d->d scipy_special_tests", "[cephes::cbrt][d->d][scipy_s
 
     auto x = input;
     auto [desired, fallback] = output;
-    auto out = xsf::cephes::cbrt(x);
+    auto out = xsf::cbrt(x);
     auto error = xsf::extended_relative_error(out, desired);
     tol = adjust_tolerance(tol);
     CAPTURE(x, out, desired, error, tol, fallback);


### PR DESCRIPTION
When trying to build SciPy against `xsf` included as a submodule, there was a failure because SciPy gets `cbrt` from the header `xsf/alg.h`, not `xsf/cephes/cbrt.h`. I had moved `cbrt` from the `xsf::cephes::detail` namespace to `xsf::cephes` because the automatic test case generation framework did not handle testing functions in `detail` namespaces, and it was a mistake to put `cbrt` in a `detail` namespace in the first place.

Going forward, I'm not sure we should have an `alg.h` (algebra?) header just for `cbrt`.  We should organize everything soon. For now, this is just about getting this to work when `xsf` is used as a submodule of SciPy.