### PR TITLE
CI: Run CuPy tests in CI for both CUDA 11 and CUDA 12

### DIFF
--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -13,8 +13,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cupy_tests:
-    name: CuPy GPU
+  cupy_tests_cuda11:
+    name: CuPy GPU CUDA 11
     runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64-gpu:22.04
     steps:
       - name: Checkout xsf repo
@@ -45,4 +45,38 @@ jobs:
           cache: false
 
       - name: Run CuPy tests
-        run: pixi run test-cupy
+        run: pixi run test-cupy-cuda11
+
+  cupy_tests_cuda12:
+    name: CuPy GPU CUDA 12
+    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64-gpu:22.04
+    steps:
+      - name: Checkout xsf repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: recursive
+
+      - name: Setup compiler cache
+        uses: cirruslabs/cache@v4  #caa3ad0624c6c2acd8ba50ad452d1f44bba078bb # v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          # Make primary key unique by using `run_id`, this ensures the cache
+          # is always saved at the end.
+          key: ${{ runner.os }}-gpu-ccache-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-gpu-ccache
+
+      - name: run nvidia-smi
+        run: nvidia-smi
+
+      - name: run nvidia-smi --query
+        run: nvidia-smi --query
+
+      - uses: prefix-dev/setup-pixi@ba3bb36eb2066252b2363392b7739741bb777659 # v0.8.1
+        with:
+          pixi-version: v0.39.2
+          manifest-path: pixi.toml
+          cache: false
+
+      - name: Run CuPy tests
+        run: pixi run test-cupy-cuda12

--- a/pixi.toml
+++ b/pixi.toml
@@ -165,8 +165,25 @@ test-cupy.cmd = "pytest --forked python_tests/test_cupy.py"
 test-cupy.cwd = "."
 test-cupy.depends-on = ["install-xsref-test-cupy"]
 
+[feature.cupy-tests-cuda11]
+platforms = ["linux-64"]
+dependencies = { cupy = { version = "*", pypi-name = "cupy-cuda11x" } }
+system-requirements = { cuda = "11" }
+tasks = { test-cupy-cuda11.cmd = "pytest --forked python_tests/test_cupy.py", test-cupy-cuda11.cwd = ".", test-cupy-cuda11.depends-on = ["install-xsref-test-cupy"] }
+# Inherit base dependencies and tasks from cupy-tests
+extend = ["cupy-tests"]
+
+
+[feature.cupy-tests-cuda12]
+platforms = ["linux-64"]
+dependencies = { cupy = { version = "*", pypi-name = "cupy-cuda12x" } }
+system-requirements = { cuda = "12" }
+tasks = { test-cupy-cuda12.cmd = "pytest --forked python_tests/test_cupy.py", test-cupy-cuda12.cwd = ".", test-cupy-cuda12.depends-on = ["install-xsref-test-cupy"] }
+extend = ["cupy-tests"]
+
 [environments]
 default = { features = ["build", "tests"], solve-group = "default" }
 tests-ci = { features = ["build", "tests", "tests-ci", "coverage"], solve-group = "default" }
 lint = { features = ["clang-format"], solve-group = "default" }
-cupy-tests = { features = ["cupy-tests"], solve-group = "default" }
+cupy-tests-cuda11 = { features = ["cupy-tests-cuda11"], solve-group = "cupy-cuda11" }
+cupy-tests-cuda12 = { features = ["cupy-tests-cuda12"], solve-group = "cupy-cuda12" }


### PR DESCRIPTION
This PR attempts to run the CuPy tests for separate CUDA versions (both CUDA 11 and CUDA 12) to make it less likely to have failures appear in CuPy CI that don't appear in xsf CI, as happened here https://github.com/cupy/cupy/pull/9159#issuecomment-2973365095.