### PR TITLE
ENH: add `nrdtrimn`

### DIFF
--- a/include/xsf/ndtri_reparametrizations.h
+++ b/include/xsf/ndtri_reparametrizations.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cmath>
+#include <limits>
+
+#include "xsf/cephes/ndtri.h"
+
+namespace xsf {
+namespace detail {
+
+    // Returns the mean of a normal distribution with standard deviation std
+    // such that the CDF at x equals p.
+    inline double nrdtrimn(double p, double std, double x) {
+        if (std::isnan(std) || std <= 0) {
+            return std::numeric_limits<double>::quiet_NaN();
+        }
+        if (std::isnan(p) || p <= 0 || p >= 1) {
+            return std::numeric_limits<double>::quiet_NaN();
+        }
+        if (std::isnan(x)) {
+            return std::numeric_limits<double>::quiet_NaN();
+        }
+        return x - std * cephes::ndtri(p);
+    }
+
+} // namespace detail
+
+inline double nrdtrimn(double p, double std, double x) { return detail::nrdtrimn(p, std, x); }
+
+inline float nrdtrimn(float p, float std, float x) {
+    return static_cast<float>(detail::nrdtrimn(static_cast<double>(p), static_cast<double>(std), static_cast<double>(x))
+    );
+}
+
+} // namespace xsf

--- a/tests/xsf_tests/test_ndtri_reparametrizations.cpp
+++ b/tests/xsf_tests/test_ndtri_reparametrizations.cpp
@@ -1,0 +1,42 @@
+#include "../testing_utils.h"
+#include <xsf/ndtri_reparametrizations.h>
+
+#include <cmath>
+#include <limits>
+
+TEST_CASE("nrdtrimn basic", "[nrdtrimn][xsf_tests]") {
+    // Test from the scipy docs example: mean=3, std=2, x=6 => p=ndtr((6-3)/2)
+    // Run for both double and float precision.
+    const double mean = 3.0;
+    const double std = 2.0;
+    const double x = 6.0;
+    const double p = 0.9331927987311419;
+
+    {
+        const double rtol = 100 * std::numeric_limits<double>::epsilon();
+        const auto result = xsf::nrdtrimn(p, std, x);
+        const auto relative_error = xsf::extended_relative_error(result, mean);
+        CAPTURE(p, std, x, result, mean, rtol, relative_error);
+        REQUIRE(relative_error <= rtol);
+    }
+
+    {
+        const float rtol = 100 * std::numeric_limits<float>::epsilon();
+        const auto result = xsf::nrdtrimn(static_cast<float>(p), static_cast<float>(std), static_cast<float>(x));
+        const auto relative_error = static_cast<float>(xsf::extended_relative_error(result, static_cast<float>(mean)));
+        CAPTURE(p, std, x, result, mean, rtol, relative_error);
+        REQUIRE(relative_error <= rtol);
+    }
+}
+
+TEST_CASE("nrdtrimn NaN inputs", "[nrdtrimn][xsf_tests]") {
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+
+    REQUIRE(std::isnan(xsf::nrdtrimn(nan, 1.0, 0.0)));  // NaN p
+    REQUIRE(std::isnan(xsf::nrdtrimn(0.5, nan, 0.0)));  // NaN std
+    REQUIRE(std::isnan(xsf::nrdtrimn(0.5, 1.0, nan)));  // NaN x
+    REQUIRE(std::isnan(xsf::nrdtrimn(0.5, 0.0, 0.0)));  // std == 0
+    REQUIRE(std::isnan(xsf::nrdtrimn(0.5, -1.0, 0.0))); // std < 0
+    REQUIRE(std::isnan(xsf::nrdtrimn(0.0, 1.0, 0.0)));  // p == 0
+    REQUIRE(std::isnan(xsf::nrdtrimn(1.0, 1.0, 0.0)));  // p == 1
+}


### PR DESCRIPTION
Towards #127 

This PR adds the function `nrdtrimn` abd is also very much educational to familiarize myself with the xsf repo. About this: as a non seasoned C++ coder I found the developer experience actually pretty great. Compiling xsf is simpler than SciPy thanks to the Pixi setup (hat tip @lucascolley @steppi ). One nit is that I currently do not understand how to run only one test, maybe add this to the README?

I added only one test with real values as `ndtri` is likely tested a lot harder already.

Note that the edge case handling was simply copied over from SciPy which mostly preserved backwards compatibility to the ancient cdflib. I am not sure if `ndtri` is currently GPU capable and GPU tested so I did not add the appropriate macros.

