### PR TITLE
BUG: specfun/specfun.h: initialize kd in mtu12 to fix potential uninitialized use

### DIFF
--- a/include/xsf/specfun/specfun.h
+++ b/include/xsf/specfun/specfun.h
@@ -4760,7 +4760,7 @@ namespace specfun {
 
         T eps = 1.0e-14;
         T a, qm, c1, c2, u1, u2, w1, w2;
-        int kd, km, ic, k, nm = 0;
+        int kd = 0, km, ic, k, nm = 0;
 
         if ((kf == 1) && (m % 2 == 0)) {
             kd = 1;

--- a/include/xsf/specfun/specfun.h
+++ b/include/xsf/specfun/specfun.h
@@ -4746,7 +4746,7 @@ namespace specfun {
 
         T eps = 1.0e-14;
         T a, qm, c1, c2, u1, u2, w1, w2;
-        int kd, km, ic, k, nm = 0;
+        int kd = 0, km, ic, k, nm = 0;
 
         if ((kf == 1) && (m % 2 == 0)) {
             kd = 1;


### PR DESCRIPTION
The kd variable was not initialized before the kf==1/kf==2 conditional blocks. If kf had an unexpected value, kd would be used uninitialized when passed to cva2(). Initialize to 0 for consistency with mtu0.

Uncovered by Coverity static analysis.