### PR TITLE
BUG: amos/amos.h: fix loop upper bound in `buni`

### DIFF
--- a/include/xsf/amos/amos.h
+++ b/include/xsf/amos/amos.h
@@ -3752,7 +3752,7 @@ namespace amos {
             nl = n - 1;
             fnui = nl;
             k = nl;
-            for (i = 0; i < (nl + 1); i++) {
+            for (i = 0; i < nl; i++) {
                 st = s2;
                 s2 = (fnu + fnui) * rz * s2 + s1;
                 s1 = st;

--- a/tests/xsf_tests/test_amos.cpp
+++ b/tests/xsf_tests/test_amos.cpp
@@ -110,3 +110,26 @@ TEST_CASE("amos asyi buffer overflow gh-158", "[amos][xsf_tests]") {
     CAPTURE(y[n]);
     CHECK(y[n] == sentinel);
 }
+
+TEST_CASE("amos buni buffer overflow gh-93", "[amos][xsf_tests]") {
+    using std::complex;
+
+    // parameters for besh which trigger overflow in buni
+    const complex<double> z{90.0, -3.0};
+    const double fnu = 1.0;
+    const int m = 1;
+    const int n = 30;
+    const int kode = 1;
+
+    // allocate n+1 elements, initialize extra to sentinel to detect overflow
+    const complex<double> sentinel{12345.67, 98765.43};
+    std::vector<complex<double>> cy(n + 2, sentinel);
+
+    int ierr = 0;
+    int nz = xsf::amos::besh(z, fnu, kode, m, n, cy.data() + 1, &ierr);
+
+    // check if guards elements were touched
+    CAPTURE(cy[0], cy[n + 1]);
+    CHECK(cy[0] == sentinel);
+    CHECK(cy[n + 1] == sentinel);
+}


### PR DESCRIPTION
Hi, I detected this error in the same way as in #92. This time I used `z = 90.0 - 3.0j` and `n = 30` in https://github.com/JaRoSchm/pyamos/blob/main/compare_xsf_zbessel.py for finding the bug. This was simply incorrectly translated from FORTRAN, see https://github.com/scipy/scipy/blob/4edfcaa3ce8a387450b6efce968572def71be089/scipy/special/amos/zbuni.f#L114, where only the lower bound has been shifted by one but not the upper bound. As `k` is reduced by one for each loop, it will become -1 during the last iteration, such that `y` as accessed at -1. Regarding testing the same question/comment from #92 applies.