### PR TITLE
MAINT: Use C++ headers instead of C headers in amos.h

### DIFF
--- a/include/xsf/amos/amos.h
+++ b/include/xsf/amos/amos.h
@@ -94,8 +94,8 @@
 
 #include <stdlib.h>
 
-#include <complex.h>
-#include <math.h>
+#include <complex>
+#include <cmath>
 #include <memory> // unique_ptr
 
 namespace xsf {


### PR DESCRIPTION
This worked locally, and when I made the same changes in the vendored copy in the scipy repo.  That was on a Linux machine, with gcc 11.4.0.