### PR TITLE
REL: Bump version to 0.2.2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'xsf',
   'cpp',
-  version : '0.2.0',
+  version : '0.2.2',
   license : 'BSD-3-Clause AND MIT AND BSD-3-Clause-LBNL AND Apache-2.0 WITH LLVM-exception',
   license_files : ['LICENSE', 'LICENSES_bundled.txt'],
   meson_version : '>=1.5.0'

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@ channels = ["https://prefix.dev/conda-forge"]
 description = "Special function implementations."
 name = "xsf"
 platforms = ["win-64", "linux-64", "osx-64", "osx-arm64"]
-version = "0.2.0"
+version = "0.2.2"
 
 ## Build
 


### PR DESCRIPTION
This PR bumps the version in `pixi.toml` and `meson.build`  to 0.2.2 in preparation for a new release. Unfortunately it seems I forgot to bump the version before creating `0.2.1`, so the jump here looks like it is from `0.2.0` to `0.2.2`.