### PR TITLE
BUG: Add missing execution space annotations

### DIFF
--- a/include/xsf/trig.h
+++ b/include/xsf/trig.h
@@ -151,14 +151,14 @@ XSF_HOST_DEVICE inline float cotdg(float x) {
     return cotdg(static_cast<double>(x));
 }
 
-inline double radian(double d, double m, double s) { return cephes::radian(d, m, s); }
+XSF_HOST_DEVICE inline double radian(double d, double m, double s) { return cephes::radian(d, m, s); }
 
-inline float radian(float d, float m, float s) {
+XSF_HOST_DEVICE inline float radian(float d, float m, float s) {
     return radian(static_cast<double>(d), static_cast<double>(m), static_cast<double>(s));
 }
 
-inline double cosm1(double x) { return cephes::cosm1(x); }
+XSF_HOST_DEVICE inline double cosm1(double x) { return cephes::cosm1(x); }
 
-inline float cosm1(float x) { return cosm1(static_cast<double>(x)); }
+XSF_HOST_DEVICE inline float cosm1(float x) { return cosm1(static_cast<double>(x)); }
 
 } // namespace xsf


### PR DESCRIPTION
This PR adds some missing execution space annotations to `xsf/trig.h`. This seems to be the problem causing the CI failures in https://github.com/cupy/cupy/pull/9159.