### PR TITLE
ENH: Add CDF and SF of the Wilcoxon distribution

### DIFF
--- a/include/xsf/stats.h
+++ b/include/xsf/stats.h
@@ -502,6 +502,85 @@ inline float tukeylambdacdf(float x, double lmbda) {
     return tukeylambdacdf(static_cast<double>(x), static_cast<double>(lmbda));
 }
 
+inline std::vector<double> wilcoxon_pmf(int n) {
+    // PMF of the Wilcoxon signed-rank statistic.
+    // The returned vector has length n*(n+1)/2 + 1, and the k-th element contains
+    // the probability of observing a test statistic equal to k for n pairs of
+    // observations.
+    std::vector<double> pmf = {1.0};
+    for (int k = 1; k < n + 1; k++) {
+        std::vector<double> tmp(k * (k + 1) / 2 + 1, 0.0);
+        int m = static_cast<int>(pmf.size());
+        for (int i = 0; i < m; i++) {
+            tmp[i] += 0.5 * pmf[i];
+            tmp[i + k] += 0.5 * pmf[i];
+        }
+        pmf = std::move(tmp);
+    }
+    return pmf;
+}
+
+inline std::vector<double> wilcoxon_cdf_table(const std::vector<double> &pmf) {
+    // Cumulative probabilities for CDF/SF queries.
+    std::vector<double> cdf_table(pmf.size());
+    double sum = 0.0;
+    for (int i = 0; i < static_cast<int>(pmf.size()); ++i) {
+        sum += pmf[i];
+        cdf_table[i] = sum;
+    }
+    return cdf_table;
+}
+
+inline double wilcoxon_cdf1(int k, const std::vector<double> &cdf_table, int n) {
+    const int max_k = n * (n + 1) / 2;
+    if (k < 0) {
+        return 0.0;
+    }
+    if (k >= max_k) {
+        return 1.0;
+    }
+    return cdf_table[k];
+}
+
+inline double wilcoxon_sf1(int k, const std::vector<double> &cdf_table, int n) {
+    const int max_k = n * (n + 1) / 2;
+    if (k < 0) {
+        return 1.0;
+    }
+    if (k > max_k) {
+        return 0.0;
+    }
+    return 1.0 - (k > 0 ? cdf_table[k - 1] : 0.0);
+}
+
+inline double wilcoxon_cdf(int k, const std::vector<double> &cdf_table, int n) {
+    // CDF of the Wilcoxon signed-rank statistic for integer k and n pairs of observations.
+    const double mn = n * (n + 1) / 4.0;
+    return (k <= mn) ? wilcoxon_cdf1(k, cdf_table, n) : 1.0 - wilcoxon_sf1(k + 1, cdf_table, n);
+}
+
+inline double wilcoxon_cdf(double k, const std::vector<double> &cdf_table, int n) {
+    // CDF of the Wilcoxon signed-rank statistic for real k and n pairs of observations.
+    if (std::isnan(k) || n < 0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    return wilcoxon_cdf(static_cast<int>(k), cdf_table, n);
+}
+
+inline double wilcoxon_sf(int k, const std::vector<double> &cdf_table, int n) {
+    // SF of the Wilcoxon signed-rank statistic for integer k and n pairs of observations.
+    const double mn = n * (n + 1) / 4.0;
+    return (k <= mn) ? wilcoxon_sf1(k, cdf_table, n) : 1.0 - wilcoxon_cdf1(k - 1, cdf_table, n);
+}
+
+inline double wilcoxon_sf(double k, const std::vector<double> &cdf_table, int n) {
+    // SF of the Wilcoxon signed-rank statistic for real k and n pairs of observations.
+    if (std::isnan(k) || n < 0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    return wilcoxon_sf(static_cast<int>(k), cdf_table, n);
+}
+
 namespace detail {
 
     template <typename InputMat, typename OutputMat>

--- a/include/xsf/stats.h
+++ b/include/xsf/stats.h
@@ -502,85 +502,6 @@ inline float tukeylambdacdf(float x, double lmbda) {
     return tukeylambdacdf(static_cast<double>(x), static_cast<double>(lmbda));
 }
 
-inline std::vector<double> wilcoxon_pmf(int n) {
-    // PMF of the Wilcoxon signed-rank statistic.
-    // The returned vector has length n*(n+1)/2 + 1, and the k-th element contains
-    // the probability of observing a test statistic equal to k for n pairs of
-    // observations.
-    std::vector<double> pmf = {1.0};
-    for (int k = 1; k < n + 1; k++) {
-        std::vector<double> tmp(k * (k + 1) / 2 + 1, 0.0);
-        int m = static_cast<int>(pmf.size());
-        for (int i = 0; i < m; i++) {
-            tmp[i] += 0.5 * pmf[i];
-            tmp[i + k] += 0.5 * pmf[i];
-        }
-        pmf = std::move(tmp);
-    }
-    return pmf;
-}
-
-inline std::vector<double> wilcoxon_cdf_table(const std::vector<double> &pmf) {
-    // Cumulative probabilities for CDF/SF queries.
-    std::vector<double> cdf_table(pmf.size());
-    double sum = 0.0;
-    for (int i = 0; i < static_cast<int>(pmf.size()); ++i) {
-        sum += pmf[i];
-        cdf_table[i] = sum;
-    }
-    return cdf_table;
-}
-
-inline double wilcoxon_cdf1(int k, const std::vector<double> &cdf_table, int n) {
-    const int max_k = n * (n + 1) / 2;
-    if (k < 0) {
-        return 0.0;
-    }
-    if (k >= max_k) {
-        return 1.0;
-    }
-    return cdf_table[k];
-}
-
-inline double wilcoxon_sf1(int k, const std::vector<double> &cdf_table, int n) {
-    const int max_k = n * (n + 1) / 2;
-    if (k < 0) {
-        return 1.0;
-    }
-    if (k > max_k) {
-        return 0.0;
-    }
-    return 1.0 - (k > 0 ? cdf_table[k - 1] : 0.0);
-}
-
-inline double wilcoxon_cdf(int k, const std::vector<double> &cdf_table, int n) {
-    // CDF of the Wilcoxon signed-rank statistic for integer k and n pairs of observations.
-    const double mn = n * (n + 1) / 4.0;
-    return (k <= mn) ? wilcoxon_cdf1(k, cdf_table, n) : 1.0 - wilcoxon_sf1(k + 1, cdf_table, n);
-}
-
-inline double wilcoxon_cdf(double k, const std::vector<double> &cdf_table, int n) {
-    // CDF of the Wilcoxon signed-rank statistic for real k and n pairs of observations.
-    if (std::isnan(k) || n < 0) {
-        return std::numeric_limits<double>::quiet_NaN();
-    }
-    return wilcoxon_cdf(static_cast<int>(k), cdf_table, n);
-}
-
-inline double wilcoxon_sf(int k, const std::vector<double> &cdf_table, int n) {
-    // SF of the Wilcoxon signed-rank statistic for integer k and n pairs of observations.
-    const double mn = n * (n + 1) / 4.0;
-    return (k <= mn) ? wilcoxon_sf1(k, cdf_table, n) : 1.0 - wilcoxon_cdf1(k - 1, cdf_table, n);
-}
-
-inline double wilcoxon_sf(double k, const std::vector<double> &cdf_table, int n) {
-    // SF of the Wilcoxon signed-rank statistic for real k and n pairs of observations.
-    if (std::isnan(k) || n < 0) {
-        return std::numeric_limits<double>::quiet_NaN();
-    }
-    return wilcoxon_sf(static_cast<int>(k), cdf_table, n);
-}
-
 namespace detail {
 
     template <typename InputMat, typename OutputMat>
@@ -677,6 +598,123 @@ XSF_HOST_DEVICE inline typename InputMat::value_type take_from_discrete_cdf(Inpu
         return T(1.0);
     }
     return cdf(k);
+}
+
+namespace detail {
+
+    template <typename OutputMat>
+    XSF_HOST_DEVICE inline void wilcoxon_pmf_all_impl(int n, OutputMat res) {
+        /* Shared implementation used by PMF and CDF table generation. */
+        using T = typename OutputMat::value_type;
+        const int max_k = n * (n + 1) / 2;
+
+        for (int i = 0; i <= max_k; ++i) {
+            res(i) = T(0.0);
+        }
+        res(0) = T(1.0);
+
+        for (int k = 1; k <= n; ++k) {
+            const int curr_max = k * (k + 1) / 2;
+            // Iterate backwards so res(i - k) still holds its previous-step value.
+            for (int i = curr_max; i >= 0; --i) {
+                res(i) = T(0.5) * (res(i) + (i >= k ? res(i - k) : T(0.0)));
+            }
+        }
+    }
+
+} // namespace detail
+
+template <typename OutputMat>
+XSF_HOST_DEVICE inline void wilcoxon_pmf_all(int n, OutputMat res) {
+    /* Fill `res` with the full PMF table for a Wilcoxon signed-rank statistic.
+     *
+     * res should be an mdspan view of a 1d array of length
+     * n * (n + 1) / 2 + 1. It is up to the caller to pass valid values
+     * for n and res.
+     */
+    if (n < 0) {
+        set_error("_wilcoxon_pmf_all", SF_ERROR_DOMAIN, "n must be non-negative");
+        return;
+    }
+
+    const long long int out_size = static_cast<long long int>(res.extent(0));
+    const long long int expected_size = static_cast<long long int>(n) * (n + 1) / 2 + 1;
+    if (out_size != expected_size) {
+        set_error("_wilcoxon_pmf_all", SF_ERROR_MEMORY, "out.shape[-1] must be n * (n + 1) / 2 + 1");
+        return;
+    }
+
+    detail::wilcoxon_pmf_all_impl(n, res);
+}
+
+template <typename OutputMat>
+XSF_HOST_DEVICE inline void wilcoxon_cdf_all(int n, OutputMat res) {
+    /* Fill `res` with the full CDF table for a Wilcoxon signed-rank statistic. */
+    using T = typename OutputMat::value_type;
+
+    if (n < 0) {
+        set_error("_wilcoxon_cdf_all", SF_ERROR_DOMAIN, "n must be non-negative");
+        return;
+    }
+
+    const long long int out_size = static_cast<long long int>(res.extent(0));
+    const long long int expected_size = static_cast<long long int>(n) * (n + 1) / 2 + 1;
+    if (out_size != expected_size) {
+        set_error("_wilcoxon_cdf_all", SF_ERROR_MEMORY, "out.shape[-1] must be n * (n + 1) / 2 + 1");
+        return;
+    }
+
+    detail::wilcoxon_pmf_all_impl(n, res);
+    for (long long int i = 1; i < out_size - 1; ++i) {
+        res(i) = std::min(res(i) + res(i - 1), T(1.0));
+    }
+    res(out_size - 1) = T(1.0);
+}
+
+template <typename InputMat>
+XSF_HOST_DEVICE inline typename InputMat::value_type wilcoxon_pmf(long long int k, InputMat pmf) {
+    /* Return a scalar value from a precomputed PMF table. */
+    return take_from_pmf(pmf, k);
+}
+
+template <typename InputMat>
+XSF_HOST_DEVICE inline typename InputMat::value_type wilcoxon_pmf(double k, InputMat pmf) {
+    using T = typename InputMat::value_type;
+    if (std::isnan(k)) {
+        return std::numeric_limits<T>::quiet_NaN();
+    }
+    return wilcoxon_pmf(static_cast<long long int>(k), pmf);
+}
+
+template <typename InputMat>
+XSF_HOST_DEVICE inline typename InputMat::value_type wilcoxon_cdf(long long int k, InputMat cdf) {
+    /* Return a scalar value from a precomputed CDF table. */
+    return take_from_discrete_cdf(cdf, k);
+}
+
+template <typename InputMat>
+XSF_HOST_DEVICE inline typename InputMat::value_type wilcoxon_cdf(double k, InputMat cdf) {
+    using T = typename InputMat::value_type;
+    if (std::isnan(k)) {
+        return std::numeric_limits<T>::quiet_NaN();
+    }
+    return wilcoxon_cdf(static_cast<long long int>(k), cdf);
+}
+
+template <typename InputMat>
+XSF_HOST_DEVICE inline typename InputMat::value_type wilcoxon_sf(long long int k, InputMat cdf) {
+    /* Return a scalar survival probability from a precomputed CDF table. */
+    using T = typename InputMat::value_type;
+    return T(1.0) - take_from_discrete_cdf(cdf, k - 1);
+}
+
+template <typename InputMat>
+XSF_HOST_DEVICE inline typename InputMat::value_type wilcoxon_sf(double k, InputMat cdf) {
+    using T = typename InputMat::value_type;
+    if (std::isnan(k)) {
+        return std::numeric_limits<T>::quiet_NaN();
+    }
+    return wilcoxon_sf(static_cast<long long int>(k), cdf);
 }
 
 namespace detail {

--- a/include/xsf/stats.h
+++ b/include/xsf/stats.h
@@ -628,9 +628,8 @@ template <typename OutputMat>
 XSF_HOST_DEVICE inline void wilcoxon_pmf_all(int n, OutputMat res) {
     /* Fill `res` with the full PMF table for a Wilcoxon signed-rank statistic.
      *
-     * res should be an mdspan view of a 1d array of length
-     * n * (n + 1) / 2 + 1. It is up to the caller to pass valid values
-     * for n and res.
+     * res should be an mdspan view of a 1d array of length n * (n + 1) / 2 + 1.
+     * It is up to the caller to pass valid values for n and res.
      */
     if (n < 0) {
         set_error("_wilcoxon_pmf_all", SF_ERROR_DOMAIN, "n must be non-negative");

--- a/tests/xsf_tests/test_wilcoxon.cpp
+++ b/tests/xsf_tests/test_wilcoxon.cpp
@@ -1,0 +1,132 @@
+#include "../testing_utils.h"
+#include <xsf/stats.h>
+
+// Values computed from scipy.stats._wilcoxon
+//
+// # Example for CDF and n = 5
+// from scipy.stats._wilcoxon import WilcoxonDistribution
+// import numpy as np
+// np.set_printoptions(precision=17)
+// n = 5
+// wd = WilcoxonDistribution(n)
+// wd.cdf([5, 6, 7, 8, 9])
+
+TEST_CASE("wilcoxon_cdf exact small cases", "[wilcoxon_cdf]") {
+    {
+        // n = 0
+        const std::vector<double> pmf = xsf::wilcoxon_pmf(0);
+        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
+        REQUIRE(xsf::wilcoxon_cdf(0.0, cdf_table, 0) == 1.0);
+    }
+
+    {   // n = 1
+        const std::vector<double> pmf = xsf::wilcoxon_pmf(1);
+        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
+        REQUIRE(xsf::wilcoxon_cdf(0.0, cdf_table, 1) == 0.5);
+        REQUIRE(xsf::wilcoxon_cdf(1.0, cdf_table, 1) == 1.0);
+    }
+
+    {   // n = 2
+        const std::vector<double> pmf = xsf::wilcoxon_pmf(2);
+        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
+        REQUIRE(xsf::wilcoxon_cdf(1.0, cdf_table, 2) == 0.5);
+        REQUIRE(xsf::wilcoxon_cdf(2.0, cdf_table, 2) == 0.75);
+        REQUIRE(xsf::wilcoxon_cdf(3.0, cdf_table, 2) == 1.0);
+        REQUIRE(xsf::wilcoxon_cdf(4.0, cdf_table, 2) == 1.0);
+    }
+
+    {   // n = 3
+        const std::vector<double> pmf = xsf::wilcoxon_pmf(3);
+        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
+        REQUIRE(xsf::wilcoxon_cdf(3.0, cdf_table, 3) == 0.625);
+        REQUIRE(xsf::wilcoxon_cdf(4.0, cdf_table, 3) == 0.75);
+        REQUIRE(xsf::wilcoxon_cdf(5.0, cdf_table, 3) == 0.875);
+        REQUIRE(xsf::wilcoxon_cdf(6.0, cdf_table, 3) == 1.0);
+        REQUIRE(xsf::wilcoxon_cdf(7.0, cdf_table, 3) == 1.0);
+    }
+
+    {   // n = 5
+        const std::vector<double> pmf = xsf::wilcoxon_pmf(5);
+        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
+        REQUIRE(xsf::wilcoxon_cdf(5.0, cdf_table, 5) == 0.3125);
+        REQUIRE(xsf::wilcoxon_cdf(6.0, cdf_table, 5) == 0.40625);
+        REQUIRE(xsf::wilcoxon_cdf(7.0, cdf_table, 5) == 0.5);
+        REQUIRE(xsf::wilcoxon_cdf(8.0, cdf_table, 5) == 0.59375);
+        REQUIRE(xsf::wilcoxon_cdf(9.0, cdf_table, 5) == 0.6875);
+    }
+}
+
+TEST_CASE("wilcoxon_cdf edge cases", "[wilcoxon_cdf]") {
+    const std::vector<double> pmf = xsf::wilcoxon_pmf(2);
+    const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
+
+    REQUIRE(xsf::wilcoxon_cdf(4.0, cdf_table, 2) == 1.0);
+
+    REQUIRE(xsf::wilcoxon_cdf(1.9, cdf_table, 2) == xsf::wilcoxon_cdf(1.0, cdf_table, 2));
+    REQUIRE(xsf::wilcoxon_cdf(-0.5, cdf_table, 2) == xsf::wilcoxon_cdf(0.0, cdf_table, 2));
+
+    REQUIRE(std::isnan(xsf::wilcoxon_cdf(0.0, cdf_table, -1)));
+    REQUIRE(std::isnan(xsf::wilcoxon_cdf(std::numeric_limits<double>::quiet_NaN(), cdf_table, 2)));
+}
+
+TEST_CASE("wilcoxon_sf exact small cases", "[wilcoxon_sf]") {
+    {
+        // n = 0
+        const std::vector<double> pmf = xsf::wilcoxon_pmf(0);
+        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
+        REQUIRE(xsf::wilcoxon_sf(0.0, cdf_table, 0) == 1.0);
+        REQUIRE(xsf::wilcoxon_sf(1.0, cdf_table, 0) == 0.0);
+    }
+
+    {   // n = 1
+        const std::vector<double> pmf = xsf::wilcoxon_pmf(1);
+        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
+        REQUIRE(xsf::wilcoxon_sf(0.0, cdf_table, 1) == 1.0);
+        REQUIRE(xsf::wilcoxon_sf(1.0, cdf_table, 1) == 0.5);
+        REQUIRE(xsf::wilcoxon_sf(2.0, cdf_table, 1) == 0.0);
+    }
+
+    {   // n = 2
+        const std::vector<double> pmf = xsf::wilcoxon_pmf(2);
+        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
+        REQUIRE(xsf::wilcoxon_sf(0.0, cdf_table, 2) == 1.0);
+        REQUIRE(xsf::wilcoxon_sf(1.0, cdf_table, 2) == 0.75);
+        REQUIRE(xsf::wilcoxon_sf(2.0, cdf_table, 2) == 0.5);
+        REQUIRE(xsf::wilcoxon_sf(3.0, cdf_table, 2) == 0.25);
+        REQUIRE(xsf::wilcoxon_sf(4.0, cdf_table, 2) == 0.0);
+    }
+
+    {   // n = 3
+        const std::vector<double> pmf = xsf::wilcoxon_pmf(3);
+        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
+        REQUIRE(xsf::wilcoxon_sf(3.0, cdf_table, 3) == 0.625);
+        REQUIRE(xsf::wilcoxon_sf(4.0, cdf_table, 3) == 0.375);
+        REQUIRE(xsf::wilcoxon_sf(5.0, cdf_table, 3) == 0.25);
+        REQUIRE(xsf::wilcoxon_sf(6.0, cdf_table, 3) == 0.125);
+        REQUIRE(xsf::wilcoxon_sf(7.0, cdf_table, 3) == 0.0);
+    }
+
+    {   // n = 5
+        const std::vector<double> pmf = xsf::wilcoxon_pmf(5);
+        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
+        REQUIRE(xsf::wilcoxon_sf(5.0, cdf_table, 5) == 0.78125);
+        REQUIRE(xsf::wilcoxon_sf(6.0, cdf_table, 5) == 0.6875);
+        REQUIRE(xsf::wilcoxon_sf(7.0, cdf_table, 5) == 0.59375);
+        REQUIRE(xsf::wilcoxon_sf(8.0, cdf_table, 5) == 0.5);
+        REQUIRE(xsf::wilcoxon_sf(9.0, cdf_table, 5) == 0.40625);
+    }
+}
+
+TEST_CASE("wilcoxon_sf edge cases", "[wilcoxon_sf]") {
+    const std::vector<double> pmf = xsf::wilcoxon_pmf(2);
+    const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
+
+    REQUIRE(xsf::wilcoxon_sf(-1.0, cdf_table, 2) == 1.0);
+    REQUIRE(xsf::wilcoxon_sf(5.0, cdf_table, 2) == 0.0);
+
+    REQUIRE(xsf::wilcoxon_sf(2.9, cdf_table, 2) == xsf::wilcoxon_sf(2.0, cdf_table, 2));
+    REQUIRE(xsf::wilcoxon_sf(-0.5, cdf_table, 2) == xsf::wilcoxon_sf(0.0, cdf_table, 2));
+
+    REQUIRE(std::isnan(xsf::wilcoxon_sf(0.0, cdf_table, -1)));
+    REQUIRE(std::isnan(xsf::wilcoxon_sf(std::numeric_limits<double>::quiet_NaN(), cdf_table, 2)));
+}

--- a/tests/xsf_tests/test_wilcoxon.cpp
+++ b/tests/xsf_tests/test_wilcoxon.cpp
@@ -19,14 +19,14 @@ TEST_CASE("wilcoxon_cdf exact small cases", "[wilcoxon_cdf]") {
         REQUIRE(xsf::wilcoxon_cdf(0.0, cdf_table, 0) == 1.0);
     }
 
-    {   // n = 1
+    { // n = 1
         const std::vector<double> pmf = xsf::wilcoxon_pmf(1);
         const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
         REQUIRE(xsf::wilcoxon_cdf(0.0, cdf_table, 1) == 0.5);
         REQUIRE(xsf::wilcoxon_cdf(1.0, cdf_table, 1) == 1.0);
     }
 
-    {   // n = 2
+    { // n = 2
         const std::vector<double> pmf = xsf::wilcoxon_pmf(2);
         const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
         REQUIRE(xsf::wilcoxon_cdf(1.0, cdf_table, 2) == 0.5);
@@ -35,7 +35,7 @@ TEST_CASE("wilcoxon_cdf exact small cases", "[wilcoxon_cdf]") {
         REQUIRE(xsf::wilcoxon_cdf(4.0, cdf_table, 2) == 1.0);
     }
 
-    {   // n = 3
+    { // n = 3
         const std::vector<double> pmf = xsf::wilcoxon_pmf(3);
         const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
         REQUIRE(xsf::wilcoxon_cdf(3.0, cdf_table, 3) == 0.625);
@@ -45,7 +45,7 @@ TEST_CASE("wilcoxon_cdf exact small cases", "[wilcoxon_cdf]") {
         REQUIRE(xsf::wilcoxon_cdf(7.0, cdf_table, 3) == 1.0);
     }
 
-    {   // n = 5
+    { // n = 5
         const std::vector<double> pmf = xsf::wilcoxon_pmf(5);
         const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
         REQUIRE(xsf::wilcoxon_cdf(5.0, cdf_table, 5) == 0.3125);
@@ -78,7 +78,7 @@ TEST_CASE("wilcoxon_sf exact small cases", "[wilcoxon_sf]") {
         REQUIRE(xsf::wilcoxon_sf(1.0, cdf_table, 0) == 0.0);
     }
 
-    {   // n = 1
+    { // n = 1
         const std::vector<double> pmf = xsf::wilcoxon_pmf(1);
         const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
         REQUIRE(xsf::wilcoxon_sf(0.0, cdf_table, 1) == 1.0);
@@ -86,7 +86,7 @@ TEST_CASE("wilcoxon_sf exact small cases", "[wilcoxon_sf]") {
         REQUIRE(xsf::wilcoxon_sf(2.0, cdf_table, 1) == 0.0);
     }
 
-    {   // n = 2
+    { // n = 2
         const std::vector<double> pmf = xsf::wilcoxon_pmf(2);
         const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
         REQUIRE(xsf::wilcoxon_sf(0.0, cdf_table, 2) == 1.0);
@@ -96,7 +96,7 @@ TEST_CASE("wilcoxon_sf exact small cases", "[wilcoxon_sf]") {
         REQUIRE(xsf::wilcoxon_sf(4.0, cdf_table, 2) == 0.0);
     }
 
-    {   // n = 3
+    { // n = 3
         const std::vector<double> pmf = xsf::wilcoxon_pmf(3);
         const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
         REQUIRE(xsf::wilcoxon_sf(3.0, cdf_table, 3) == 0.625);
@@ -106,7 +106,7 @@ TEST_CASE("wilcoxon_sf exact small cases", "[wilcoxon_sf]") {
         REQUIRE(xsf::wilcoxon_sf(7.0, cdf_table, 3) == 0.0);
     }
 
-    {   // n = 5
+    { // n = 5
         const std::vector<double> pmf = xsf::wilcoxon_pmf(5);
         const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
         REQUIRE(xsf::wilcoxon_sf(5.0, cdf_table, 5) == 0.78125);

--- a/tests/xsf_tests/test_wilcoxon.cpp
+++ b/tests/xsf_tests/test_wilcoxon.cpp
@@ -1,5 +1,24 @@
 #include "../testing_utils.h"
 #include <xsf/stats.h>
+#include <xsf/third_party/kokkos/mdspan.hpp>
+
+namespace {
+
+std::vector<double> wilcoxon_pmf_table(int n) {
+    std::vector<double> table(n * (n + 1) / 2 + 1, 0.0);
+    std::mdspan table_span(table.data(), table.size());
+    xsf::wilcoxon_pmf_all(n, table_span);
+    return table;
+}
+
+std::vector<double> wilcoxon_cdf_table(int n) {
+    std::vector<double> table(n * (n + 1) / 2 + 1, 0.0);
+    std::mdspan table_span(table.data(), table.size());
+    xsf::wilcoxon_cdf_all(n, table_span);
+    return table;
+}
+
+} // namespace
 
 // Values computed from scipy.stats._wilcoxon
 //
@@ -14,119 +33,141 @@
 TEST_CASE("wilcoxon_cdf exact small cases", "[wilcoxon_cdf]") {
     {
         // n = 0
-        const std::vector<double> pmf = xsf::wilcoxon_pmf(0);
-        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
-        REQUIRE(xsf::wilcoxon_cdf(0.0, cdf_table, 0) == 1.0);
+        std::vector<double> cdf_table = wilcoxon_cdf_table(0);
+        std::mdspan cdf_span(cdf_table.data(), cdf_table.size());
+        REQUIRE(xsf::wilcoxon_cdf(0.0, cdf_span) == 1.0);
     }
 
     { // n = 1
-        const std::vector<double> pmf = xsf::wilcoxon_pmf(1);
-        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
-        REQUIRE(xsf::wilcoxon_cdf(0.0, cdf_table, 1) == 0.5);
-        REQUIRE(xsf::wilcoxon_cdf(1.0, cdf_table, 1) == 1.0);
+        std::vector<double> cdf_table = wilcoxon_cdf_table(1);
+        std::mdspan cdf_span(cdf_table.data(), cdf_table.size());
+        REQUIRE(xsf::wilcoxon_cdf(0.0, cdf_span) == 0.5);
+        REQUIRE(xsf::wilcoxon_cdf(1.0, cdf_span) == 1.0);
     }
 
     { // n = 2
-        const std::vector<double> pmf = xsf::wilcoxon_pmf(2);
-        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
-        REQUIRE(xsf::wilcoxon_cdf(1.0, cdf_table, 2) == 0.5);
-        REQUIRE(xsf::wilcoxon_cdf(2.0, cdf_table, 2) == 0.75);
-        REQUIRE(xsf::wilcoxon_cdf(3.0, cdf_table, 2) == 1.0);
-        REQUIRE(xsf::wilcoxon_cdf(4.0, cdf_table, 2) == 1.0);
+        std::vector<double> cdf_table = wilcoxon_cdf_table(2);
+        std::mdspan cdf_span(cdf_table.data(), cdf_table.size());
+        REQUIRE(xsf::wilcoxon_cdf(1.0, cdf_span) == 0.5);
+        REQUIRE(xsf::wilcoxon_cdf(2.0, cdf_span) == 0.75);
+        REQUIRE(xsf::wilcoxon_cdf(3.0, cdf_span) == 1.0);
+        REQUIRE(xsf::wilcoxon_cdf(4.0, cdf_span) == 1.0);
     }
 
     { // n = 3
-        const std::vector<double> pmf = xsf::wilcoxon_pmf(3);
-        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
-        REQUIRE(xsf::wilcoxon_cdf(3.0, cdf_table, 3) == 0.625);
-        REQUIRE(xsf::wilcoxon_cdf(4.0, cdf_table, 3) == 0.75);
-        REQUIRE(xsf::wilcoxon_cdf(5.0, cdf_table, 3) == 0.875);
-        REQUIRE(xsf::wilcoxon_cdf(6.0, cdf_table, 3) == 1.0);
-        REQUIRE(xsf::wilcoxon_cdf(7.0, cdf_table, 3) == 1.0);
+        std::vector<double> cdf_table = wilcoxon_cdf_table(3);
+        std::mdspan cdf_span(cdf_table.data(), cdf_table.size());
+        REQUIRE(xsf::wilcoxon_cdf(3.0, cdf_span) == 0.625);
+        REQUIRE(xsf::wilcoxon_cdf(4.0, cdf_span) == 0.75);
+        REQUIRE(xsf::wilcoxon_cdf(5.0, cdf_span) == 0.875);
+        REQUIRE(xsf::wilcoxon_cdf(6.0, cdf_span) == 1.0);
+        REQUIRE(xsf::wilcoxon_cdf(7.0, cdf_span) == 1.0);
     }
 
     { // n = 5
-        const std::vector<double> pmf = xsf::wilcoxon_pmf(5);
-        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
-        REQUIRE(xsf::wilcoxon_cdf(5.0, cdf_table, 5) == 0.3125);
-        REQUIRE(xsf::wilcoxon_cdf(6.0, cdf_table, 5) == 0.40625);
-        REQUIRE(xsf::wilcoxon_cdf(7.0, cdf_table, 5) == 0.5);
-        REQUIRE(xsf::wilcoxon_cdf(8.0, cdf_table, 5) == 0.59375);
-        REQUIRE(xsf::wilcoxon_cdf(9.0, cdf_table, 5) == 0.6875);
+        std::vector<double> cdf_table = wilcoxon_cdf_table(5);
+        std::mdspan cdf_span(cdf_table.data(), cdf_table.size());
+        REQUIRE(xsf::wilcoxon_cdf(5.0, cdf_span) == 0.3125);
+        REQUIRE(xsf::wilcoxon_cdf(6.0, cdf_span) == 0.40625);
+        REQUIRE(xsf::wilcoxon_cdf(7.0, cdf_span) == 0.5);
+        REQUIRE(xsf::wilcoxon_cdf(8.0, cdf_span) == 0.59375);
+        REQUIRE(xsf::wilcoxon_cdf(9.0, cdf_span) == 0.6875);
     }
 }
 
 TEST_CASE("wilcoxon_cdf edge cases", "[wilcoxon_cdf]") {
-    const std::vector<double> pmf = xsf::wilcoxon_pmf(2);
-    const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
+    std::vector<double> cdf_table = wilcoxon_cdf_table(2);
+    std::mdspan cdf_span(cdf_table.data(), cdf_table.size());
 
-    REQUIRE(xsf::wilcoxon_cdf(4.0, cdf_table, 2) == 1.0);
+    REQUIRE(xsf::wilcoxon_cdf(4.0, cdf_span) == 1.0);
 
-    REQUIRE(xsf::wilcoxon_cdf(1.9, cdf_table, 2) == xsf::wilcoxon_cdf(1.0, cdf_table, 2));
-    REQUIRE(xsf::wilcoxon_cdf(-0.5, cdf_table, 2) == xsf::wilcoxon_cdf(0.0, cdf_table, 2));
+    REQUIRE(xsf::wilcoxon_cdf(1.9, cdf_span) == xsf::wilcoxon_cdf(1.0, cdf_span));
+    REQUIRE(xsf::wilcoxon_cdf(-0.5, cdf_span) == xsf::wilcoxon_cdf(0.0, cdf_span));
 
-    REQUIRE(std::isnan(xsf::wilcoxon_cdf(0.0, cdf_table, -1)));
-    REQUIRE(std::isnan(xsf::wilcoxon_cdf(std::numeric_limits<double>::quiet_NaN(), cdf_table, 2)));
+    REQUIRE(std::isnan(xsf::wilcoxon_cdf(std::numeric_limits<double>::quiet_NaN(), cdf_span)));
 }
 
 TEST_CASE("wilcoxon_sf exact small cases", "[wilcoxon_sf]") {
     {
         // n = 0
-        const std::vector<double> pmf = xsf::wilcoxon_pmf(0);
-        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
-        REQUIRE(xsf::wilcoxon_sf(0.0, cdf_table, 0) == 1.0);
-        REQUIRE(xsf::wilcoxon_sf(1.0, cdf_table, 0) == 0.0);
+        std::vector<double> cdf_table = wilcoxon_cdf_table(0);
+        std::mdspan cdf_span(cdf_table.data(), cdf_table.size());
+        REQUIRE(xsf::wilcoxon_sf(0.0, cdf_span) == 1.0);
+        REQUIRE(xsf::wilcoxon_sf(1.0, cdf_span) == 0.0);
     }
 
     { // n = 1
-        const std::vector<double> pmf = xsf::wilcoxon_pmf(1);
-        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
-        REQUIRE(xsf::wilcoxon_sf(0.0, cdf_table, 1) == 1.0);
-        REQUIRE(xsf::wilcoxon_sf(1.0, cdf_table, 1) == 0.5);
-        REQUIRE(xsf::wilcoxon_sf(2.0, cdf_table, 1) == 0.0);
+        std::vector<double> cdf_table = wilcoxon_cdf_table(1);
+        std::mdspan cdf_span(cdf_table.data(), cdf_table.size());
+        REQUIRE(xsf::wilcoxon_sf(0.0, cdf_span) == 1.0);
+        REQUIRE(xsf::wilcoxon_sf(1.0, cdf_span) == 0.5);
+        REQUIRE(xsf::wilcoxon_sf(2.0, cdf_span) == 0.0);
     }
 
     { // n = 2
-        const std::vector<double> pmf = xsf::wilcoxon_pmf(2);
-        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
-        REQUIRE(xsf::wilcoxon_sf(0.0, cdf_table, 2) == 1.0);
-        REQUIRE(xsf::wilcoxon_sf(1.0, cdf_table, 2) == 0.75);
-        REQUIRE(xsf::wilcoxon_sf(2.0, cdf_table, 2) == 0.5);
-        REQUIRE(xsf::wilcoxon_sf(3.0, cdf_table, 2) == 0.25);
-        REQUIRE(xsf::wilcoxon_sf(4.0, cdf_table, 2) == 0.0);
+        std::vector<double> cdf_table = wilcoxon_cdf_table(2);
+        std::mdspan cdf_span(cdf_table.data(), cdf_table.size());
+        REQUIRE(xsf::wilcoxon_sf(0.0, cdf_span) == 1.0);
+        REQUIRE(xsf::wilcoxon_sf(1.0, cdf_span) == 0.75);
+        REQUIRE(xsf::wilcoxon_sf(2.0, cdf_span) == 0.5);
+        REQUIRE(xsf::wilcoxon_sf(3.0, cdf_span) == 0.25);
+        REQUIRE(xsf::wilcoxon_sf(4.0, cdf_span) == 0.0);
     }
 
     { // n = 3
-        const std::vector<double> pmf = xsf::wilcoxon_pmf(3);
-        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
-        REQUIRE(xsf::wilcoxon_sf(3.0, cdf_table, 3) == 0.625);
-        REQUIRE(xsf::wilcoxon_sf(4.0, cdf_table, 3) == 0.375);
-        REQUIRE(xsf::wilcoxon_sf(5.0, cdf_table, 3) == 0.25);
-        REQUIRE(xsf::wilcoxon_sf(6.0, cdf_table, 3) == 0.125);
-        REQUIRE(xsf::wilcoxon_sf(7.0, cdf_table, 3) == 0.0);
+        std::vector<double> cdf_table = wilcoxon_cdf_table(3);
+        std::mdspan cdf_span(cdf_table.data(), cdf_table.size());
+        REQUIRE(xsf::wilcoxon_sf(3.0, cdf_span) == 0.625);
+        REQUIRE(xsf::wilcoxon_sf(4.0, cdf_span) == 0.375);
+        REQUIRE(xsf::wilcoxon_sf(5.0, cdf_span) == 0.25);
+        REQUIRE(xsf::wilcoxon_sf(6.0, cdf_span) == 0.125);
+        REQUIRE(xsf::wilcoxon_sf(7.0, cdf_span) == 0.0);
     }
 
     { // n = 5
-        const std::vector<double> pmf = xsf::wilcoxon_pmf(5);
-        const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
-        REQUIRE(xsf::wilcoxon_sf(5.0, cdf_table, 5) == 0.78125);
-        REQUIRE(xsf::wilcoxon_sf(6.0, cdf_table, 5) == 0.6875);
-        REQUIRE(xsf::wilcoxon_sf(7.0, cdf_table, 5) == 0.59375);
-        REQUIRE(xsf::wilcoxon_sf(8.0, cdf_table, 5) == 0.5);
-        REQUIRE(xsf::wilcoxon_sf(9.0, cdf_table, 5) == 0.40625);
+        std::vector<double> cdf_table = wilcoxon_cdf_table(5);
+        std::mdspan cdf_span(cdf_table.data(), cdf_table.size());
+        REQUIRE(xsf::wilcoxon_sf(5.0, cdf_span) == 0.78125);
+        REQUIRE(xsf::wilcoxon_sf(6.0, cdf_span) == 0.6875);
+        REQUIRE(xsf::wilcoxon_sf(7.0, cdf_span) == 0.59375);
+        REQUIRE(xsf::wilcoxon_sf(8.0, cdf_span) == 0.5);
+        REQUIRE(xsf::wilcoxon_sf(9.0, cdf_span) == 0.40625);
     }
 }
 
 TEST_CASE("wilcoxon_sf edge cases", "[wilcoxon_sf]") {
-    const std::vector<double> pmf = xsf::wilcoxon_pmf(2);
-    const std::vector<double> cdf_table = xsf::wilcoxon_cdf_table(pmf);
+    std::vector<double> cdf_table = wilcoxon_cdf_table(2);
+    std::mdspan cdf_span(cdf_table.data(), cdf_table.size());
 
-    REQUIRE(xsf::wilcoxon_sf(-1.0, cdf_table, 2) == 1.0);
-    REQUIRE(xsf::wilcoxon_sf(5.0, cdf_table, 2) == 0.0);
+    REQUIRE(xsf::wilcoxon_sf(-1.0, cdf_span) == 1.0);
+    REQUIRE(xsf::wilcoxon_sf(5.0, cdf_span) == 0.0);
 
-    REQUIRE(xsf::wilcoxon_sf(2.9, cdf_table, 2) == xsf::wilcoxon_sf(2.0, cdf_table, 2));
-    REQUIRE(xsf::wilcoxon_sf(-0.5, cdf_table, 2) == xsf::wilcoxon_sf(0.0, cdf_table, 2));
+    REQUIRE(xsf::wilcoxon_sf(2.9, cdf_span) == xsf::wilcoxon_sf(2.0, cdf_span));
+    REQUIRE(xsf::wilcoxon_sf(-0.5, cdf_span) == xsf::wilcoxon_sf(0.0, cdf_span));
 
-    REQUIRE(std::isnan(xsf::wilcoxon_sf(0.0, cdf_table, -1)));
-    REQUIRE(std::isnan(xsf::wilcoxon_sf(std::numeric_limits<double>::quiet_NaN(), cdf_table, 2)));
+    REQUIRE(std::isnan(xsf::wilcoxon_sf(std::numeric_limits<double>::quiet_NaN(), cdf_span)));
+}
+
+TEST_CASE("wilcoxon_pmf_all exact small cases", "[wilcoxon_pmf]") {
+    REQUIRE(wilcoxon_pmf_table(0) == std::vector<double>{1.0});
+    REQUIRE(wilcoxon_pmf_table(1) == std::vector<double>{0.5, 0.5});
+    REQUIRE(wilcoxon_pmf_table(2) == std::vector<double>{0.25, 0.25, 0.25, 0.25});
+    REQUIRE(wilcoxon_pmf_table(3) == std::vector<double>{0.125, 0.125, 0.125, 0.25, 0.125, 0.125, 0.125});
+    REQUIRE(
+        wilcoxon_pmf_table(5) == std::vector<double>{
+                                     0.03125, 0.03125, 0.03125, 0.0625, 0.0625, 0.09375, 0.09375, 0.09375, 0.09375,
+                                     0.09375, 0.09375, 0.0625, 0.0625, 0.03125, 0.03125, 0.03125
+                                 }
+    );
+
+    std::vector<double> pmf_table = wilcoxon_pmf_table(3);
+    std::mdspan pmf_span(pmf_table.data(), pmf_table.size());
+    REQUIRE(xsf::wilcoxon_pmf(3.0, pmf_span) == 0.25);
+    REQUIRE(xsf::wilcoxon_pmf(-1.0, pmf_span) == 0.0);
+    REQUIRE(xsf::wilcoxon_pmf(7.0, pmf_span) == 0.0);
+    REQUIRE(std::isnan(xsf::wilcoxon_pmf(std::numeric_limits<double>::quiet_NaN(), pmf_span)));
+}
+
+TEST_CASE("wilcoxon_cdf_all exact small cases", "[wilcoxon_cdf]") {
+    REQUIRE(wilcoxon_cdf_table(3) == std::vector<double>{0.125, 0.25, 0.375, 0.625, 0.75, 0.875, 1.0});
 }

--- a/tests/xsf_tests/test_wilcoxon.cpp
+++ b/tests/xsf_tests/test_wilcoxon.cpp
@@ -153,12 +153,9 @@ TEST_CASE("wilcoxon_pmf_all exact small cases", "[wilcoxon_pmf]") {
     REQUIRE(wilcoxon_pmf_table(1) == std::vector<double>{0.5, 0.5});
     REQUIRE(wilcoxon_pmf_table(2) == std::vector<double>{0.25, 0.25, 0.25, 0.25});
     REQUIRE(wilcoxon_pmf_table(3) == std::vector<double>{0.125, 0.125, 0.125, 0.25, 0.125, 0.125, 0.125});
-    REQUIRE(
-        wilcoxon_pmf_table(5) == std::vector<double>{
-                                     0.03125, 0.03125, 0.03125, 0.0625, 0.0625, 0.09375, 0.09375, 0.09375, 0.09375,
-                                     0.09375, 0.09375, 0.0625, 0.0625, 0.03125, 0.03125, 0.03125
-                                 }
-    );
+    const std::vector<double> expected_n5 = {0.03125, 0.03125, 0.03125, 0.0625, 0.0625, 0.09375, 0.09375, 0.09375,
+                                             0.09375, 0.09375, 0.09375, 0.0625, 0.0625, 0.03125, 0.03125, 0.03125};
+    REQUIRE(wilcoxon_pmf_table(5) == expected_n5);
 
     std::vector<double> pmf_table = wilcoxon_pmf_table(3);
     std::mdspan pmf_span(pmf_table.data(), pmf_table.size());


### PR DESCRIPTION
### Reference issue

Toward https://github.com/scipy/xsf/issues/98

### What does this implement/fix?

- Implement the CDF and SF of the Wilcoxon signed-rank distribution.
- Port the exact distribution logic from [scipy.stats._wilcoxon.py](https://github.com/scipy/scipy/blob/a4463edad21e858fb7556b4fd121463da8da2e33/scipy/stats/_wilcoxon.py#L13)
- Precompute a CDF table from the PMF so repeated CDF/SF queries for a given `n` are efficient.