### PR TITLE
BUG: avoid spurious overflow warning in j0/y0 for tiny x

### DIFF
--- a/include/xsf/cephes/j0.h
+++ b/include/xsf/cephes/j0.h
@@ -168,9 +168,7 @@ namespace cephes {
 
         if (x <= 5.0) {
             if (x < 3e-8) {
-                /* For x < 3e-8, 1 - x^2/4 rounds to 1.0 in double precision
-                 * (x^2/4 is below machine epsilon). Avoid computing x*x entirely.
-                 */
+                /* x^2/4 is below machine epsilon — 1 - x^2/4 rounds to 1.0. */
                 return (1.0);
             }
             if (x < 1.0e-5) {
@@ -217,10 +215,8 @@ namespace cephes {
                 set_error("y0", SF_ERROR_DOMAIN, NULL);
                 return std::numeric_limits<double>::quiet_NaN();
             }
-            /* When x < 3e-8, x*x/4 is below machine epsilon for double precision.
-             * Avoid computing x*x entirely by using the limiting form directly.
-             */
             if (x < 3e-8) {
+                /* x*x/4 below machine epsilon — use limiting form directly. */
                 w = detail::j0_YP[7] / detail::j0_YQ[6];
                 w += M_2_PI * std::log(x);
                 return (w);

--- a/include/xsf/cephes/j0.h
+++ b/include/xsf/cephes/j0.h
@@ -105,7 +105,7 @@ namespace cephes {
 
     namespace detail {
 
-        inline constexpr double double_min = 1.4916681462400413e-154;
+        inline constexpr double sqrt_double_min = 1.4916681462400413e-154;
 
         constexpr double j0_PP[7] = {
             7.96936729297347051624E-4, 8.28352392107440799803E-2, 1.23953371646414299388E0,  5.44725003058768775090E0,
@@ -170,11 +170,11 @@ namespace cephes {
 
         if (x <= 5.0) {
             if (x < 1.0e-5) {
-                /* For x < double_min (~1.49e-154), x*x underflows to zero and raises a
+                /* For x < sqrt_double_min (~1.49e-154), x*x underflows to zero and raises a
                  * spurious floating-point exception. j0(x) = 1 - x^2/4 + ...
                  * is 1.0 to machine precision when x*x underflows.
                  */
-                if (x < detail::double_min) {
+                if (x < detail::sqrt_double_min) {
                     return (1.0);
                 }
                 z = x * x;
@@ -220,12 +220,12 @@ namespace cephes {
                 set_error("y0", SF_ERROR_DOMAIN, NULL);
                 return std::numeric_limits<double>::quiet_NaN();
             }
-            /* When x < double_min (~1.49e-154), x*x underflows to zero, which raises a
+            /* When x < sqrt_double_min (~1.49e-154), x*x underflows to zero, which raises a
              * spurious floating-point exception. Avoid the underflow by using
              * the limiting form directly: for tiny x, j0(x) ≈ 1 and the
              * rational approximation reduces to its constant term.
              */
-            if (x < detail::double_min) {
+            if (x < detail::sqrt_double_min) {
                 w = detail::j0_YP[7] / detail::j0_YQ[6];
                 w += M_2_PI * std::log(x);
                 return (w);

--- a/include/xsf/cephes/j0.h
+++ b/include/xsf/cephes/j0.h
@@ -105,8 +105,6 @@ namespace cephes {
 
     namespace detail {
 
-        inline constexpr double sqrt_double_min = 1.4916681462400413e-154;
-
         constexpr double j0_PP[7] = {
             7.96936729297347051624E-4, 8.28352392107440799803E-2, 1.23953371646414299388E0,  5.44725003058768775090E0,
             8.74716500199817011941E0,  5.30324038235394892183E0,  9.99999999999999997821E-1,
@@ -169,14 +167,13 @@ namespace cephes {
         }
 
         if (x <= 5.0) {
-            if (x < 1.0e-5) {
-                /* For x < sqrt_double_min (~1.49e-154), x*x underflows to zero and raises a
-                 * spurious floating-point exception. j0(x) = 1 - x^2/4 + ...
-                 * is 1.0 to machine precision when x*x underflows.
+            if (x < 3e-8) {
+                /* For x < 3e-8, 1 - x^2/4 rounds to 1.0 in double precision
+                 * (x^2/4 is below machine epsilon). Avoid computing x*x entirely.
                  */
-                if (x < detail::sqrt_double_min) {
-                    return (1.0);
-                }
+                return (1.0);
+            }
+            if (x < 1.0e-5) {
                 z = x * x;
                 return (1.0 - z / 4.0);
             }
@@ -220,12 +217,10 @@ namespace cephes {
                 set_error("y0", SF_ERROR_DOMAIN, NULL);
                 return std::numeric_limits<double>::quiet_NaN();
             }
-            /* When x < sqrt_double_min (~1.49e-154), x*x underflows to zero, which raises a
-             * spurious floating-point exception. Avoid the underflow by using
-             * the limiting form directly: for tiny x, j0(x) ≈ 1 and the
-             * rational approximation reduces to its constant term.
+            /* When x < 3e-8, x*x/4 is below machine epsilon for double precision.
+             * Avoid computing x*x entirely by using the limiting form directly.
              */
-            if (x < detail::sqrt_double_min) {
+            if (x < 3e-8) {
                 w = detail::j0_YP[7] / detail::j0_YQ[6];
                 w += M_2_PI * std::log(x);
                 return (w);

--- a/include/xsf/cephes/j0.h
+++ b/include/xsf/cephes/j0.h
@@ -105,6 +105,8 @@ namespace cephes {
 
     namespace detail {
 
+        inline constexpr double double_min = 1.4916681462400413e-154;
+
         constexpr double j0_PP[7] = {
             7.96936729297347051624E-4, 8.28352392107440799803E-2, 1.23953371646414299388E0,  5.44725003058768775090E0,
             8.74716500199817011941E0,  5.30324038235394892183E0,  9.99999999999999997821E-1,
@@ -168,11 +170,11 @@ namespace cephes {
 
         if (x <= 5.0) {
             if (x < 1.0e-5) {
-                /* For very small x, x*x underflows to zero and raises a
+                /* For x < double_min (~1.49e-154), x*x underflows to zero and raises a
                  * spurious floating-point exception. j0(x) = 1 - x^2/4 + ...
                  * is 1.0 to machine precision when x*x underflows.
                  */
-                if (x < 2e-154) {
+                if (x < detail::double_min) {
                     return (1.0);
                 }
                 z = x * x;
@@ -218,12 +220,12 @@ namespace cephes {
                 set_error("y0", SF_ERROR_DOMAIN, NULL);
                 return std::numeric_limits<double>::quiet_NaN();
             }
-            /* When x is very small, x*x underflows to zero, which raises a
+            /* When x < double_min (~1.49e-154), x*x underflows to zero, which raises a
              * spurious floating-point exception. Avoid the underflow by using
              * the limiting form directly: for tiny x, j0(x) ≈ 1 and the
              * rational approximation reduces to its constant term.
              */
-            if (x < 2e-154) {
+            if (x < detail::double_min) {
                 w = detail::j0_YP[7] / detail::j0_YQ[6];
                 w += M_2_PI * std::log(x);
                 return (w);

--- a/include/xsf/cephes/j0.h
+++ b/include/xsf/cephes/j0.h
@@ -167,10 +167,18 @@ namespace cephes {
         }
 
         if (x <= 5.0) {
-            z = x * x;
             if (x < 1.0e-5) {
+                /* For very small x, x*x underflows to zero and raises a
+                 * spurious floating-point exception. j0(x) = 1 - x^2/4 + ...
+                 * is 1.0 to machine precision when x*x underflows.
+                 */
+                if (x < 2e-154) {
+                    return (1.0);
+                }
+                z = x * x;
                 return (1.0 - z / 4.0);
             }
+            z = x * x;
 
             p = (z - detail::j0_DR1) * (z - detail::j0_DR2);
             p = p * polevl(z, detail::j0_RP, 3) / p1evl(z, detail::j0_RQ, 8);
@@ -209,6 +217,16 @@ namespace cephes {
             } else if (x < 0.0) {
                 set_error("y0", SF_ERROR_DOMAIN, NULL);
                 return std::numeric_limits<double>::quiet_NaN();
+            }
+            /* When x is very small, x*x underflows to zero, which raises a
+             * spurious floating-point exception. Avoid the underflow by using
+             * the limiting form directly: for tiny x, j0(x) ≈ 1 and the
+             * rational approximation reduces to its constant term.
+             */
+            if (x < 2e-154) {
+                w = detail::j0_YP[7] / detail::j0_YQ[6];
+                w += M_2_PI * std::log(x);
+                return (w);
             }
             z = x * x;
             w = polevl(z, detail::j0_YP, 7) / p1evl(z, detail::j0_YQ, 7);

--- a/tests/xsf_tests/test_j0y0_tiny_x.cpp
+++ b/tests/xsf_tests/test_j0y0_tiny_x.cpp
@@ -16,8 +16,10 @@ TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
     SECTION("j0 at tiny x should not underflow") {
         using test_case = std::tuple<double, double>;
         auto [x, expected] = GENERATE(
-            test_case{0.0, 1.0},       test_case{1e-200, 1.0},
-            test_case{1e-100, 1.0},    test_case{1e-10, 1.0},
+            test_case{0.0, 1.0},
+            test_case{1e-200, 1.0},
+            test_case{1e-100, 1.0},
+            test_case{1e-10, 1.0},
             test_case{2e-154, 1.0}
         );
         std::feclearexcept(FE_ALL_EXCEPT);

--- a/tests/xsf_tests/test_j0y0_tiny_x.cpp
+++ b/tests/xsf_tests/test_j0y0_tiny_x.cpp
@@ -2,13 +2,6 @@
 #include <cfenv>
 #include <xsf/cephes/j0.h>
 
-#define CHECK_NO_UNDERFLOW(expr)                                                           \
-    do {                                                                                   \
-        std::feclearexcept(FE_ALL_EXCEPT);                                                 \
-        CHECK(expr);                                                                       \
-        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);                                       \
-    } while (0)
-
 TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
     // Regression test for gh-25199: j0/y0 at tiny x should not raise spurious
     // FP exceptions from x*x underflowing to zero.
@@ -21,15 +14,18 @@ TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
     //     print(x, mp.nstr(mp.besselj(0, x), 18), mp.nstr(mp.bessely(0, x), 18))
 
     SECTION("j0 at tiny x should not underflow") {
-        // j0(0) = 1
-        CHECK_NO_UNDERFLOW(xsf::cephes::j0(0.0) == 1.0);
-        // j0(1e-200) = 1.0 (to machine precision)
-        CHECK_NO_UNDERFLOW(xsf::cephes::j0(1e-200) == 1.0);
-        // j0(1e-100) = 1.0 (to machine precision)
-        CHECK_NO_UNDERFLOW(xsf::cephes::j0(1e-100) == 1.0);
-        // j0 at 1e-10, still below 1e-5 threshold, uses 1 - x^2/4
-        CHECK_NO_UNDERFLOW(xsf::cephes::j0(1e-10) == 1.0);
-        // j0 at 1e-5, edge of the small-x branch (should not underflow)
+        using test_case = std::tuple<double, double>;
+        auto [x, expected] = GENERATE(
+            test_case{0.0, 1.0},       test_case{1e-200, 1.0},
+            test_case{1e-100, 1.0},    test_case{1e-10, 1.0},
+            test_case{2e-154, 1.0}
+        );
+        std::feclearexcept(FE_ALL_EXCEPT);
+        CHECK(xsf::cephes::j0(x) == expected);
+        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
+    }
+
+    SECTION("j0 at 1e-5 uses 1 - x^2/4") {
         std::feclearexcept(FE_ALL_EXCEPT);
         auto w = xsf::cephes::j0(1e-5);
         CHECK(w > 0.9999999999);
@@ -38,26 +34,25 @@ TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
     }
 
     SECTION("y0 at tiny x should not underflow") {
-        // y0(0) = -inf
-        CHECK_NO_UNDERFLOW(xsf::cephes::y0(0.0) == -std::numeric_limits<double>::infinity());
-        // y0(1e-200) should avoid spurious overflow/underflow
-        // Reference from scipy test: -293.2480438468798
-        CHECK_NO_UNDERFLOW(xsf::cephes::y0(1e-200) == -293.2480438468798);
-        // y0(1e-100) should also be computed safely
-        // mpmath: y0(1e-100) = -145.3526521672157...
+        using test_case = std::tuple<double, double>;
+        auto [x, expected] = GENERATE(
+            test_case{0.0, -std::numeric_limits<double>::infinity()},
+            test_case{1e-200, -293.2480438468798}
+        );
+        std::feclearexcept(FE_ALL_EXCEPT);
+        CHECK(xsf::cephes::y0(x) == expected);
+        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
+    }
+
+    SECTION("y0 at 1e-100 is finite and negative") {
         std::feclearexcept(FE_ALL_EXCEPT);
         auto w = xsf::cephes::y0(1e-100);
-        // Just check it's finite and negative
         CHECK(std::isfinite(w));
         CHECK(w < 0.0);
         CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
     }
 
-    SECTION("j0 and y0 at values just above sqrt_double_min") {
-        // Values just above the threshold should still compute correctly
-        // via the normal path without underflow exceptions
-        CHECK_NO_UNDERFLOW(xsf::cephes::j0(2e-154) == 1.0);
-
+    SECTION("y0 at 2e-154 is finite and negative") {
         std::feclearexcept(FE_ALL_EXCEPT);
         auto y = xsf::cephes::y0(2e-154);
         CHECK(std::isfinite(y));

--- a/tests/xsf_tests/test_j0y0_tiny_x.cpp
+++ b/tests/xsf_tests/test_j0y0_tiny_x.cpp
@@ -42,7 +42,7 @@ TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
         CHECK(w < 0.0);
     }
 
-    SECTION("j0 and y0 at values just above double_min") {
+    SECTION("j0 and y0 at values just above sqrt_double_min") {
         // Values just above the threshold should still compute correctly
         // via the normal path without underflow exceptions
         auto j = xsf::cephes::j0(2e-154);

--- a/tests/xsf_tests/test_j0y0_tiny_x.cpp
+++ b/tests/xsf_tests/test_j0y0_tiny_x.cpp
@@ -2,6 +2,13 @@
 #include <cfenv>
 #include <xsf/cephes/j0.h>
 
+#define CHECK_NO_UNDERFLOW(expr)                                                           \
+    do {                                                                                   \
+        std::feclearexcept(FE_ALL_EXCEPT);                                                 \
+        CHECK(expr);                                                                       \
+        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);                                       \
+    } while (0)
+
 TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
     // Regression test for gh-25199: j0/y0 at tiny x should not raise spurious
     // FP exceptions from x*x underflowing to zero.
@@ -15,21 +22,13 @@ TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
 
     SECTION("j0 at tiny x should not underflow") {
         // j0(0) = 1
-        std::feclearexcept(FE_ALL_EXCEPT);
-        CHECK(xsf::cephes::j0(0.0) == 1.0);
-        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
+        CHECK_NO_UNDERFLOW(xsf::cephes::j0(0.0) == 1.0);
         // j0(1e-200) = 1.0 (to machine precision)
-        std::feclearexcept(FE_ALL_EXCEPT);
-        CHECK(xsf::cephes::j0(1e-200) == 1.0);
-        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
+        CHECK_NO_UNDERFLOW(xsf::cephes::j0(1e-200) == 1.0);
         // j0(1e-100) = 1.0 (to machine precision)
-        std::feclearexcept(FE_ALL_EXCEPT);
-        CHECK(xsf::cephes::j0(1e-100) == 1.0);
-        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
+        CHECK_NO_UNDERFLOW(xsf::cephes::j0(1e-100) == 1.0);
         // j0 at 1e-10, still below 1e-5 threshold, uses 1 - x^2/4
-        std::feclearexcept(FE_ALL_EXCEPT);
-        CHECK(xsf::cephes::j0(1e-10) == 1.0);
-        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
+        CHECK_NO_UNDERFLOW(xsf::cephes::j0(1e-10) == 1.0);
         // j0 at 1e-5, edge of the small-x branch (should not underflow)
         std::feclearexcept(FE_ALL_EXCEPT);
         auto w = xsf::cephes::j0(1e-5);
@@ -40,19 +39,14 @@ TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
 
     SECTION("y0 at tiny x should not underflow") {
         // y0(0) = -inf
-        std::feclearexcept(FE_ALL_EXCEPT);
-        CHECK(xsf::cephes::y0(0.0) == -std::numeric_limits<double>::infinity());
-        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
+        CHECK_NO_UNDERFLOW(xsf::cephes::y0(0.0) == -std::numeric_limits<double>::infinity());
         // y0(1e-200) should avoid spurious overflow/underflow
         // Reference from scipy test: -293.2480438468798
-        std::feclearexcept(FE_ALL_EXCEPT);
-        auto w = xsf::cephes::y0(1e-200);
-        CHECK(w == -293.2480438468798);
-        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
+        CHECK_NO_UNDERFLOW(xsf::cephes::y0(1e-200) == -293.2480438468798);
         // y0(1e-100) should also be computed safely
         // mpmath: y0(1e-100) = -145.3526521672157...
         std::feclearexcept(FE_ALL_EXCEPT);
-        w = xsf::cephes::y0(1e-100);
+        auto w = xsf::cephes::y0(1e-100);
         // Just check it's finite and negative
         CHECK(std::isfinite(w));
         CHECK(w < 0.0);
@@ -62,10 +56,7 @@ TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
     SECTION("j0 and y0 at values just above sqrt_double_min") {
         // Values just above the threshold should still compute correctly
         // via the normal path without underflow exceptions
-        std::feclearexcept(FE_ALL_EXCEPT);
-        auto j = xsf::cephes::j0(2e-154);
-        CHECK(j == 1.0);
-        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
+        CHECK_NO_UNDERFLOW(xsf::cephes::j0(2e-154) == 1.0);
 
         std::feclearexcept(FE_ALL_EXCEPT);
         auto y = xsf::cephes::y0(2e-154);

--- a/tests/xsf_tests/test_j0y0_tiny_x.cpp
+++ b/tests/xsf_tests/test_j0y0_tiny_x.cpp
@@ -16,10 +16,7 @@ TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
     SECTION("j0 at tiny x should not underflow") {
         using test_case = std::tuple<double, double>;
         auto [x, expected] = GENERATE(
-            test_case{0.0, 1.0},
-            test_case{1e-200, 1.0},
-            test_case{1e-100, 1.0},
-            test_case{1e-10, 1.0},
+            test_case{0.0, 1.0}, test_case{1e-200, 1.0}, test_case{1e-100, 1.0}, test_case{1e-10, 1.0},
             test_case{2e-154, 1.0}
         );
         std::feclearexcept(FE_ALL_EXCEPT);
@@ -37,10 +34,8 @@ TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
 
     SECTION("y0 at tiny x should not underflow") {
         using test_case = std::tuple<double, double>;
-        auto [x, expected] = GENERATE(
-            test_case{0.0, -std::numeric_limits<double>::infinity()},
-            test_case{1e-200, -293.2480438468798}
-        );
+        auto [x, expected] =
+            GENERATE(test_case{0.0, -std::numeric_limits<double>::infinity()}, test_case{1e-200, -293.2480438468798});
         std::feclearexcept(FE_ALL_EXCEPT);
         CHECK(xsf::cephes::y0(x) == expected);
         CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);

--- a/tests/xsf_tests/test_j0y0_tiny_x.cpp
+++ b/tests/xsf_tests/test_j0y0_tiny_x.cpp
@@ -1,0 +1,55 @@
+#include "../testing_utils.h"
+#include <xsf/cephes/j0.h>
+
+TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
+    // Regression test for gh-25199: j0/y0 at tiny x should not raise spurious
+    // FP exceptions from x*x underflowing to zero.
+    //
+    // Reference values computed with mpmath with 1000 digits of precision:
+    //
+    // import mpmath as mp
+    // mp.mp.dps = 1000
+    // for x in [0.0, 1e-300, 1e-200, 1e-100, 1e-10, 1e-5]:
+    //     print(x, mp.nstr(mp.besselj(0, x), 18), mp.nstr(mp.bessely(0, x), 18))
+
+    SECTION("j0 at tiny x should not underflow") {
+        // j0(0) = 1
+        CHECK(xsf::cephes::j0(0.0) == 1.0);
+        // j0(1e-200) = 1.0 (to machine precision)
+        CHECK(xsf::cephes::j0(1e-200) == 1.0);
+        // j0(1e-100) = 1.0 (to machine precision)
+        CHECK(xsf::cephes::j0(1e-100) == 1.0);
+        // j0 at 1e-10, still below 1e-5 threshold, uses 1 - x^2/4
+        CHECK(xsf::cephes::j0(1e-10) == 1.0);
+        // j0 at 1e-5, edge of the small-x branch (should not underflow)
+        auto w = xsf::cephes::j0(1e-5);
+        CHECK(w > 0.9999999999);
+        CHECK(w < 1.0);
+    }
+
+    SECTION("y0 at tiny x should not underflow") {
+        // y0(0) = -inf
+        CHECK(xsf::cephes::y0(0.0) == -std::numeric_limits<double>::infinity());
+        // y0(1e-200) should avoid spurious overflow/underflow
+        // Reference from scipy test: -293.2480438468798
+        auto w = xsf::cephes::y0(1e-200);
+        CHECK(w == -293.2480438468798);
+        // y0(1e-100) should also be computed safely
+        // mpmath: y0(1e-100) = -145.3526521672157...
+        w = xsf::cephes::y0(1e-100);
+        // Just check it's finite and negative
+        CHECK(std::isfinite(w));
+        CHECK(w < 0.0);
+    }
+
+    SECTION("j0 and y0 at values just above double_min") {
+        // Values just above the threshold should still compute correctly
+        // via the normal path without underflow exceptions
+        auto j = xsf::cephes::j0(2e-154);
+        CHECK(j == 1.0);
+
+        auto y = xsf::cephes::y0(2e-154);
+        CHECK(std::isfinite(y));
+        CHECK(y < 0.0);
+    }
+}

--- a/tests/xsf_tests/test_j0y0_tiny_x.cpp
+++ b/tests/xsf_tests/test_j0y0_tiny_x.cpp
@@ -46,19 +46,12 @@ TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
         CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
     }
 
-    SECTION("y0 at 1e-100 is finite and negative") {
+    SECTION("y0 at tiny x is finite with no underflow") {
+        auto x = GENERATE(1e-100, 2e-154);
         std::feclearexcept(FE_ALL_EXCEPT);
-        auto w = xsf::cephes::y0(1e-100);
+        auto w = xsf::cephes::y0(x);
         CHECK(std::isfinite(w));
         CHECK(w < 0.0);
-        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
-    }
-
-    SECTION("y0 at 2e-154 is finite and negative") {
-        std::feclearexcept(FE_ALL_EXCEPT);
-        auto y = xsf::cephes::y0(2e-154);
-        CHECK(std::isfinite(y));
-        CHECK(y < 0.0);
         CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
     }
 }

--- a/tests/xsf_tests/test_j0y0_tiny_x.cpp
+++ b/tests/xsf_tests/test_j0y0_tiny_x.cpp
@@ -1,6 +1,6 @@
 #include "../testing_utils.h"
-#include <xsf/cephes/j0.h>
 #include <cfenv>
+#include <xsf/cephes/j0.h>
 
 TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
     // Regression test for gh-25199: j0/y0 at tiny x should not raise spurious

--- a/tests/xsf_tests/test_j0y0_tiny_x.cpp
+++ b/tests/xsf_tests/test_j0y0_tiny_x.cpp
@@ -1,5 +1,6 @@
 #include "../testing_utils.h"
 #include <xsf/cephes/j0.h>
+#include <cfenv>
 
 TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
     // Regression test for gh-25199: j0/y0 at tiny x should not raise spurious
@@ -14,42 +15,62 @@ TEST_CASE("j0 tiny x underflow threshold", "[j0][y0][xsf_tests]") {
 
     SECTION("j0 at tiny x should not underflow") {
         // j0(0) = 1
+        std::feclearexcept(FE_ALL_EXCEPT);
         CHECK(xsf::cephes::j0(0.0) == 1.0);
+        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
         // j0(1e-200) = 1.0 (to machine precision)
+        std::feclearexcept(FE_ALL_EXCEPT);
         CHECK(xsf::cephes::j0(1e-200) == 1.0);
+        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
         // j0(1e-100) = 1.0 (to machine precision)
+        std::feclearexcept(FE_ALL_EXCEPT);
         CHECK(xsf::cephes::j0(1e-100) == 1.0);
+        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
         // j0 at 1e-10, still below 1e-5 threshold, uses 1 - x^2/4
+        std::feclearexcept(FE_ALL_EXCEPT);
         CHECK(xsf::cephes::j0(1e-10) == 1.0);
+        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
         // j0 at 1e-5, edge of the small-x branch (should not underflow)
+        std::feclearexcept(FE_ALL_EXCEPT);
         auto w = xsf::cephes::j0(1e-5);
         CHECK(w > 0.9999999999);
         CHECK(w < 1.0);
+        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
     }
 
     SECTION("y0 at tiny x should not underflow") {
         // y0(0) = -inf
+        std::feclearexcept(FE_ALL_EXCEPT);
         CHECK(xsf::cephes::y0(0.0) == -std::numeric_limits<double>::infinity());
+        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
         // y0(1e-200) should avoid spurious overflow/underflow
         // Reference from scipy test: -293.2480438468798
+        std::feclearexcept(FE_ALL_EXCEPT);
         auto w = xsf::cephes::y0(1e-200);
         CHECK(w == -293.2480438468798);
+        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
         // y0(1e-100) should also be computed safely
         // mpmath: y0(1e-100) = -145.3526521672157...
+        std::feclearexcept(FE_ALL_EXCEPT);
         w = xsf::cephes::y0(1e-100);
         // Just check it's finite and negative
         CHECK(std::isfinite(w));
         CHECK(w < 0.0);
+        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
     }
 
     SECTION("j0 and y0 at values just above sqrt_double_min") {
         // Values just above the threshold should still compute correctly
         // via the normal path without underflow exceptions
+        std::feclearexcept(FE_ALL_EXCEPT);
         auto j = xsf::cephes::j0(2e-154);
         CHECK(j == 1.0);
+        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
 
+        std::feclearexcept(FE_ALL_EXCEPT);
         auto y = xsf::cephes::y0(2e-154);
         CHECK(std::isfinite(y));
         CHECK(y < 0.0);
+        CHECK(std::fetestexcept(FE_UNDERFLOW) == 0);
     }
 }


### PR DESCRIPTION
### Title
BUG: cephes: avoid spurious FP exception in j0/y0 for tiny x
### Description
For very small x (< 3e-8), `x^2/4` is below machine epsilon so
`1 - x^2/4` rounds to 1.0. Avoid computing `x*x`, which also
prevents spurious underflow exceptions for extreme values near
`sqrt(DBL_MIN)`. Use limiting forms directly:
- `j0(x) ≈ 1.0`  error is O(x²), far below machine precision
- `y0(x) ≈ YP[7]/YQ[6] + (2/π)·log(x)` — the rational approximation
  reduces to its constant term.
This preserves the exact numerical result while avoiding the underflowing
computation. The threshold 3e-8 is chosen because `x^2/4 < ε_mach` for
all x < 3e-8.
Includes GENERATE-based tests that verify:
- Correct values for j0 and y0 at tiny x
- No FE_UNDERFLOW exception is raised
- y0 at 1e-100 and 2e-154 is finite, negative, and exception-free
cc @steppi
Fixes scipy/scipy#25199

I used an AI coding assistant (opencode) to help draft parts of this fix, including the threshold constant extraction and test scaffolding , Also used for text formatting. All code was reviewed, understood, and verified by me before submission.