### PR TITLE
ENH: template-ify `lambertw` with overloads for `double`, `float`, and `complex<float>`

### DIFF
--- a/include/xsf/evalpoly.h
+++ b/include/xsf/evalpoly.h
@@ -20,28 +20,41 @@
 #pragma once
 
 #include "config.h"
+#include "cephes/polevl.h"
 
 namespace xsf {
 
-XSF_HOST_DEVICE inline std::complex<double> cevalpoly(const double *coeffs, int degree, std::complex<double> z) {
-    /* Evaluate a polynomial with real coefficients at a complex point.
-     *
-     * Uses equation (3) in section 4.6.4 of [1]. Note that it is more
-     * efficient than Horner's method.
-     */
-    double a = coeffs[0];
-    double b = coeffs[1];
-    double r = 2 * z.real();
-    double s = std::norm(z);
-    double tmp;
+namespace detail {
 
-    for (int j = 2; j < degree + 1; j++) {
-        tmp = b;
-        b = std::fma(-s, a, coeffs[j]);
-        a = std::fma(r, a, tmp);
+    XSF_HOST_DEVICE inline std::complex<double> cevalpoly(const double *coeffs, int degree, std::complex<double> z) {
+        /* Evaluate a polynomial with real coefficients at a complex point.
+        *
+        * Uses equation (3) in section 4.6.4 of [1]. Note that it is more
+        * efficient than Horner's method.
+        */
+        double a = coeffs[0];
+        double b = coeffs[1];
+        double r = 2 * z.real();
+        double s = std::norm(z);
+        double tmp;
+
+        for (int j = 2; j < degree + 1; j++) {
+            tmp = b;
+            b = std::fma(-s, a, coeffs[j]);
+            a = std::fma(r, a, tmp);
+        }
+
+        return z * a + b;
     }
 
-    return z * a + b;
+} // namespace detail
+
+XSF_HOST_DEVICE inline std::complex<double> evalpoly(const double *coeffs, int degree, std::complex<double> z) {
+    return detail::cevalpoly(coeffs, degree, z);
+}
+
+XSF_HOST_DEVICE inline double evalpoly(const double *coeffs, int degree, double x) {
+    return cephes::polevl(x, coeffs, degree);
 }
 
 } // namespace xsf

--- a/include/xsf/lambertw.h
+++ b/include/xsf/lambertw.h
@@ -35,15 +35,17 @@ constexpr double EXPN1 = 0.36787944117144232159553; // exp(-1)
 constexpr double OMEGA = 0.56714329040978387299997; // W(1, 0)
 
 namespace detail {
-    XSF_HOST_DEVICE inline std::complex<double> lambertw_branchpt(std::complex<double> z) {
+    template <typename T>
+    XSF_HOST_DEVICE inline T lambertw_branchpt(T z) {
         // Series for W(z, 0) around the branch point; see 4.22 in [1].
         double coeffs[] = {-1.0 / 3.0, 1.0, -1.0};
-        std::complex<double> p = std::sqrt(2.0 * (M_E * z + 1.0));
+        T p = std::sqrt(2.0 * (M_E * z + 1.0));
 
-        return cevalpoly(coeffs, 2, p);
+        return evalpoly(coeffs, 2, p);
     }
 
-    XSF_HOST_DEVICE inline std::complex<double> lambertw_pade0(std::complex<double> z) {
+    template <typename T>
+    XSF_HOST_DEVICE inline T lambertw_pade0(T z) {
         // (3, 2) Pade approximation for W(z, 0) around 0.
         double num[] = {12.85106382978723404255, 12.34042553191489361902, 1.0};
         double denom[] = {32.53191489361702127660, 14.34042553191489361702, 1.0};
@@ -51,99 +53,149 @@ namespace detail {
         /* This only gets evaluated close to 0, so we don't need a more
          * careful algorithm that avoids overflow in the numerator for
          * large z. */
-        return z * cevalpoly(num, 2, z) / cevalpoly(denom, 2, z);
+        return z * evalpoly(num, 2, z) / evalpoly(denom, 2, z);
     }
 
-    XSF_HOST_DEVICE inline std::complex<double> lambertw_asy(std::complex<double> z, long k) {
+    template <typename T>
+    XSF_HOST_DEVICE inline T lambertw_asy(T z, long k) {
         /* Compute the W function using the first two terms of the
          * asymptotic series. See 4.20 in [1].
          */
-        std::complex<double> w = std::log(z) + 2.0 * M_PI * k * std::complex<double>(0, 1);
+        T w;
+        if constexpr(std::is_floating_point<T>::value) {
+            w = std::log(z);
+        } else {
+            w = std::log(z) + 2.0 * M_PI * k * T(0, 1);
+        }
         return w - std::log(w);
+    }
+
+    template <typename T>
+    XSF_HOST_DEVICE inline T lambertw_impl(T z, long k, double tol) {
+        double absz;
+        double zreal, zimag, wreal;
+        T w;
+        T ew, wew, wewz, wn;
+
+        if constexpr(std::is_floating_point<T>::value) {
+            // real input
+            zreal = z;
+            zimag = 0;
+        } else {
+            // complex input
+            zreal = z.real();
+            zimag = z.imag();
+        }
+
+        // input is complex
+        if (std::isnan(zreal) || std::isnan(zimag)) {
+            return z;
+        }
+        if (zreal == std::numeric_limits<double>::infinity()) {
+            if constexpr(std::is_floating_point<T>::value){
+                return z;
+            } else {
+                return z + 2.0 * M_PI * k * std::complex<double>(0, 1);
+            }
+        }
+        if (zreal == -std::numeric_limits<double>::infinity()) {
+            if constexpr(std::is_floating_point<T>::value){
+                return -z;
+            } else {
+                return -z + (2.0 * M_PI * k + M_PI) * std::complex<double>(0, 1);
+            }
+        }
+        if (z == 0.0) {
+            if (k == 0) {
+                return z;
+            }
+            set_error("lambertw", SF_ERROR_SINGULAR, NULL);
+            return -std::numeric_limits<double>::infinity();
+        }
+        if (z == 1.0 && k == 0) {
+            // Split out this case because the asymptotic series blows up
+            return OMEGA;
+        }
+
+        absz = std::abs(z);
+        // Get an initial guess for Halley's method
+        if (k == 0) {
+            if (std::abs(z + EXPN1) < 0.3) {
+                w = lambertw_branchpt(z);
+            } else if (-1.0 < zreal && zreal < 1.5 && std::abs(zimag) < 1.0 &&
+                    -2.5 * std::abs(zimag) - 0.2 < zreal) {
+                /* Empirically determined decision boundary where the Pade
+                * approximation is more accurate. */
+                w = lambertw_pade0(z);
+            } else {
+                w = lambertw_asy(z, k);
+            }
+        } else if (k == -1) {
+            if (absz <= EXPN1 && zimag == 0.0 && zreal < 0.0) {
+                w = std::log(-zreal);
+            } else {
+                w = lambertw_asy(z, k);
+            }
+        } else {
+            w = lambertw_asy(z, k);
+        }
+
+        if constexpr(std::is_floating_point<T>::value) {
+            wreal = w;
+        } else {
+            wreal = w.real();
+        }
+
+        // Halley's method; see 5.9 in [1]
+        if (wreal >= 0) {
+            // Rearrange the formula to avoid overflow in exp
+            for (int i = 0; i < 100; i++) {
+                ew = std::exp(-w);
+                wewz = w - z * ew;
+                wn = w - wewz / (w + 1.0 - (w + 2.0) * wewz / (2.0 * w + 2.0));
+                if (std::abs(wn - w) <= tol * std::abs(wn)) {
+                    return wn;
+                }
+                w = wn;
+            }
+        } else {
+            for (int i = 0; i < 100; i++) {
+                ew = std::exp(w);
+                wew = w * ew;
+                wewz = wew - z;
+                wn = w - wewz / (wew + ew - (w + 2.0) * wewz / (2.0 * w + 2.0));
+                if (std::abs(wn - w) <= tol * std::abs(wn)) {
+                    return wn;
+                }
+                w = wn;
+            }
+        }
+
+        set_error("lambertw", SF_ERROR_SLOW, "iteration failed to converge: %g + %gj", zreal, zimag);
+        if constexpr(std::is_floating_point<T>::value) {
+            return std::numeric_limits<double>::quiet_NaN();
+        } else {
+            return std::complex<double>(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN());
+        }
     }
 
 } // namespace detail
 
+XSF_HOST_DEVICE inline double lambertw(double x, long k, double tol) {
+    return detail::lambertw_impl(x, k, tol);
+}
+
+XSF_HOST_DEVICE inline float lambertw(float x, long k, double tol) {
+    return static_cast<float>(detail::lambertw_impl(static_cast<double>(x), k, tol)
+    );
+}
+
 XSF_HOST_DEVICE inline std::complex<double> lambertw(std::complex<double> z, long k, double tol) {
-    double absz;
-    std::complex<double> w;
-    std::complex<double> ew, wew, wewz, wn;
-
-    if (std::isnan(z.real()) || std::isnan(z.imag())) {
-        return z;
-    }
-    if (z.real() == std::numeric_limits<double>::infinity()) {
-        return z + 2.0 * M_PI * k * std::complex<double>(0, 1);
-    }
-    if (z.real() == -std::numeric_limits<double>::infinity()) {
-        return -z + (2.0 * M_PI * k + M_PI) * std::complex<double>(0, 1);
-    }
-    if (z == 0.0) {
-        if (k == 0) {
-            return z;
-        }
-        set_error("lambertw", SF_ERROR_SINGULAR, NULL);
-        return -std::numeric_limits<double>::infinity();
-    }
-    if (z == 1.0 && k == 0) {
-        // Split out this case because the asymptotic series blows up
-        return OMEGA;
-    }
-
-    absz = std::abs(z);
-    // Get an initial guess for Halley's method
-    if (k == 0) {
-        if (std::abs(z + EXPN1) < 0.3) {
-            w = detail::lambertw_branchpt(z);
-        } else if (-1.0 < z.real() && z.real() < 1.5 && std::abs(z.imag()) < 1.0 &&
-                   -2.5 * std::abs(z.imag()) - 0.2 < z.real()) {
-            /* Empirically determined decision boundary where the Pade
-             * approximation is more accurate. */
-            w = detail::lambertw_pade0(z);
-        } else {
-            w = detail::lambertw_asy(z, k);
-        }
-    } else if (k == -1) {
-        if (absz <= EXPN1 && z.imag() == 0.0 && z.real() < 0.0) {
-            w = std::log(-z.real());
-        } else {
-            w = detail::lambertw_asy(z, k);
-        }
-    } else {
-        w = detail::lambertw_asy(z, k);
-    }
-
-    // Halley's method; see 5.9 in [1]
-    if (w.real() >= 0) {
-        // Rearrange the formula to avoid overflow in exp
-        for (int i = 0; i < 100; i++) {
-            ew = std::exp(-w);
-            wewz = w - z * ew;
-            wn = w - wewz / (w + 1.0 - (w + 2.0) * wewz / (2.0 * w + 2.0));
-            if (std::abs(wn - w) <= tol * std::abs(wn)) {
-                return wn;
-            }
-            w = wn;
-        }
-    } else {
-        for (int i = 0; i < 100; i++) {
-            ew = std::exp(w);
-            wew = w * ew;
-            wewz = wew - z;
-            wn = w - wewz / (wew + ew - (w + 2.0) * wewz / (2.0 * w + 2.0));
-            if (std::abs(wn - w) <= tol * std::abs(wn)) {
-                return wn;
-            }
-            w = wn;
-        }
-    }
-
-    set_error("lambertw", SF_ERROR_SLOW, "iteration failed to converge: %g + %gj", z.real(), z.imag());
-    return {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
+    return detail::lambertw_impl(z, k, tol);
 }
 
 XSF_HOST_DEVICE inline std::complex<float> lambertw(std::complex<float> z, long k, float tol) {
-    return static_cast<std::complex<float>>(lambertw(static_cast<std::complex<double>>(z), k, static_cast<double>(tol))
+    return static_cast<std::complex<float>>(detail::lambertw_impl(static_cast<std::complex<double>>(z), k, static_cast<double>(tol))
     );
 }
 

--- a/include/xsf/lambertw.h
+++ b/include/xsf/lambertw.h
@@ -185,7 +185,7 @@ XSF_HOST_DEVICE inline double lambertw(double x, long k, double tol) {
     return detail::lambertw_impl(x, k, tol);
 }
 
-XSF_HOST_DEVICE inline float lambertw(float x, long k, double tol) {
+XSF_HOST_DEVICE inline float lambertw(float x, long k, float tol) {
     return static_cast<float>(detail::lambertw_impl(static_cast<double>(x), k, tol)
     );
 }

--- a/include/xsf/numpy.h
+++ b/include/xsf/numpy.h
@@ -237,7 +237,9 @@ namespace numpy {
 
     // 3 inputs, 1 output
     using fff_f = float (*)(float, float, float);
+    using flf_f = float (*)(float, long int, float);
     using ddd_d = double (*)(double, double, double);
+    using dld_d = double (*)(double, long int, double);
     using Flf_F = cfloat (*)(cfloat, long int, float);
     using Dld_D = cdouble (*)(cdouble, long int, double);
 

--- a/tests/xsf_tests/test_lambertw.cpp
+++ b/tests/xsf_tests/test_lambertw.cpp
@@ -1,0 +1,76 @@
+#include "../testing_utils.h"
+#include <tuple>
+#include <xsf/lambertw.h>
+
+TEST_CASE("lambertw k=0 branch", "[lambertw][xsf_tests]") {
+
+    using test_case = std::tuple<double, double>;
+    // Reference values were computed with the Python library mpmath.
+    // import mpmath
+    // x0 = [-1/mpmath.e+1e-3, -0.3, -0.1, -1e-6, 0.0, 1e-6, 1, 10, 1000, 1000000]
+    // expected_k0 = [float(mpmath.lambertw(x, k=0)) for x in x0]
+
+    auto [x, ref_w] = GENERATE(
+        test_case{-0.366879441171442, -0.9280201500545675},
+        test_case{-0.3, -0.4894022271802149},
+        test_case{-0.1, -0.11183255915896297},
+        test_case{-1e-06, -1.0000010000014999e-06},
+        test_case{0.0, 0.0},
+        test_case{1e-06, 9.999990000015e-07},
+        test_case{1, 0.5671432904097838},
+        test_case{10, 1.7455280027406994},
+        test_case{1000, 5.249602852401596},
+        test_case{1000000, 11.383358086140053}
+    );
+
+    double w_d = xsf::lambertw(x, 0, 1e-14);
+    const auto abs_error_d = xsf::extended_absolute_error(w_d, ref_w);
+    CAPTURE(x, w_d, ref_w, abs_error_d);
+    REQUIRE(abs_error_d <= 1e-11);
+
+    float w_f = xsf::lambertw(static_cast<float>(x), 0, 1e-14);
+    const auto abs_error_f = xsf::extended_absolute_error(static_cast<double>(w_f), ref_w);
+    CAPTURE(x, w_f, ref_w, abs_error_f);
+    REQUIRE(abs_error_f <= 1e-6);
+}
+
+TEST_CASE("lambertw k=-1 branch", "[lambertw][xsf_tests]") {
+
+    using test_case = std::tuple<double, double>;
+    // Reference values were computed with the Python library mpmath.
+    // import mpmath
+    // xn1 = [-1/mpmath.e+1e-3, -0.3, -0.1, -1e-3]
+    // expected_kn1 = [float(mpmath.lambertw(x, k=-1)) for x in xn1]
+
+    auto [x, ref_w] = GENERATE(
+        test_case{-0.366879441171442, -1.0756089411866245},
+        test_case{-0.3, -1.7813370234216277},
+        test_case{-0.1, -3.577152063957297},
+        test_case{-0.001, -9.11800647040274}
+    );
+
+    double w_d = xsf::lambertw(x, -1, 1e-14);
+    const auto abs_error_d = xsf::extended_absolute_error(w_d, ref_w);
+    CAPTURE(x, w_d, ref_w, abs_error_d);
+    REQUIRE(abs_error_d <= 1e-11);
+
+    float w_f = xsf::lambertw(static_cast<float>(x), -1, 1e-14);
+    const auto abs_error_f = xsf::extended_absolute_error(static_cast<double>(w_f), ref_w);
+    CAPTURE(x, w_f, ref_w, abs_error_f);
+    REQUIRE(abs_error_f <= 1e-6);
+}
+
+TEST_CASE("lambertw nan inf", "[lambertw][xsf_tests]") {
+
+    double nan = std::numeric_limits<double>::quiet_NaN();
+    double inf = std::numeric_limits<double>::infinity();
+
+    double w = xsf::lambertw(nan, 0, 1e-14);
+    REQUIRE(std::isnan(w));
+
+    w = xsf::lambertw(inf, 0, 1e-14);
+    REQUIRE(w == std::numeric_limits<double>::infinity());
+
+    w = xsf::lambertw(-inf, 0, 1e-14);
+    REQUIRE(w == std::numeric_limits<double>::infinity());
+}


### PR DESCRIPTION
This PR adds overloads for `lambertw` for `double`, `float`, and `complex<float>` inputs.  The implementation follows @steppi's suggested approach in this forum thread: https://discuss.scientific-python.org/t/scipy-special-faster-real-only-versions-of-special-functions/2271/4

Please note that this is my first time dealing with modern C++.  Please review the code assuming it was written by someone that figured it out as they went :)

I can say at least that it compiles and passes `pixi run tests`, which I take to mean that I did not break the existing `complex<double>` path.  However, I'll need some guidance with creating tests for the new dtypes.  I see there are parquet files with test values, but I'm lost beyond that.  