### PR TITLE
BUG: amos.h: fix translation errors in asyi, unk1, and besi

### DIFF
--- a/include/xsf/amos/amos.h
+++ b/include/xsf/amos/amos.h
@@ -1140,7 +1140,7 @@ namespace amos {
                 return nz;
             }
             ck = std::exp(cz);
-            for (int i = 0; i < (nn + 1); i++) {
+            for (int i = 0; i < nn; i++) {
                 y[i] *= ck;
             }
             /* 90 */
@@ -5622,7 +5622,7 @@ namespace amos {
                 return -1;
             }
             nz = n;
-            for (i = 0; i < (n + 1); i++) {
+            for (i = 0; i < n; i++) {
                 y[i] = 0.0;
             }
             return nz;
@@ -6067,8 +6067,7 @@ namespace amos {
                 // REFINE ESTIMATE AND TEST
                 //
                 aphi = std::abs(phid);
-                aarg = std::abs(argd);
-                rs1 += std::log(aphi) - 0.25 * std::log(aarg) - aic;
+                rs1 += std::log(aphi);
                 if (std::fabs(rs1) < elim) {
                     goto L120;
                 }

--- a/include/xsf/amos/amos.h
+++ b/include/xsf/amos/amos.h
@@ -1770,7 +1770,7 @@ namespace amos {
             *ierr = 2;
             return 0;
         }
-        if (xx > 0.0) {
+        if (xx >= 0.0) {
             return nz;
         }
         //

--- a/tests/xsf_tests/test_amos.cpp
+++ b/tests/xsf_tests/test_amos.cpp
@@ -61,3 +61,30 @@ TEST_CASE("amos besi vectorized", "[amos][xsf_tests]") {
         REQUIRE(rel_error <= rtol);
     }
 }
+
+TEST_CASE("amos asyi buffer overflow gh-158", "[amos][xsf_tests]") {
+    using std::complex;
+
+    // parameters for asyi (computed as in besi)
+    const double tol = 2.220446049250313e-16;
+    const double rl = 24.6;
+    const double elim = 700.0;
+    const double alim = 664.0;
+
+    const complex<double> z{700.0, 10.0};
+    const double fnu = 0.0;
+    const int n = 5;
+    const int kode = 1;
+
+    // allocate n+1 elements, initialize extra to sentinel to detect overflow
+    const complex<double> sentinel{12345.67, 98765.43};
+    std::vector<complex<double>> y(n + 1, sentinel);
+
+    int nz = xsf::amos::asyi(z, fnu, kode, n, y.data(), rl, tol, elim, alim);
+
+    REQUIRE(nz == 0);
+
+    // check if the extra element (index n) was touched
+    CAPTURE(y[n]);
+    CHECK(y[n] == sentinel);
+}

--- a/tests/xsf_tests/test_amos.cpp
+++ b/tests/xsf_tests/test_amos.cpp
@@ -31,3 +31,33 @@ TEST_CASE("amos besj vectorized", "[amos][xsf_tests]") {
         REQUIRE(rel_error <= rtol);
     }
 }
+
+TEST_CASE("amos besi vectorized", "[amos][xsf_tests]") {
+    // tests the functionality of amos to return multiple consecutive orders for besi
+    // by comparing to the versions returning only a single order
+    using std::complex;
+
+    using test_case = std::tuple<complex<double>, double, int, int, double>;
+    auto [z, fnu, kode, n, rtol] = GENERATE(
+        test_case{complex{0.0, -15.0}, 0.0, 1, 10, 1e-15} // gh-158
+    );
+
+    std::vector<complex<double>> cy(n);
+    int ierr = 0;
+    int nz;
+
+    nz = xsf::amos::besi(z, fnu, kode, n, cy.data(), &ierr);
+
+    REQUIRE(ierr == 0);
+
+    complex<double> ref;
+
+    for (int i = 0; i < n; ++i) {
+        nz = xsf::amos::besi(z, fnu + i, kode, 1, &ref, &ierr);
+        REQUIRE(ierr == 0);
+
+        const auto rel_error = xsf::extended_relative_error(cy[i], ref);
+        CAPTURE(i, cy[i], ref, rel_error);
+        REQUIRE(rel_error <= rtol);
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
After the number of translation errors I found by hand, I decided to try an LLM for comparing the Fortran and C versions of amos. These are the translation errors unveiled this way. The disadvantage is, that I cannot add I test as it's hard to predict how to hit these branches.

#### Additional information
None

#### AI Generation Disclosure
Used Gemini 3.5 Flash to compare `amos.f` with `amos.h`. All suggestions were checked by hand (there was one additional false positive). Using a more powerful (= more expansive) model might also be rewarding.
