### PR TITLE
MAINT: ensure zero sign is returned for tangd at multiples of 180 and for cotdg at multiples of 90

### DIFF
--- a/include/xsf/cephes/tandg.h
+++ b/include/xsf/cephes/tandg.h
@@ -103,7 +103,8 @@ namespace cephes {
             }
 
             /* modulo 180 */
-            x = x - 180.0 * std::floor(x / 180.0);
+            double k = std::floor(x / 180.0);
+            x = x - 180.0 * k;
             if (cotflg) {
                 if (x <= 90.0) {
                     x = 90.0 - x;
@@ -118,6 +119,9 @@ namespace cephes {
                 }
             }
             if (x == 0.0) {
+                if (static_cast<long long>(k) & 1) {
+                    sign *= -1;
+                }
                 return sign * 0.0;
             } else if (x == 45.0) {
                 return sign * 1.0;

--- a/tests/xsf_tests/test_trig.cpp
+++ b/tests/xsf_tests/test_trig.cpp
@@ -12,8 +12,64 @@ void check_zeros(double (*f)(double)) {
     }
 }
 
-TEST_CASE("sindg IEEE scipy/20731", "[sindg][xsf_tests]") { check_zeros(&xsf::sindg); }
+TEST_CASE("sindg IEEE pm zero scipy/20731", "[sindg][xsf_tests]") { check_zeros(&xsf::sindg); }
 
-TEST_CASE("sinpi IEEE scipy/20731", "[sinpi][xsf_tests]") { check_zeros(&xsf::sinpi); }
+TEST_CASE("sinpi IEEE pm zero scipy/20731", "[sinpi][xsf_tests]") { check_zeros(&xsf::sinpi); }
 
-TEST_CASE("tandg IEEE scipy/20731", "[tandg][xsf_tests]") { check_zeros(&xsf::tandg); }
+TEST_CASE("tandg IEEE pm zero scipy/20731", "[tandg][xsf_tests]") { check_zeros(&xsf::tandg); }
+
+TEST_CASE("tandg IEEE zero sign at multiples of 180 scipy/20731", "[tandg][xsf_tests]") {
+    double x, result;
+    for (int n : {1, 2}) {
+        x = (2 * n + 1) * 180.0;
+        result = xsf::tandg(x);
+        CAPTURE(n, x, result);
+        REQUIRE(std::signbit(result));
+        REQUIRE(result == 0);
+        x = (2 * n + 2) * 180.0;
+        result = xsf::tandg(x);
+        CAPTURE(n, x, result);
+        REQUIRE(!std::signbit(result));
+        REQUIRE(result == 0);
+    }
+    for (int n : {-1, -2}) {
+        x = (2 * n - 1) * 180.0;
+        result = xsf::tandg(x);
+        CAPTURE(n, x, result);
+        REQUIRE(!std::signbit(result));
+        REQUIRE(result == 0);
+        x = (2 * n - 2) * 180.0;
+        result = xsf::tandg(x);
+        CAPTURE(n, x, result);
+        REQUIRE(std::signbit(result));
+        REQUIRE(result == 0);
+    }
+}
+
+TEST_CASE("cotdg IEEE zero sign at multiples of 90 scipy/20731", "[cotdg][xsf_tests]") {
+    double x, result;
+    for (int n : {1, 2}) {
+        x = (4 * n - 3) * 90.0;
+        result = xsf::cotdg(x);
+        CAPTURE(n, x, result);
+        REQUIRE(!std::signbit(result));
+        REQUIRE(result == 0);
+        x = (4 * n - 1) * 90.0;
+        result = xsf::cotdg(x);
+        CAPTURE(n, x, result);
+        REQUIRE(std::signbit(result));
+        REQUIRE(result == 0);
+    }
+    for (int n : {-1, -2}) {
+        x = (4 * n + 3) * 90.0;
+        result = xsf::cotdg(x);
+        CAPTURE(n, x, result);
+        REQUIRE(std::signbit(result));
+        REQUIRE(result == 0);
+        x = (4 * n + 1) * 90.0;
+        result = xsf::cotdg(x);
+        CAPTURE(n, x, result);
+        REQUIRE(!std::signbit(result));
+        REQUIRE(result == 0);
+    }
+}


### PR DESCRIPTION

<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
towards https://github.com/scipy/scipy/issues/20731
#### What does this implement/fix?
<!--Please explain your changes.-->
Ensures the following special values from the IEE spec are returned
<img width="753" height="321" alt="image" src="https://github.com/user-attachments/assets/d342a430-ba8d-4ace-8708-44b1b898d5bb" />
I will have a follow-up PR for the poles.
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI