### PR TITLE
BUG(cephes): tukeylambdacdf: fix precision issues

### DIFF
--- a/include/xsf/cephes/tukey.h
+++ b/include/xsf/cephes/tukey.h
@@ -21,7 +21,7 @@ namespace cephes {
     namespace detail {
 
         constexpr double tukey_SMALLVAL = 1e-4;
-        constexpr double tukey_EPS = 1.0e-14;
+        constexpr double tukey_EPS = 1.0e-18;
         constexpr int tukey_MAXCOUNT = 60;
 
     } // namespace detail

--- a/include/xsf/cephes/tukey.h
+++ b/include/xsf/cephes/tukey.h
@@ -21,7 +21,7 @@ namespace cephes {
     namespace detail {
 
         constexpr double tukey_SMALLVAL = 1e-4;
-        constexpr double tukey_EPS = 1.0e-18;
+        double tukey_EPS = 1.0e-14;
         constexpr int tukey_MAXCOUNT = 60;
 
     } // namespace detail
@@ -42,6 +42,10 @@ namespace cephes {
             if (x >= xeval) {
                 return 1.0;
             }
+        }
+
+        if (x > 1e9){
+            detail::tukey_EPS = 1.0e-18;
         }
 
         if ((-detail::tukey_SMALLVAL < lmbda) && (lmbda < detail::tukey_SMALLVAL)) {


### PR DESCRIPTION
This fixes the bug documented in issue [scipy/#21370](https://github.com/scipy/scipy/issues/21370). For $\lambda < 0$ and large $x$, the `stats.tukeylambda.cdf` function would not return 0. By reducing the parameter `tukey_EPS`, this can be achieved. 