### PR TITLE
TST/MAINT: Fix Windows CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
         run: pixi run --environment=tests-ci build-tests-ci
       - name: Run tests
         run: pixi run --skip-deps --environment=tests-ci tests-ci
-      - name: Generate converage
+      - name: Generate coverage report
         run: pixi run --skip-deps --environment=tests-ci coverage
       - name: Upload HTML coverage report
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,8 +49,10 @@ jobs:
       - name: Run tests
         run: pixi run --skip-deps --environment=tests-ci tests-ci
       - name: Generate coverage report
+        if: runner.os != 'Windows'
         run: pixi run --skip-deps --environment=tests-ci coverage
       - name: Upload HTML coverage report
+        if: runner.os != 'Windows'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3
         with:
           name: cov-html-${{ matrix.runs-on }}

--- a/pixi.toml
+++ b/pixi.toml
@@ -207,15 +207,15 @@ pytest-forked = "*"
 [feature.cupy-tests.tasks]
 # Since CuPy tests are only available on Linux, we can use bash like
 # this to only clone xsref if it isn't already there and checked out
-# at the proper tag.
+# at the proper commit.
 clone-xsref-test-cupy.cmd = """
 bash -c '
 if [ -d xsref ]; then
-  tag=$(git -C xsref describe --tags --exact-match 2>/dev/null || true)
+  commit=$(git -C xsref rev-parse HEAD 2>/dev/null || true)
 fi
-if [ \"$tag\" != v0.0.0 ]; then
+if [ \"$commit\" != 4e9b2343813136e355f0262754a3929d98bc5bff ]; then
   rm -rf xsref
-  git clone --branch v0.0.0 --depth 1 https://github.com/scipy/xsref.git
+  git clone https://github.com/scipy/xsref.git && git -C xsref checkout 4e9b2343813136e355f0262754a3929d98bc5bff
 fi
 '
 """

--- a/pixi.toml
+++ b/pixi.toml
@@ -48,7 +48,7 @@ libarrow-all = ">=19.0.1,<20"
 # clean xsref dir
 clean-xsref = { cwd = ".", cmd = "rm -rf xsref", description = "Remove the local xsref." }
 # clone xsref
-clone-xsref.cmd = "git clone --depth 1 --branch v0.0.0 https://github.com/scipy/xsref.git"
+clone-xsref.cmd = "git clone --depth 1 https://github.com/scipy/xsref.git"
 clone-xsref.cwd = "."
 clone-xsref.depends-on = ["clean-xsref"]
 clone-xsref.description = "Clone xsref after cleaning old checkout."

--- a/pixi.toml
+++ b/pixi.toml
@@ -48,7 +48,7 @@ libarrow-all = ">=19.0.1,<20"
 # clean xsref dir
 clean-xsref = { cwd = ".", cmd = "rm -rf xsref", description = "Remove the local xsref." }
 # clone xsref
-clone-xsref.cmd = "git clone --depth 1 https://github.com/scipy/xsref.git"
+clone-xsref.cmd = "git clone https://github.com/scipy/xsref.git && git -C xsref checkout 4e9b2343813136e355f0262754a3929d98bc5bff"
 clone-xsref.cwd = "."
 clone-xsref.depends-on = ["clean-xsref"]
 clone-xsref.description = "Clone xsref after cleaning old checkout."

--- a/tests/testing_utils.h
+++ b/tests/testing_utils.h
@@ -143,13 +143,14 @@ std::string get_platform_str() {
      * (Boost isn't a dependency yet but this is planned)
      * and we should have tolerance files for a wider variety of
      * compiler/os/architecture combos, including for specific compiler
-     * versions. For now, there are these two platforms with tolerance
-     * files and we use the former with Clang on Mac and the later
-     * otherwise. */
+     * versions. For now, there are three known platforms with tolerance
+     * files and we use "other" otherwise. */
 #if defined(__clang__) && defined(__APPLE__) && defined(__aarch64__)
     return "clang-darwin-aarch64";
 #elif defined(__GNUG__) && !defined(__clang__) && defined(__linux__) && defined(__x86_64__)
     return "gcc-linux-x86_64";
+#elif (defined(_MSC_VER) || (defined(__clang__) && defined(_WIN32))) && defined(_M_X64)
+    return "msvc-windows-x86_64";
 #else
     return "other";
 #endif


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes https://github.com/scipy/xsf/issues/70 and follow-up of https://github.com/scipy/xsref/pull/13



#### What does this implement/fix?
- Use the latest upstream `scipy/xsref` tables in test CI (see @steppi's [comment](https://github.com/scipy/xsref/pull/13#issuecomment-4483802407))
- Select `msvc-windows-x86_64` tolerance tables for Windows x64 builds.
- Skip coverage generation/upload on Windows

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Codex helped me with the changes.