### PR TITLE
MAINT: change [project] to [workspace] in pixi.toml.

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 authors = [
   "Albert Steppi <albert.steppi@gmail.com>",
   "Irwin Zaid <irwin.zaid@gmail.com>",


### PR DESCRIPTION
Fixes the following pixi 0.59.0 warning:

  The `project` field is deprecated. Use `workspace` instead.