### PR TITLE
BUG: Fix subtle bug in ufunc loops

### DIFF
--- a/include/xsf/numpy.h
+++ b/include/xsf/numpy.h
@@ -801,17 +801,19 @@ namespace numpy {
             map_dims_type map_dims = static_cast<ufunc_data<Func> *>(data)->map_dims;
             map_dims(dims + 1, new_dims.data());
 
+            char *local_args[sizeof...(Args) + 1];
+            for (npy_uintp j = 0; j <= sizeof...(Args); ++j) {
+                local_args[j] = args[j];
+            }
+
             Func func = static_cast<ufunc_data<Func> *>(data)->func;
             for (npy_intp i = 0; i < dims[0]; ++i) {
-                Res res = func(
-                    npy_traits<Args>::get(
-                        args[I], new_dims.data() + ranks_scan[I], steps + ranks_scan[I] + sizeof...(Args) + 1
-                    )...
-                );
-                npy_traits<Res>::set(args[sizeof...(Args)], res); // assign to the output pointer
-
+                Res res = func(npy_traits<Args>::get(
+                    local_args[I], new_dims.data() + ranks_scan[I], steps + ranks_scan[I] + sizeof...(Args) + 1
+                )...);
+                npy_traits<Res>::set(local_args[sizeof...(Args)], res); // assign to the output pointer
                 for (npy_uintp j = 0; j <= sizeof...(Args); ++j) {
-                    args[j] += steps[j];
+                    local_args[j] += steps[j];
                 }
             }
 
@@ -837,16 +839,18 @@ namespace numpy {
             map_dims_type map_dims = static_cast<ufunc_data<Func> *>(data)->map_dims;
             map_dims(dims + 1, new_dims.data());
 
+            char *local_args[sizeof...(Args)];
+            for (npy_uintp j = 0; j < sizeof...(Args); ++j) {
+                local_args[j] = args[j];
+            }
             Func func = static_cast<ufunc_data<Func> *>(data)->func;
             for (npy_intp i = 0; i < dims[0]; ++i) {
-                func(
-                    npy_traits<Args>::get(
-                        args[I], new_dims.data() + ranks_scan[I], steps + ranks_scan[I] + sizeof...(Args)
-                    )...
-                );
+                func(npy_traits<Args>::get(
+                    local_args[I], new_dims.data() + ranks_scan[I], steps + ranks_scan[I] + sizeof...(Args)
+                )...);
 
                 for (npy_uintp j = 0; j < sizeof...(Args); ++j) {
-                    args[j] += steps[j];
+                    local_args[j] += steps[j];
                 }
             }
 

--- a/include/xsf/numpy.h
+++ b/include/xsf/numpy.h
@@ -808,9 +808,11 @@ namespace numpy {
 
             Func func = static_cast<ufunc_data<Func> *>(data)->func;
             for (npy_intp i = 0; i < dims[0]; ++i) {
-                Res res = func(npy_traits<Args>::get(
-                    local_args[I], new_dims.data() + ranks_scan[I], steps + ranks_scan[I] + sizeof...(Args) + 1
-                )...);
+                Res res = func(
+                    npy_traits<Args>::get(
+                        local_args[I], new_dims.data() + ranks_scan[I], steps + ranks_scan[I] + sizeof...(Args) + 1
+                    )...
+                );
                 npy_traits<Res>::set(local_args[sizeof...(Args)], res); // assign to the output pointer
                 for (npy_uintp j = 0; j <= sizeof...(Args); ++j) {
                     local_args[j] += steps[j];
@@ -845,9 +847,11 @@ namespace numpy {
             }
             Func func = static_cast<ufunc_data<Func> *>(data)->func;
             for (npy_intp i = 0; i < dims[0]; ++i) {
-                func(npy_traits<Args>::get(
-                    local_args[I], new_dims.data() + ranks_scan[I], steps + ranks_scan[I] + sizeof...(Args)
-                )...);
+                func(
+                    npy_traits<Args>::get(
+                        local_args[I], new_dims.data() + ranks_scan[I], steps + ranks_scan[I] + sizeof...(Args)
+                    )...
+                );
 
                 for (npy_uintp j = 0; j < sizeof...(Args); ++j) {
                     local_args[j] += steps[j];


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
While working on the SciPy companion to #144, I wrote extensive tests which unearthed a bug in the ufunc infrastructure in `xsf::numpy`. The following stripped down version of a test I wrote causes a segfault not just on my feature branch, but also on SciPy's main branch.

```python
import numpy as np
import pytest
from numpy.testing import assert_allclose, assert_equal

from scipy.special import mathieu_sem
# from scipy.special._ufuncs import _mathieu_sem


@pytest.mark.parametrize("m_shape,q_shape,x_shape,where_shape", [
    ((5, 1), (1, 1), (1, 10), ()),
    ((2, 3), (2, 3), (2, 3), ()),
    ((1, 5), (1, 5), (10, 5), ()),
    ((5, 1), (1, 1), (1, 10), (1, 10)),
    ((2, 3), (2, 3), (2, 3), (2, 3)),
    ((1, 5), (1, 5), (10, 5), (10, 5)),
    ((5, 1), (1, 1), (1, 10), (5, 1)),
])
def test_out(m_shape, q_shape, x_shape, where_shape):
    rng = np.random.default_rng(1234)
    
    m = rng.integers(1, 20, m_shape)
    q = rng.uniform(0, 10, q_shape)
    x = rng.uniform(0, 90, x_shape)
    
    if where_shape == ():
        batch_shape = np.broadcast_shapes(m_shape, q_shape, x_shape)
        where = True
    else:
        where = rng.choice([True, False], size=where_shape)
        batch_shape = np.broadcast_shapes(m_shape, q_shape, x_shape, where_shape)
        
    out0 = np.empty(batch_shape)
    out1 = np.empty(batch_shape)
    res0, res1 = mathieu_sem(m, q, x, out=(out0, out1), where=where)
    assert res0 is out0 and res1 is out1
```

Looking at a classic example of a ufunc loop

```C
static void double_add(char **args, npy_intp const *dimensions,
                       npy_intp const *steps, void *data) 
{
    npy_intp i;
    npy_intp n = dimensions[0];
    char *in1 = args[0], *in2 = args[1], *out = args[2];
    npy_intp step1 = steps[0], step2 = steps[1], step_out = steps[2];

    for (i = 0; i < n; i++) {
        /* Core computation: adding two doubles */
        *(double *)out = *(double *)in1 + *(double *)in2;
        
        /* Increment pointers by their respective strides */
        in1 += step1;
        in2 += step2;
        out += step_out;
    }
}
```

and comparing to what we have:

```C++
            Func func = static_cast<ufunc_data<Func> *>(data)->func;
            for (npy_intp i = 0; i < dims[0]; ++i) {
                Res res = func(
                    npy_traits<Args>::get(
                        args[I], new_dims.data() + ranks_scan[I], steps + ranks_scan[I] + sizeof...(Args) + 1
                    )...
                );
                npy_traits<Res>::set(args[sizeof...(Args)], res); // assign to the output pointer

                for (npy_uintp j = 0; j <= sizeof...(Args); ++j) {
                    args[j] += steps[j];
                }
            }
```

one sees that in the classic example, one updates pointers into args, but in `xsf::numpy`, elements of args are themselves updated. It seems this usually works out fine actually, except in particular situations. The situation that triggered it for me was having a ufunc kernel that uses heap memory, has two or more outputs, and having the ufunc called using `where` and `out` together. It is perhaps very rare to use `where` and `out` together, especially for the handful of functions that satisfy these: hence no bug reports.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
I was lead on many false goose chases trying to get help from AI on this one. Google Gemini hallucinated nonsense cause after nonsense cause. Once I realized the bug appeared on main in scipy too, and not just on my mathieu branch, it was easier to figure out.
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
