### PR TITLE
ENH: Fix y0 for large values

### DIFF
--- a/include/xsf/cephes/j0.h
+++ b/include/xsf/cephes/j0.h
@@ -200,7 +200,7 @@ namespace cephes {
      */
 
     XSF_HOST_DEVICE inline double y0(double x) {
-        double w, z, p, q, xn;
+        double w, z, p, q;
 
         if (x <= 5.0) {
             if (x == 0.0) {
@@ -220,9 +220,13 @@ namespace cephes {
         z = 25.0 / (x * x);
         p = polevl(z, detail::j0_PP, 6) / polevl(z, detail::j0_PQ, 6);
         q = polevl(z, detail::j0_QP, 7) / p1evl(z, detail::j0_QQ, 7);
-        xn = x - M_PI_4;
-        p = p * std::sin(xn) + w * q * std::cos(xn);
-        return (p * detail::SQRT2OPI / std::sqrt(x));
+        if (x < 10.0) {
+            double xn = x - M_PI_4;
+            p = p * std::sin(xn) + w * q * std::cos(xn);
+            return (p * detail::SQRT2OPI / std::sqrt(x));
+        }
+        p = (w * q - p) * std::cos(x) + (p + w * q) * std::sin(x);
+        return (p * detail::SQRT1OPI / std::sqrt(x));
     }
 
 } // namespace cephes

--- a/tests/xsf_tests/test_y0_right_tail.cpp
+++ b/tests/xsf_tests/test_y0_right_tail.cpp
@@ -1,0 +1,29 @@
+#include "../testing_utils.h"
+#include <xsf/cephes/j0.h>
+
+TEST_CASE("y0 right tail gh-large-input", "[y0][xsf_tests]") {
+    using test_case = std::tuple<double, double, double>;
+    // Reference values computed with mpmath with 1000 digits of precision:
+    //
+    // import math
+    // import mpmath as mp
+    // mp.mp.dps = 1000
+    // xs = [
+    //     math.nextafter(10.0, 0.0), 10.0, math.nextafter(10.0, math.inf),
+    //     100.0, 1e4, 1e8, 1e12, 1e13, 1e15, 1e20,
+    // ]
+    // for x in xs:
+    //     print(x, mp.nstr(mp.bessely(0, x), 18))
+    auto [x, ref, rtol] = GENERATE(
+        test_case{9.999999999999998, 0.055671167283599834, 5e-15}, test_case{10.0, 0.05567116728359939, 5e-15},
+        test_case{10.000000000000002, 0.05567116728359895, 5e-15}, test_case{100.0, -0.07724431336508315, 5e-15},
+        test_case{1e4, 0.003647805558986606, 5e-15}, test_case{1e8, 0.00007306391165521707, 1e-15},
+        test_case{1e12, -7.913802683850949e-7, 1e-15}, test_case{1e13, -2.2234629165383075e-7, 1e-15},
+        test_case{1e15, 2.4468665123771323e-8, 1e-15}, test_case{1e20, -7.95068198242545e-11, 2e-15}
+    );
+    const double w = xsf::cephes::y0(x);
+    const double rel_error = xsf::extended_relative_error(w, ref);
+
+    CAPTURE(x, w, ref, rtol, rel_error);
+    REQUIRE(rel_error <= rtol);
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
This is a follow-up of https://github.com/scipy/xsf/pull/131

#### What does this implement/fix?
Improve `y0` for large values

#### Additional information
Uses the same pattern as in https://github.com/scipy/xsf/pull/131

The existing tail for `y0` is $p  \sin(x - \pi/4) + w  q   \cos(x - \pi/4)$.
This PR uses the trigonometric relations:

$$
\sqrt{2}  \sin(x - \pi/4) = \sin(x) - \cos(x), \quad \sqrt{2}  \cos(x - \pi/4) = \sin(x) + \cos(x)
$$

Running the script 

<details>

```python
```python
import math
import mpmath as mp

mp.mp.dps = 100

# Cephes j0/y0 tail coefficients from include/xsf/cephes/j0.h
PP = [
    7.96936729297347051624e-4,
    8.28352392107440799803e-2,
    1.23953371646414299388e0,
    5.44725003058768775090e0,
    8.74716500199817011941e0,
    5.30324038235394892183e0,
    9.99999999999999997821e-1,
]
PQ = [
    9.24408810558863637013e-4,
    8.56288474354474431428e-2,
    1.25352743901058953537e0,
    5.47097740330417105182e0,
    8.76190883237069594232e0,
    5.30605288235394617618e0,
    1.00000000000000000218e0,
]
QP = [
    -1.13663838898469149931e-2,
    -1.28252718670509318512e0,
    -1.95539544257735972385e1,
    -9.32060152123768231369e1,
    -1.77681167980488050595e2,
    -1.47077505154951170175e2,
    -5.14105326766599330220e1,
    -6.05014350600728481186e0,
]
QQ = [
    6.43178256118178023184e1,
    8.56430025976980587198e2,
    3.88240183605401609683e3,
    7.24046774195652478189e3,
    5.93072701187316984827e3,
    2.06209331660327847417e3,
    2.42005740240291393179e2,
]


def polevl(x, c):
    r = 0.0
    for a in c:
        r = r * x + a
    return r


def p1evl(x, c):
    r = x + c[0]
    for a in c[1:]:
        r = r * x + a
    return r


def vals(x):
    w = 5.0 / x
    z = 25.0 / (x * x)
    p = polevl(z, PP) / polevl(z, PQ)
    q = polevl(z, QP) / p1evl(z, QQ)

    old = (
        (p * math.sin(x - math.pi / 4) + w * q * math.cos(x - math.pi / 4))
        * math.sqrt(2 / math.pi)
        / math.sqrt(x)
    )

    new = (
        ((w * q - p) * math.cos(x) + (p + w * q) * math.sin(x))
        * math.sqrt(1 / math.pi)
        / math.sqrt(x)
    )

    return old, new


def rel(y, r):
    return float(abs(mp.mpf(y) - r) / abs(r)) if r else float(abs(y))


for lo, hi, n in [
    (5, 10, 1000),
    (10, 100, 1000),
    (100, 1e3, 1000),
    (1e3, 1e4, 1000),
    (1e4, 1e5, 1000),
    (1e5, 1e6, 500),
    (1e6, 1e8, 300),
]:
    oldmax = newmax = 0.0
    oldwins = newwins = 0
    worst_old = worst_new = None

    for i in range(n):
        x = lo + (hi - lo) * (i + 0.5) / n
        r = mp.bessely(0, x)
        old, new = vals(x)
        eo = rel(old, r)
        en = rel(new, r)

        if eo < en:
            oldwins += 1
        elif en < eo:
            newwins += 1

        if eo > oldmax:
            oldmax = eo
            worst_old = x
        if en > newmax:
            newmax = en
            worst_new = x

    print(
        f"{lo:g}-{hi:g}: "
        f"oldmax {oldmax:.2e}@{worst_old:.6g} "
        f"newmax {newmax:.2e}@{worst_new:.6g} "
        f"oldwins {oldwins} newwins {newwins}"
    )
```
</details>

gives

```markdown
5-10: oldmax 1.81e-14@7.0875 newmax 4.82e-14@7.0875 oldwins 234 newwins 407
10-100: oldmax 2.14e-12@73.045 newmax 3.23e-14@38.485 oldwins 24 newwins 943
100-1000: oldmax 3.16e-11@761.05 newmax 7.64e-14@761.05 oldwins 5 newwins 989
1000-10000: oldmax 2.42e-10@8159.5 newmax 3.46e-14@4964.5 oldwins 0 newwins 1000
10000-100000: oldmax 1.02e-10@17245 newmax 1.11e-14@23635 oldwins 0 newwins 1000
100000-1e+06: oldmax 1.83e-08@408700 newmax 2.68e-14@408700 oldwins 1 newwins 499
1e+06-1e+08: oldmax 1.12e-06@8.6965e+07 newmax 1.36e-14@4.0435e+07 oldwins 0 newwins 300
```

suggesting that 10 remains a reasonable cutoff, see the [comment](https://github.com/scipy/xsf/pull/131#issuecomment-4391110255) for additional information.


#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I gave Codex the script I used for `j0` and asked it to update and follow the same pattern used for `y0`. Code is mine except it added the reference values I had locally.