### PR TITLE
Codeql alert fixes

### DIFF
--- a/include/xsf/legendre.h
+++ b/include/xsf/legendre.h
@@ -946,7 +946,9 @@ void lqmn(T x, OutputMat1 qm, OutputMat2 qd) {
 
     for (i = 1; i <= m; i++) {
         for (j = 0; j <= n; j++) {
-            qd(i, j) = ls * i * x / xs * qm(i, j) + (i + j) * (j - i + 1.) / xq * qm(i - 1, j);
+            qd(i, j) = ls * i * x / xs * qm(i, j) +
+                       (static_cast<double>(i) + static_cast<double>(j)) *
+                           (static_cast<double>(j) - static_cast<double>(i) + 1.0) / xq * qm(i - 1, j);
         }
     }
 }
@@ -1072,7 +1074,8 @@ void lqmn(std::complex<T> z, OutputMat1 cqm, OutputMat2 cqd) {
     for (i = 1; i <= m; i++) {
         for (j = 0; j <= n; j++) {
             cqd(i, j) = static_cast<T>(ls * i) * z / zs * cqm(i, j) +
-                        static_cast<T>((i + j) * (j - i + 1)) / zq * cqm(i - 1, j);
+                        (static_cast<T>(i) + static_cast<T>(j)) *
+                            (static_cast<T>(j) - static_cast<T>(i) + static_cast<T>(1)) / zq * cqm(i - 1, j);
         }
     }
 }

--- a/include/xsf/legendre.h
+++ b/include/xsf/legendre.h
@@ -946,9 +946,9 @@ void lqmn(T x, OutputMat1 qm, OutputMat2 qd) {
 
     for (i = 1; i <= m; i++) {
         for (j = 0; j <= n; j++) {
-            qd(i, j) = ls * i * x / xs * qm(i, j) +
-                       (static_cast<double>(i) + static_cast<double>(j)) *
-                           (static_cast<double>(j) - static_cast<double>(i) + 1.0) / xq * qm(i - 1, j);
+            qd(i, j) = ls * i * x / xs * qm(i, j) + (static_cast<double>(i) + static_cast<double>(j)) *
+                                                        (static_cast<double>(j) - static_cast<double>(i) + 1.0) / xq *
+                                                        qm(i - 1, j);
         }
     }
 }

--- a/include/xsf/specfun/specfun.h
+++ b/include/xsf/specfun/specfun.h
@@ -4814,13 +4814,14 @@ namespace specfun {
         w1 = 0.0;
         w2 = 0.0;
 
+	T sign_kd = (kd % 2 == 0) ? static_cast<T>(1) : static_cast<T>(-1);
         if (kc != 2) {
             *f1r = 0.0;
             for (k = 1; k <= km; k++) {
                 if (kd == 1) {
-                    *f1r += pow(-1, ic + k) * fg[k - 1] * bj1[k - 1] * bj2[k - 1];
+                    *f1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * bj1[k - 1] * bj2[k - 1];
                 } else if (kd == 2 || kd == 3) {
-                    *f1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * bj2[k] + pow(static_cast<T>(-1), kd) * bj1[k] * bj2[k - 1]);
+                    *f1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * bj2[k] + sign_kd * bj1[k] * bj2[k - 1]);
                 } else {
                     *f1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * bj2[k + 1] - bj1[k + 1] * bj2[k - 1]);
                 }
@@ -4839,8 +4840,8 @@ namespace specfun {
                     *d1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (c2 * bj1[k - 1] * dj2[k - 1] - c1 * dj1[k - 1] * bj2[k - 1]);
                 } else if (kd == 2 || kd == 3) {
                     *d1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] *
-                            (c2 * (bj1[k - 1] * dj2[k] + pow(static_cast<T>(-1), kd) * bj1[k] * dj2[k - 1]) -
-                             c1 * (dj1[k - 1] * bj2[k] + pow(static_cast<T>(-1), kd) * dj1[k] * bj2[k - 1]));
+                            (c2 * (bj1[k - 1] * dj2[k] + sign_kd * bj1[k] * dj2[k - 1]) -
+                             c1 * (dj1[k - 1] * bj2[k] + sign_kd * dj1[k] * bj2[k - 1]));
                 } else {
                     *d1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] *
                             (c2 * (bj1[k - 1] * dj2[k + 1] - bj1[k + 1] * dj2[k - 1]) -
@@ -4863,7 +4864,7 @@ namespace specfun {
             if (kd == 1) {
                 *f2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * bj1[k - 1] * by2[k - 1];
             } else if (kd == 2 || kd == 3) {
-                *f2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * by2[k] + pow(static_cast<T>(-1), kd) * bj1[k] * by2[k - 1]);
+                *f2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * by2[k] + sign_kd * bj1[k] * by2[k - 1]);
             } else {
                 *f2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * by2[k + 1] - bj1[k + 1] * by2[k - 1]);
             }
@@ -4881,8 +4882,8 @@ namespace specfun {
                 *d2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (c2 * bj1[k - 1] * dy2[k - 1] - c1 * dj1[k - 1] * by2[k - 1]);
             } else if (kd == 2 || kd == 3) {
                 *d2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] *
-                        (c2 * (bj1[k - 1] * dy2[k] + pow(static_cast<T>(-1), kd) * bj1[k] * dy2[k - 1]) -
-                         c1 * (dj1[k - 1] * by2[k] + pow(static_cast<T>(-1), kd) * dj1[k] * by2[k - 1]));
+                        (c2 * (bj1[k - 1] * dy2[k] + sign_kd * bj1[k] * dy2[k - 1]) -
+                         c1 * (dj1[k - 1] * by2[k] + sign_kd * dj1[k] * by2[k - 1]));
             } else {
                 *d2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] *
                         (c2 * (bj1[k - 1] * dy2[k + 1] - bj1[k + 1] * dy2[k - 1]) -

--- a/include/xsf/specfun/specfun.h
+++ b/include/xsf/specfun/specfun.h
@@ -4814,16 +4814,18 @@ namespace specfun {
         w1 = 0.0;
         w2 = 0.0;
 
-	T sign_kd = (kd % 2 == 0) ? static_cast<T>(1) : static_cast<T>(-1);
+        T sign_kd = (kd % 2 == 0) ? static_cast<T>(1) : static_cast<T>(-1);
         if (kc != 2) {
             *f1r = 0.0;
             for (k = 1; k <= km; k++) {
                 if (kd == 1) {
                     *f1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * bj1[k - 1] * bj2[k - 1];
                 } else if (kd == 2 || kd == 3) {
-                    *f1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * bj2[k] + sign_kd * bj1[k] * bj2[k - 1]);
+                    *f1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] *
+                            (bj1[k - 1] * bj2[k] + sign_kd * bj1[k] * bj2[k - 1]);
                 } else {
-                    *f1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * bj2[k + 1] - bj1[k + 1] * bj2[k - 1]);
+                    *f1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] *
+                            (bj1[k - 1] * bj2[k + 1] - bj1[k + 1] * bj2[k - 1]);
                 }
 
                 if (k >= 5 && fabs(*f1r - w1) < fabs(*f1r) * eps) {
@@ -4837,7 +4839,8 @@ namespace specfun {
             *d1r = 0.0;
             for (k = 1; k <= km; k++) {
                 if (kd == 1) {
-                    *d1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (c2 * bj1[k - 1] * dj2[k - 1] - c1 * dj1[k - 1] * bj2[k - 1]);
+                    *d1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] *
+                            (c2 * bj1[k - 1] * dj2[k - 1] - c1 * dj1[k - 1] * bj2[k - 1]);
                 } else if (kd == 2 || kd == 3) {
                     *d1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] *
                             (c2 * (bj1[k - 1] * dj2[k] + sign_kd * bj1[k] * dj2[k - 1]) -
@@ -4864,9 +4867,11 @@ namespace specfun {
             if (kd == 1) {
                 *f2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * bj1[k - 1] * by2[k - 1];
             } else if (kd == 2 || kd == 3) {
-                *f2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * by2[k] + sign_kd * bj1[k] * by2[k - 1]);
+                *f2r +=
+                    pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * by2[k] + sign_kd * bj1[k] * by2[k - 1]);
             } else {
-                *f2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * by2[k + 1] - bj1[k + 1] * by2[k - 1]);
+                *f2r +=
+                    pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * by2[k + 1] - bj1[k + 1] * by2[k - 1]);
             }
 
             if (k >= 5 && fabs(*f2r - w1) < fabs(*f2r) * eps) {
@@ -4879,7 +4884,8 @@ namespace specfun {
         *d2r = 0.0;
         for (k = 1; k <= km; k++) {
             if (kd == 1) {
-                *d2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (c2 * bj1[k - 1] * dy2[k - 1] - c1 * dj1[k - 1] * by2[k - 1]);
+                *d2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] *
+                        (c2 * bj1[k - 1] * dy2[k - 1] - c1 * dj1[k - 1] * by2[k - 1]);
             } else if (kd == 2 || kd == 3) {
                 *d2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] *
                         (c2 * (bj1[k - 1] * dy2[k] + sign_kd * bj1[k] * dy2[k - 1]) -

--- a/include/xsf/specfun/specfun.h
+++ b/include/xsf/specfun/specfun.h
@@ -204,7 +204,7 @@ namespace specfun {
             d1 = -2.0 * a0 * pow(x, ip + 1.0);
             su2 = ck[1];
             for (k = 2; k <= nm2; k++) {
-                r = k * ck[k] * pow(x1, (k - 1.0));
+                r = static_cast<T>(k) * ck[k] * pow(x1, (k - 1.0));
                 su2 += r;
                 if ((k >= 10) && (fabs(r / su2) < eps)) {
                     break;
@@ -2813,7 +2813,7 @@ namespace specfun {
             gw = gf0;
         }
 
-        *gf = xm * gf0 * pow(x, 1 - ip);
+        *gf = xm * gf0 * pow(x, static_cast<T>(1) - static_cast<T>(ip));
         gd1 = -m * x / (1.0 + x * x) * (*gf);
         gd0 = 0.0;
 
@@ -4820,9 +4820,9 @@ namespace specfun {
                 if (kd == 1) {
                     *f1r += pow(-1, ic + k) * fg[k - 1] * bj1[k - 1] * bj2[k - 1];
                 } else if (kd == 2 || kd == 3) {
-                    *f1r += pow(-1, ic + k) * fg[k - 1] * (bj1[k - 1] * bj2[k] + pow(-1, kd) * bj1[k] * bj2[k - 1]);
+                    *f1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * bj2[k] + pow(static_cast<T>(-1), kd) * bj1[k] * bj2[k - 1]);
                 } else {
-                    *f1r += pow(-1, ic + k) * fg[k - 1] * (bj1[k - 1] * bj2[k + 1] - bj1[k + 1] * bj2[k - 1]);
+                    *f1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * bj2[k + 1] - bj1[k + 1] * bj2[k - 1]);
                 }
 
                 if (k >= 5 && fabs(*f1r - w1) < fabs(*f1r) * eps) {
@@ -4836,13 +4836,13 @@ namespace specfun {
             *d1r = 0.0;
             for (k = 1; k <= km; k++) {
                 if (kd == 1) {
-                    *d1r += pow(-1, ic + k) * fg[k - 1] * (c2 * bj1[k - 1] * dj2[k - 1] - c1 * dj1[k - 1] * bj2[k - 1]);
+                    *d1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (c2 * bj1[k - 1] * dj2[k - 1] - c1 * dj1[k - 1] * bj2[k - 1]);
                 } else if (kd == 2 || kd == 3) {
-                    *d1r += pow(-1, ic + k) * fg[k - 1] *
-                            (c2 * (bj1[k - 1] * dj2[k] + pow(-1, kd) * bj1[k] * dj2[k - 1]) -
-                             c1 * (dj1[k - 1] * bj2[k] + pow(-1, kd) * dj1[k] * bj2[k - 1]));
+                    *d1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] *
+                            (c2 * (bj1[k - 1] * dj2[k] + pow(static_cast<T>(-1), kd) * bj1[k] * dj2[k - 1]) -
+                             c1 * (dj1[k - 1] * bj2[k] + pow(static_cast<T>(-1), kd) * dj1[k] * bj2[k - 1]));
                 } else {
-                    *d1r += pow(-1, ic + k) * fg[k - 1] *
+                    *d1r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] *
                             (c2 * (bj1[k - 1] * dj2[k + 1] - bj1[k + 1] * dj2[k - 1]) -
                              c1 * (dj1[k - 1] * bj2[k + 1] - dj1[k + 1] * bj2[k - 1]));
                 }
@@ -4861,11 +4861,11 @@ namespace specfun {
         *f2r = 0.0;
         for (k = 1; k <= km; k++) {
             if (kd == 1) {
-                *f2r += pow(-1, ic + k) * fg[k - 1] * bj1[k - 1] * by2[k - 1];
+                *f2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * bj1[k - 1] * by2[k - 1];
             } else if (kd == 2 || kd == 3) {
-                *f2r += pow(-1, ic + k) * fg[k - 1] * (bj1[k - 1] * by2[k] + pow(-1, kd) * bj1[k] * by2[k - 1]);
+                *f2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * by2[k] + pow(static_cast<T>(-1), kd) * bj1[k] * by2[k - 1]);
             } else {
-                *f2r += pow(-1, ic + k) * fg[k - 1] * (bj1[k - 1] * by2[k + 1] - bj1[k + 1] * by2[k - 1]);
+                *f2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (bj1[k - 1] * by2[k + 1] - bj1[k + 1] * by2[k - 1]);
             }
 
             if (k >= 5 && fabs(*f2r - w1) < fabs(*f2r) * eps) {
@@ -4878,13 +4878,13 @@ namespace specfun {
         *d2r = 0.0;
         for (k = 1; k <= km; k++) {
             if (kd == 1) {
-                *d2r += pow(-1, ic + k) * fg[k - 1] * (c2 * bj1[k - 1] * dy2[k - 1] - c1 * dj1[k - 1] * by2[k - 1]);
+                *d2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] * (c2 * bj1[k - 1] * dy2[k - 1] - c1 * dj1[k - 1] * by2[k - 1]);
             } else if (kd == 2 || kd == 3) {
-                *d2r += pow(-1, ic + k) * fg[k - 1] *
-                        (c2 * (bj1[k - 1] * dy2[k] + pow(-1, kd) * bj1[k] * dy2[k - 1]) -
-                         c1 * (dj1[k - 1] * by2[k] + pow(-1, kd) * dj1[k] * by2[k - 1]));
+                *d2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] *
+                        (c2 * (bj1[k - 1] * dy2[k] + pow(static_cast<T>(-1), kd) * bj1[k] * dy2[k - 1]) -
+                         c1 * (dj1[k - 1] * by2[k] + pow(static_cast<T>(-1), kd) * dj1[k] * by2[k - 1]));
             } else {
-                *d2r += pow(-1, ic + k) * fg[k - 1] *
+                *d2r += pow(static_cast<T>(-1), ic + k) * fg[k - 1] *
                         (c2 * (bj1[k - 1] * dy2[k + 1] - bj1[k + 1] * dy2[k - 1]) -
                          c1 * (dj1[k - 1] * by2[k + 1] - dj1[k + 1] * by2[k - 1]));
             }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Closes codeql alerts for xsf

#### What does this implement/fix?
The potential integer overflow codeql alerts for this repo.  

#### Additional information
Addresses xsf alerts in https://github.com/scipy/scipy/issues/25260

I also hoisted out the `sign_kd` calculation because `kd` is an unchanging variable in the for loops. 
 
#### AI Generation Disclosure
Consulted an ai to implement fixes. All code written by human and I also ran `pixi run tests` and they pass. 