### PR TITLE
digamma: handle non-finite complex inputs before std::abs

### DIFF
--- a/include/xsf/digamma.h
+++ b/include/xsf/digamma.h
@@ -34,6 +34,16 @@ namespace detail {
     // Value of the negative root
     constexpr double digamma_negrootval = 7.2897639029768949e-17;
 
+    // Limit of digamma(z) for non-finite complex z.
+    // Precondition: !std::isfinite(z.real()) || !std::isfinite(z.imag()).
+    template <typename T>
+    XSF_HOST_DEVICE std::complex<T> digamma_nonfinite_limit(std::complex<T> z) {
+        constexpr T qnan = std::numeric_limits<T>::quiet_NaN();
+        if (std::isnan(z.real()) || !std::isfinite(z.imag()) || z.real() <= T{0})
+            return {qnan, qnan};
+        return {std::numeric_limits<T>::infinity(), T{0}};
+    }
+
     template <typename T>
     XSF_HOST_DEVICE T digamma_zeta_series(T z, double root, double rootval) {
         T res = rootval;
@@ -144,6 +154,12 @@ XSF_HOST_DEVICE inline std::complex<double> digamma(std::complex<double> z) {
      * - If |z| is small, use a recurrence relation to make |z| large
      * enough to use the asymptotic series.
      */
+
+    // Non-finite z: std::abs(complex) can return NaN, false-routing dispatch.
+    if (!std::isfinite(z.real()) || !std::isfinite(z.imag())) {
+        return detail::digamma_nonfinite_limit(z);
+    }
+
     double absz = std::abs(z);
     std::complex<double> res = 0;
     /* Use the asymptotic series for z away from the negative real axis

--- a/tests/xsf_tests/test_digamma.cpp
+++ b/tests/xsf_tests/test_digamma.cpp
@@ -1,0 +1,105 @@
+#include "../testing_utils.h"
+#include <xsf/digamma.h>
+
+#include <array>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <complex>
+#include <limits>
+
+using Catch::Matchers::IsNaN;
+using Catch::Matchers::WithinAbs;
+
+// Regression: digamma must short-circuit non-finite complex inputs
+// before std::abs(z), which can return NaN for inf operands under
+// libstdc++ and false-route every subsequent dispatch comparison.
+
+TEMPLATE_TEST_CASE("digamma non-finite complex inputs", "[digamma][xsf_tests][nonfinite]", float, double) {
+    using T = TestType;
+    using cd = std::complex<T>;
+    constexpr T inf = std::numeric_limits<T>::infinity();
+    constexpr T qnan = std::numeric_limits<T>::quiet_NaN();
+
+    SECTION("+inf real -> +inf + 0j") {
+        for (T im : std::array<T, 4>{T{0}, T{1}, T{-1}, T{1e30}}) {
+            cd r = xsf::digamma(cd{inf, im});
+            CAPTURE(im, r);
+            REQUIRE(r.real() == inf);
+            REQUIRE(r.imag() == T{0});
+        }
+    }
+
+    SECTION("-inf real -> NaN") {
+        for (T im : std::array<T, 3>{T{0}, T{1}, T{-1e30}}) {
+            cd r = xsf::digamma(cd{-inf, im});
+            CAPTURE(im, r);
+            REQUIRE_THAT(r.real(), IsNaN());
+            REQUIRE_THAT(r.imag(), IsNaN());
+        }
+    }
+
+    SECTION("imag inf -> NaN") {
+        for (cd z : std::array<cd, 7>{
+                 {{T{0}, inf}, {T{0}, -inf}, {T{1}, inf}, {T{-1}, -inf}, {inf, inf}, {-inf, inf}, {inf, -inf}}
+             }) {
+            cd r = xsf::digamma(z);
+            CAPTURE(z, r);
+            REQUIRE_THAT(r.real(), IsNaN());
+            REQUIRE_THAT(r.imag(), IsNaN());
+        }
+    }
+
+    SECTION("any NaN component -> NaN") {
+        for (cd z : std::array<cd, 8>{
+                 {{qnan, T{0}},
+                  {T{0}, qnan},
+                  {qnan, qnan},
+                  {qnan, T{1}},
+                  {T{1}, qnan},
+                  {qnan, inf},
+                  {inf, qnan},
+                  {-inf, qnan}}
+             }) {
+            cd r = xsf::digamma(z);
+            CAPTURE(z, r);
+            REQUIRE_THAT(r.real(), IsNaN());
+            REQUIRE_THAT(r.imag(), IsNaN());
+        }
+    }
+
+    SECTION("finite inputs still work") {
+        cd v1 = xsf::digamma(cd{T{1}, T{0}});
+        REQUIRE_THAT(v1.real(), WithinAbs(-0.5772156649015329, 1e-6));
+        cd v2 = xsf::digamma(cd{T{2}, T{0}});
+        REQUIRE_THAT(v2.real(), WithinAbs(0.4227843350984671, 1e-6));
+        cd v3 = xsf::digamma(cd{T{1}, T{1}});
+        REQUIRE(std::isfinite(v3.real()));
+        REQUIRE(std::isfinite(v3.imag()));
+    }
+}
+
+TEMPLATE_TEST_CASE("digamma non-finite enumeration", "[digamma][xsf_tests][nonfinite]", float, double) {
+    using T = TestType;
+    using cd = std::complex<T>;
+    constexpr T inf = std::numeric_limits<T>::infinity();
+    constexpr T qnan = std::numeric_limits<T>::quiet_NaN();
+
+    constexpr std::array<T, 4> values{T{1.5}, inf, -inf, qnan};
+    for (T re : values) {
+        for (T im : values) {
+            cd r = xsf::digamma(cd{re, im});
+            CAPTURE(re, im, r);
+            if (re == inf && std::isfinite(im)) {
+                REQUIRE(r.real() == inf);
+                REQUIRE(r.imag() == T{0});
+            } else if (!std::isfinite(re) || !std::isfinite(im)) {
+                REQUIRE_THAT(r.real(), IsNaN());
+                REQUIRE_THAT(r.imag(), IsNaN());
+            } else {
+                REQUIRE(std::isfinite(r.real()));
+                REQUIRE(std::isfinite(r.imag()));
+            }
+        }
+    }
+}


### PR DESCRIPTION
xsf::digamma(std::complex<double>) starts with

    double absz = std::abs(z);

and then dispatches every subsequent branch on absz comparisons. Under libstdc++ the generic __complex_abs template (selected whenever __builtin_cabs is not picked -- in particular whenever _GLIBCXX_USE_C99_COMPLEX is 0, which is the default that clang's cuda_wrappers/complex pins for both CUDA and HIP) applies the standard scale-by-max-magnitude algorithm

    template<typename _Tp>
    inline _Tp __complex_abs(const complex<_Tp>& z) {
        _Tp x = z.real();
        _Tp y = z.imag();
        const _Tp s = std::max(abs(x), abs(y));
        if (s == _Tp()) return s;
        x /= s;                            // inf/inf == NaN
        y /= s;                            // 0  /inf == 0
        return s * sqrt(x*x + y*y);        // inf * sqrt(NaN) == NaN
    }

That algorithm is correct for every finite input, but produces NaN when an operand is already infinite (inf/inf == NaN).

Cascade for digamma(+inf + 0j):

    absz = std::abs(z) = NaN
    if (absz < 0.5)             ->  NaN < 0.5  = false (skip)
    if (absz > smallabsz)       ->  NaN > 16   = false (skip!)
    else if (z.real() >= 0.0)   ->  enter
        n = trunc(16 - NaN) + 1                = NaN
        z + n                                  = NaN + 0j
        digamma_asymptotic_series(NaN + 0j)    = NaN + NaN*i
        return NaN + NaN*i

So digamma(+inf + 0j) returns NaN+NaNj instead of the expected +inf + 0j. The same routing failure affects -inf + finite*j (which silently returns 0+0j because every branch's pole / reflection / recurrence guard also false-routes on NaN) and nan + finite*j.

Fix: short-circuit non-finite inputs before reaching std::abs(z) and return the analytic limit directly:

  * any NaN component   -> NaN + NaN*j
  * imaginary infinity  -> NaN + NaN*j  (no finite limit; dense poles)
  * +inf + finite*j     -> +inf + 0j    (psi -> +inf on positive real)
  * -inf + finite*j     -> NaN + NaN*j  (limit of poles, matches
                                         the existing pole branch)

The patch is a strict improvement even for builds that go through __builtin_cabs (and therefore return inf correctly for absz): on those builds, +inf + 0j happens to land in the asymptotic branch whose early-return for non-finite z masks the issue, but nan + 0j still silently returns 0+0j today; this patch makes it return NaN+ NaN*j instead.

Zero overhead on the hot path: two isfinite tests on entry, then the original code.

Reproducer (CuPy, ROCm 7.2 on gfx90a):

    import cupy
    from cupyx.scipy.special import digamma
    import numpy as np
    digamma(cupy.asarray([np.inf + 0j], dtype=cupy.complex128))

Before:  array([nan+nanj])
After:   array([inf+0.j])

Adds tests/xsf_tests/test_digamma.cpp with two TEST_CASEs:

  * "digamma non-finite complex inputs" -- one SECTION per analytic- limit class above, including the explicit (+inf, 0) -> (+inf, 0) case that motivated the patch.

  * "digamma non-finite enumeration" -- enumerates every (re, im) combination of {finite, +inf, -inf, NaN}, asserts call-determinism (two calls return bit-identical results) and asserts the result matches the analytic-limit table. Without the patch this test fails on every infinite input.

<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
