### PR TITLE
MAINT: fix maybe-uninitialized compiler warning in amos.h

### DIFF
--- a/include/xsf/amos/amos.h
+++ b/include/xsf/amos/amos.h
@@ -5473,7 +5473,7 @@ namespace amos {
         std::complex<double> cfn, ck, crsc, cs, cscl, csgn, cspn, c1, c2, rz, s1, s2, zr, phid, zeta1d = 0.0,
                                                                                                 zeta2d = 0.0, sumd;
         double ang, aphi, asc, ascle, c2i, c2m, c2r, fmr, fn, fnf, rs1, sgn, x;
-        int i, ib, iflag = 0, ifn, il, inu, iuf, k, kdflg, kflag, kk, m, nw, nz, j, jc, ipard, initd, ic;
+        int i, ib, iflag = 0, ifn, il, inu, iuf, k, kdflg, kflag, kk, m, nw, nz, j, jc, ipard, initd = 0, ic;
 
         cscl = 1.0 / tol;
         crsc = tol;


### PR DESCRIPTION
Warning this fixes with GCC 13.3.0 in a SciPy CI job:

```
  [649/1264] Compiling C++ object scipy/special/_ufuncs.cpython-312-x86_64-linux-gnu.so.p/xsf_wrappers.cpp.o
  In file included from ../subprojects/xsf/include/xsf/amos.h:3,
                   from ../subprojects/xsf/include/xsf/airy.h:3,
                   from ../scipy/special/xsf_wrappers.cpp:2:
  In function ‘void xsf::amos::unik(std::complex<double>, double, int, int, double, int*, std::complex<double>*, std::complex<double>*, std::complex<double>*, std::complex<double>*, std::complex<double>*)’,
      inlined from ‘int xsf::amos::unk1(std::complex<double>, double, int, int, int, std::complex<double>*, double, double, double)’ at ../subprojects/xsf/include/xsf/amos/amos.h:5716:17:
  ../subprojects/xsf/include/xsf/amos/amos.h:5379:9: warning: ‘initd’ may be used uninitialized [-Wmaybe-uninitialized]
   5379 |         if (*init == 0) {
        |         ^~
  ../subprojects/xsf/include/xsf/amos/amos.h: In function ‘int xsf::amos::unk1(std::complex<double>, double, int, int, int, std::complex<double>*, double, double, double)’:
  ../subprojects/xsf/include/xsf/amos/amos.h:5476:96: note: ‘initd’ was declared here
   5476 |         int i, ib, iflag = 0, ifn, il, inu, iuf, k, kdflg, kflag, kk, m, nw, nz, j, jc, ipard, initd, ic;
        |     
```