### PR TITLE
REL: Bump version on main post-release

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'xsf',
   'cpp',
-  version : '0.1.0',
+  version : '0.1.1.dev0',
   license : 'BSD-3-Clause AND MIT AND BSD-3-Clause-LBNL AND Apache-2.0 WITH LLVM-exception',
   license_files : ['LICENSE', 'LICENSES_bundled.txt'],
   meson_version : '>=1.5.0'

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@ channels = ["https://prefix.dev/conda-forge"]
 description = "Special function implementations."
 name = "xsf"
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
-version = "0.1.0"
+version = "0.1.1.dev0"
 
 ## Build
 


### PR DESCRIPTION
Closes #35 

This PR bumps the version on main to `0.1.1.dev0` as @lucascolley reminded we should do in #35. I think these are the only places where the version is listed, but let me know if I missed any @lucascolley.

