### PR TITLE
MAINT: ensure sindg/tandg/sinpi return -0 for input -0

### DIFF
--- a/include/xsf/cephes/sindg.h
+++ b/include/xsf/cephes/sindg.h
@@ -108,7 +108,7 @@ namespace cephes {
 
         /* make argument positive but save the sign */
         sign = 1;
-        if (x < 0) {
+        if (std::signbit(x)) {
             x = -x;
             sign = -1;
         }

--- a/include/xsf/cephes/tandg.h
+++ b/include/xsf/cephes/tandg.h
@@ -118,7 +118,7 @@ namespace cephes {
                 }
             }
             if (x == 0.0) {
-                return 0.0;
+                return sign * 0.0;
             } else if (x == 45.0) {
                 return sign * 1.0;
             } else if (x == 90.0) {

--- a/include/xsf/cephes/tandg.h
+++ b/include/xsf/cephes/tandg.h
@@ -89,7 +89,7 @@ namespace cephes {
             int sign;
 
             /* make argument positive but save the sign */
-            if (xx < 0) {
+            if (std::signbit(xx)) {
                 x = -xx;
                 sign = -1;
             } else {

--- a/include/xsf/cephes/trig.h
+++ b/include/xsf/cephes/trig.h
@@ -21,7 +21,7 @@ namespace cephes {
     XSF_HOST_DEVICE T sinpi(T x) {
         T s = 1.0;
 
-        if (x < 0.0) {
+        if (std::signbit(x)) {
             x = -x;
             s = -1.0;
         }

--- a/tests/xsf_tests/test_trig.cpp
+++ b/tests/xsf_tests/test_trig.cpp
@@ -1,0 +1,19 @@
+#include "../testing_utils.h"
+#include <cmath>
+#include <xsf/trig.h>
+
+void check_zeros(double (*f)(double)) {
+    std::vector<double> zeros{-0.0, 0.0};
+    for (double x : zeros) {
+        double result = f(x);
+        CAPTURE(x, result);
+        REQUIRE(std::signbit(result) == std::signbit(x));
+        REQUIRE(result == 0.0);
+    }
+}
+
+TEST_CASE("sindg IEEE scipy/20731", "[sindg][xsf_tests]") { check_zeros(&xsf::sindg); }
+
+TEST_CASE("sinpi IEEE scipy/20731", "[sinpi][xsf_tests]") { check_zeros(&xsf::sinpi); }
+
+TEST_CASE("tandg IEEE scipy/20731", "[tandg][xsf_tests]") { check_zeros(&xsf::tandg); }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Towards https://github.com/scipy/scipy/issues/20731
#### What does this implement/fix?
<!--Please explain your changes.-->
Ensure sindg/tandg/sinpi follow the IEEE standard by returning -0 for -0 inputs.
<img width="1087" height="66" alt="image" src="https://github.com/user-attachments/assets/dba84c05-0f71-4534-baa1-2990ddb45189" />

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I used chatgpt to understand how the test framework works