### PR TITLE
MAINT: ensure tandg and cotdg return the correct sign at poles

### DIFF
--- a/include/xsf/cephes/tandg.h
+++ b/include/xsf/cephes/tandg.h
@@ -127,7 +127,10 @@ namespace cephes {
                 return sign * 1.0;
             } else if (x == 90.0) {
                 set_error((cotflg ? "cotdg" : "tandg"), SF_ERROR_SINGULAR, NULL);
-                return std::numeric_limits<double>::infinity();
+                if (static_cast<long long>(k) & 1) {
+                    sign *= -1;
+                }
+                return sign * std::numeric_limits<double>::infinity();
             }
             /* x is now transformed into [0, 90) */
             return sign * std::tan(x * detail::PI180);

--- a/tests/xsf_tests/test_trig.cpp
+++ b/tests/xsf_tests/test_trig.cpp
@@ -84,3 +84,18 @@ TEST_CASE("tandg IEEE infinity sign scipy/20731", "[tandg][xsf_tests]") {
         REQUIRE(std::signbit(result) == (n % 2 != 0));
     }
 }
+
+TEST_CASE("cotdg IEEE infinity sign scipy/20731", "[cotdg][xsf_tests]") {
+    double x, result;
+    for (double n : {-2.0, -1.0, -0.0, 0.0, 1.0, 2.0}) {
+        x = n * 180.0;
+        result = xsf::cotdg(x);
+        CAPTURE(n, x, result);
+        REQUIRE(std::isinf(result));
+        if (std::signbit(n)) {
+            REQUIRE(std::signbit(result) == (static_cast<int>(n) % 2 == 0));
+        } else {
+            REQUIRE(std::signbit(result) == (static_cast<int>(n) % 2 != 0));
+        }
+    }
+}

--- a/tests/xsf_tests/test_trig.cpp
+++ b/tests/xsf_tests/test_trig.cpp
@@ -73,3 +73,14 @@ TEST_CASE("cotdg IEEE zero sign at multiples of 90 scipy/20731", "[cotdg][xsf_te
         REQUIRE(result == 0);
     }
 }
+
+TEST_CASE("tandg IEEE infinity sign scipy/20731", "[tandg][xsf_tests]") {
+    double x, result;
+    for (int n : {-2, -1, 0, 1, 2}) {
+        x = (2 * n + 1) * 90.0;
+        result = xsf::tandg(x);
+        CAPTURE(n, x, result);
+        REQUIRE(std::isinf(result));
+        REQUIRE(std::signbit(result) == (n % 2 != 0));
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Last pr (I think) towards https://github.com/scipy/scipy/issues/20731
#### What does this implement/fix?
<!--Please explain your changes.-->
Ensures the correct return value at the functions poles
<img width="1080" height="420" alt="Screenshot_20260522-061120~2" src="https://github.com/user-attachments/assets/ff9bb1a6-58a8-4712-af21-74a5e9ef1d1c" />

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No ai 