### PR TITLE
BUG: Add more missing execution space annotations

### DIFF
--- a/include/xsf/expint.h
+++ b/include/xsf/expint.h
@@ -164,7 +164,7 @@ XSF_HOST_DEVICE inline double expi(double x) {
 
 XSF_HOST_DEVICE inline float expi(float x) { return expi(static_cast<double>(x)); }
 
-std::complex<double> expi(std::complex<double> z) {
+XSF_HOST_DEVICE inline std::complex<double> expi(std::complex<double> z) {
     // ============================================
     // Purpose: Compute exponential integral Ei(x)
     // Input :  x  --- Complex argument of Ei(x)


### PR DESCRIPTION
I found one more of these running CuPy tests with CUDA 11 locally.