### PR TITLE
BUG(bessel): cyl_bessel_y: short-circuit return on zero input

### DIFF
--- a/include/xsf/bessel.h
+++ b/include/xsf/bessel.h
@@ -945,7 +945,29 @@ inline std::complex<double> cyl_bessel_y(double v, std::complex<double> z) {
 
     if (z.real() == 0 && z.imag() == 0) {
         /* overflow */
-        cy_y.real(-sign * INFINITY);
+        double re;
+        if (sign == 1 || v < 0.5) {
+            re = -INFINITY;
+        } else {
+            if (v >= std::pow(2.0, 53)) {
+                // The original v (before sign flip) is an even negative integer.
+                re = -INFINITY;
+            } else {
+                double s = v - 0.5;
+                if (s != v && std::rint(s) == s) {
+                    re = 0.0;
+                } else {
+                    double si = std::floor(s);
+                    double half_si = si / 2;
+                    if (std::floor(half_si) == half_si) {
+                        re = INFINITY;
+                    } else {
+                        re = -INFINITY;
+                    }
+                }
+            }
+        }
+        cy_y.real(re);
         cy_y.imag(0);
         set_error("yv", SF_ERROR_OVERFLOW, NULL);
         return cy_y;

--- a/include/xsf/bessel.h
+++ b/include/xsf/bessel.h
@@ -948,6 +948,7 @@ inline std::complex<double> cyl_bessel_y(double v, std::complex<double> z) {
         cy_y.real(-INFINITY);
         cy_y.imag(0);
         set_error("yv", SF_ERROR_OVERFLOW, NULL);
+        return cy_y;
     } else {
         nz = amos::besy(z, v, kode, n, &cy_y, &ierr);
         set_error_and_nan("yv:", ierr_to_sferr(nz, ierr), cy_y);

--- a/include/xsf/bessel.h
+++ b/include/xsf/bessel.h
@@ -945,7 +945,7 @@ inline std::complex<double> cyl_bessel_y(double v, std::complex<double> z) {
 
     if (z.real() == 0 && z.imag() == 0) {
         /* overflow */
-        cy_y.real(-sign*INFINITY);
+        cy_y.real(-sign * INFINITY);
         cy_y.imag(0);
         set_error("yv", SF_ERROR_OVERFLOW, NULL);
         return cy_y;

--- a/include/xsf/bessel.h
+++ b/include/xsf/bessel.h
@@ -945,7 +945,7 @@ inline std::complex<double> cyl_bessel_y(double v, std::complex<double> z) {
 
     if (z.real() == 0 && z.imag() == 0) {
         /* overflow */
-        cy_y.real(-INFINITY);
+        cy_y.real(-sign*INFINITY);
         cy_y.imag(0);
         set_error("yv", SF_ERROR_OVERFLOW, NULL);
         return cy_y;


### PR DESCRIPTION
Over in https://github.com/scipy/xsf/pull/69, there were about 30 failures of the `cyl_bessel_y()` tests in the Windows CI job.  This line

```
D:\a\xsf\xsf\tests\scipy_special_tests\test_cyl_bessel_y.cpp(42): FAILED:
```

appears 30 times in the log, and in each case the `z` input is 0.  Apparently the culprit is somewhere in here:

https://github.com/scipy/xsf/blob/33768a09623689efdf7bcaf0afa167341dda0758/include/xsf/bessel.h#L963-L970 

In this PR, I avoid that code by handling `z=0+0j` entirely in the first if-statemet where it checks for `z = 0+0j`.  With this change, I don't see any of those `cyl_bessel_y()` test failures (but there are many others, so the Windows job still fails overall).

This change is not thoroughly checked, and is probably not the most elegant way to implement the calculation.  I'm sure I'm duplicating functionality that should be in that code shown above, so I'm leaving this in *draft* status.  I think this gets close to the correct behavior, so it might be useful for further investigation and debugging.  Ideally the specific problem in the above code that occurs on Windows would be identified and fixed, and this PR closed without merging.