### PR TITLE
MAINT: Fix commit for clang-format in .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # clang-format repo gh-5
-e6323cae55daee686221c54160994ee1c7825ba5
+b5e297bba45b56af14d6f057002d16efdf27ad59


### PR DESCRIPTION
I accidentally did a rebase merge instead of a regular merge and changed the commit hash. This fixes it.