### PR TITLE
config: emit __host__ __device__ on HIP-clang too

### DIFF
--- a/include/xsf/config.h
+++ b/include/xsf/config.h
@@ -235,7 +235,12 @@ using cuda::std::uint64_t;
 } // namespace std
 
 #else
+#if defined(__HIPCC__) || defined(__HIP__)
+// HIP-clang strictly enforces host/device call boundaries.
+#define XSF_HOST_DEVICE __host__ __device__
+#else
 #define XSF_HOST_DEVICE
+#endif
 
 #include <algorithm>
 #include <cassert>


### PR DESCRIPTION
Under HIP-clang's single-source compilation model, every helper that might be reached from a __global__ kernel must carry an explicit __device__ qualifier; without it the compiler aborts with

    error: call to __host__ function from __global__ function

while listing the (post-preprocessor) signature

    inline double digamma(double z) { ... }

as the only candidate. The xsf headers declare the helper as

    XSF_HOST_DEVICE inline double digamma(double z) { ... }

but XSF_HOST_DEVICE expands to nothing on every non-__CUDACC__ target, so under HIP it disappears and the function ends up host-only.

NVCC has long silently relaxed this rule for unannotated inline functions, so the upstream macro definition was never a problem on CUDA. HIP-clang -- like recent (post-9.0) NVCC '--strict-host-device' mode -- enforces the boundary, and any consumer that pulls xsf::digamma, xsf::wright_bessel, xsf::cephes::ellie, etc. into a kernel on the HIP backend trips over it.

Add a HIP-clang arm to the existing #ifdef __CUDACC__ ladder that keeps the bare-STL include set used by the generic host path (pulling in <cuda/std/...> here would conflict with libstdc++) but redefines XSF_HOST_DEVICE to '__host__ __device__' so every XSF_HOST_DEVICE- prefixed helper picks up the device qualifier HIP-clang requires.

Reproducer (CuPy, ROCm 7.2 on gfx90a):

    import cupy
    from cupyx.scipy.special import digamma
    digamma(cupy.asarray([1.5, 2.5]))

Before the patch, the kernel compile aborts with the "call to __host__ function from __global__ function" error above on every helper xsf marks XSF_HOST_DEVICE. With the patch the kernel compiles and runs unchanged.


This commit is for CuPy enablment on AMD hardware. 
