### PR TITLE
Fix j0 for large arguments

### DIFF
--- a/include/xsf/cephes/j0.h
+++ b/include/xsf/cephes/j0.h
@@ -160,7 +160,7 @@ namespace cephes {
     } // namespace detail
 
     XSF_HOST_DEVICE inline double j0(double x) {
-        double w, z, p, q, xn;
+        double w, z, p, q;
 
         if (x < 0) {
             x = -x;
@@ -181,9 +181,8 @@ namespace cephes {
         q = 25.0 / (x * x);
         p = polevl(q, detail::j0_PP, 6) / polevl(q, detail::j0_PQ, 6);
         q = polevl(q, detail::j0_QP, 7) / p1evl(q, detail::j0_QQ, 7);
-        xn = x - M_PI_4;
-        p = p * std::cos(xn) - w * q * std::sin(xn);
-        return (p * detail::SQRT2OPI / std::sqrt(x));
+        p = (p + w * q) * std::cos(x) + (p - w * q) * std::sin(x);
+        return (p * detail::SQRT1OPI / std::sqrt(x));
     }
 
     /*                                                     y0() 2  */

--- a/include/xsf/cephes/j0.h
+++ b/include/xsf/cephes/j0.h
@@ -181,6 +181,11 @@ namespace cephes {
         q = 25.0 / (x * x);
         p = polevl(q, detail::j0_PP, 6) / polevl(q, detail::j0_PQ, 6);
         q = polevl(q, detail::j0_QP, 7) / p1evl(q, detail::j0_QQ, 7);
+        if (x < 10.0) {
+            double xn = x - M_PI_4;
+            p = p * std::cos(xn) - w * q * std::sin(xn);
+            return (p * detail::SQRT2OPI / std::sqrt(x));
+        }
         p = (p + w * q) * std::cos(x) + (p - w * q) * std::sin(x);
         return (p * detail::SQRT1OPI / std::sqrt(x));
     }

--- a/tests/xsf_tests/test_j0_right_tail.cpp
+++ b/tests/xsf_tests/test_j0_right_tail.cpp
@@ -1,0 +1,15 @@
+#include "../testing_utils.h"
+#include <xsf/cephes/j0.h>
+
+TEST_CASE("j0 right tail gh-large-input", "[j0][xsf_tests]") {
+    // Reference value computed with mpmath: mp.besselj(0, 1e15)
+    const double x = 1e15;
+    const double ref = 6.156638646885021e-09;
+    const double rtol = 1e-13;
+
+    const double w = xsf::cephes::j0(x);
+    const double rel_error = xsf::extended_relative_error(w, ref);
+
+    CAPTURE(x, w, ref, rtol, rel_error);
+    REQUIRE(rel_error <= rtol);
+}

--- a/tests/xsf_tests/test_j0_right_tail.cpp
+++ b/tests/xsf_tests/test_j0_right_tail.cpp
@@ -2,14 +2,16 @@
 #include <xsf/cephes/j0.h>
 
 TEST_CASE("j0 right tail gh-large-input", "[j0][xsf_tests]") {
-    // Reference value computed with mpmath: mp.besselj(0, 1e15)
-    const double x = 1e15;
-    const double ref = 6.156638646885021e-09;
-    const double rtol = 1e-13;
-
+    using test_case = std::tuple<double, double>;
+    // Reference values computed with mpmath with 1000 digts of precision
+    auto [x, ref] = GENERATE(
+        test_case{1e15, 6.156638646885021e-09}, test_case{1e12, 1.0167125050040682e-07},
+        test_case{1e13, 1.1926484739665653e-07}, test_case{1e8, 3.206029534041208e-05},
+        test_case{1e20, 6.698009040703424e-12}
+    );
     const double w = xsf::cephes::j0(x);
     const double rel_error = xsf::extended_relative_error(w, ref);
 
-    CAPTURE(x, w, ref, rtol, rel_error);
-    REQUIRE(rel_error <= rtol);
+    CAPTURE(x, w, ref, rel_error);
+    REQUIRE(rel_error <= 1e-15);
 }

--- a/tests/xsf_tests/test_j0_right_tail.cpp
+++ b/tests/xsf_tests/test_j0_right_tail.cpp
@@ -3,15 +3,27 @@
 
 TEST_CASE("j0 right tail gh-large-input", "[j0][xsf_tests]") {
     using test_case = std::tuple<double, double>;
-    // Reference values computed with mpmath with 1000 digts of precision
-    auto [x, ref] = GENERATE(
-        test_case{1e15, 6.156638646885021e-09}, test_case{1e12, 1.0167125050040682e-07},
-        test_case{1e13, 1.1926484739665653e-07}, test_case{1e8, 3.206029534041208e-05},
-        test_case{1e20, 6.698009040703424e-12}
+    // Reference values computed with mpmath with 1000 digits of precision:
+    //
+    // import math
+    // import mpmath as mp
+    // mp.mp.dps = 1000
+    // xs = [
+    //     math.nextafter(10.0, 0.0), 10.0, math.nextafter(10.0, math.inf),
+    //     100.0, 1e4, 1e8, 1e12, 1e13, 1e15, 1e20,
+    // ]
+    // for x in xs:
+    //     print(x, mp.nstr(mp.besselj(0, x), 18))
+    auto [x, ref, rtol] = GENERATE(
+        test_case{9.999999999999998, -0.24593576445134826, 5e-15}, test_case{10.0, -0.24593576445134834, 5e-15},
+        test_case{10.000000000000002, -0.24593576445134841, 5e-15}, test_case{100.0, 0.019985850304223122, 5e-15},
+        test_case{1e4, -0.0070961603533888015, 5e-15}, test_case{1e8, 3.206029534041208e-05, 1e-15},
+        test_case{1e12, 1.0167125050040682e-07, 1e-15}, test_case{1e13, 1.1926484739665653e-07, 1e-15},
+        test_case{1e15, 6.156638646885021e-09, 1e-15}, test_case{1e20, 6.698009040703424e-12, 2e-15}
     );
     const double w = xsf::cephes::j0(x);
     const double rel_error = xsf::extended_relative_error(w, ref);
 
-    CAPTURE(x, w, ref, rel_error);
-    REQUIRE(rel_error <= 1e-15);
+    CAPTURE(x, w, ref, rtol, rel_error);
+    REQUIRE(rel_error <= rtol);
 }

--- a/tests/xsf_tests/test_j0_right_tail.cpp
+++ b/tests/xsf_tests/test_j0_right_tail.cpp
@@ -2,7 +2,7 @@
 #include <xsf/cephes/j0.h>
 
 TEST_CASE("j0 right tail gh-large-input", "[j0][xsf_tests]") {
-    using test_case = std::tuple<double, double>;
+    using test_case = std::tuple<double, double, double>;
     // Reference values computed with mpmath with 1000 digits of precision:
     //
     // import math


### PR DESCRIPTION
Motivated by https://github.com/scipy/scipy/issues/22705 over at SciPy.

The fix is directly taken from @pearu 's suggestion: rewriting 
`sqrt(2 / (pi * x)) * cos(x - pi/4) = sqrt(1 / (pi * x)) * (cos(x) + sin(x))`.

The same fix can be applied to `y0` in a followup.

