### PR TITLE
fix endpoints norm for m=0 in assoc_legendre_p

### DIFF
--- a/include/xsf/legendre.h
+++ b/include/xsf/legendre.h
@@ -303,12 +303,12 @@ void assoc_legendre_p_pm1(NormPolicy norm, int n, int m, T z, int branch_cut, T 
     if (m == 0) {
         if (real(z) >= 0) {
             res = T(1);
-            // Apply normalization for m=0
-            if (std::is_same_v<NormPolicy, assoc_legendre_norm_policy>) {
-                res *= sqrt(T(2 * n + 1) / T(2));
-            }
         } else {
             res = T(std::pow(-1, n));
+        }
+        // Apply normalization for m=0
+        if (std::is_same_v<NormPolicy, assoc_legendre_norm_policy>) {
+            res *= sqrt(T(2 * n + 1) / T(2));
         }
     } else {
         res = T(0);
@@ -320,12 +320,12 @@ void assoc_legendre_p_pm1(NormPolicy norm, int n, int m, dual<T, Order> z, int b
     if (m == 0) {
         if (real(z[0]) >= 0) {
             res[0] = T(1);
-            // Apply normalization for m=0
-            if (std::is_same_v<NormPolicy, assoc_legendre_norm_policy>) {
-                res[0] *= sqrt(T(2 * n + 1) / T(2));
-            }
         } else {
             res[0] = T(std::pow(-1, n));
+        }
+        // Apply normalization for m=0
+        if (std::is_same_v<NormPolicy, assoc_legendre_norm_policy>) {
+            res[0] *= sqrt(T(2 * n + 1) / T(2));
         }
     } else {
         res[0] = T(0);

--- a/tests/xsf_tests/test_assoc_legendre_p.cpp
+++ b/tests/xsf_tests/test_assoc_legendre_p.cpp
@@ -21,3 +21,32 @@ TEST_CASE("assoc_legendre_p scipy/gh-23101", "[assoc_legendre_p][xsf_tests]") {
     CAPTURE(n, m, z, w, ref, rtol, rel_error);
     REQUIRE(rel_error <= rtol);
 }
+
+TEST_CASE("assoc_legendre_p norm m0 gh-78", "[assoc_legendre_p][xsf_tests]") {
+    const int n_max = 10;
+    const int m = 0;
+    const int num_points = 1000;
+    const double left = -1.0;
+    const double right = 1.0;
+
+    std::vector<double> z(num_points);
+    for (int i = 0; i < num_points; ++i) {
+        z[i] = left + (right - left) * i / (num_points - 1);
+    }
+
+    for (int n = 0; n <= n_max; ++n) {
+        for (const auto z_val : z) {
+            // Compute unnormalized and normalized versions
+            const double leg_p = xsf::assoc_legendre_p(xsf::assoc_legendre_unnorm, n, m, z_val, 1);
+            const double leg_p_norm = xsf::assoc_legendre_p(xsf::assoc_legendre_norm, n, m, z_val, 1);
+
+            // Expected relationship: p_norm = sqrt((2*n + 1) / 2) * p
+            const double factor = std::sqrt((2.0 * n + 1.0) / 2.0);
+            const double expected = factor * leg_p;
+
+            const double rel_error = xsf::extended_relative_error(leg_p_norm, expected);
+            CAPTURE(n, m, z_val, leg_p, leg_p_norm, expected, factor, rel_error);
+            REQUIRE(rel_error <= 1e-8);
+        }
+    }
+}


### PR DESCRIPTION
Fixes endpoints normalization error in https://github.com/scipy/scipy/issues/24099