### PR TITLE
MAINT: Use correct name for bivariate normal survival function

### DIFF
--- a/include/xsf/stats.h
+++ b/include/xsf/stats.h
@@ -269,8 +269,8 @@ inline std::complex<float> log_ndtr(std::complex<float> z) {
 
 inline double nbdtr(int k, int n, double p) { return cephes::nbdtr(k, n, p); }
 
-XSF_HOST_DEVICE inline bool bivariate_normal_cdf_boundary(double dh, double dk, double r, double &p) {
-    // Handles degenerate cases for bivariate_normal_cdf (infinite arguments or zero correlation).
+XSF_HOST_DEVICE inline bool bivariate_normal_sf_boundary(double dh, double dk, double r, double &p) {
+    // Handles degenerate cases for bivariate_normal_sf (infinite arguments or zero correlation).
     // Returns true and sets p if a boundary case applies, false otherwise.
 
     const double math_inf = std::numeric_limits<double>::infinity();
@@ -312,19 +312,21 @@ constexpr double bvn_x20[10] = {0.9931285991850949, 0.9639719272779138, 0.912234
                                 0.7463319064601508, 0.6360536807265150, 0.5108670019508271, 0.3737060887154196,
                                 0.2277858511416451, 0.07652652113349733};
 
-XSF_HOST_DEVICE inline double bivariate_normal_cdf(double dh, double dk, double r) {
-    // CDF of the bivariate normal distribution with zero means, unit variances,
-    // and correlation r, evaluated at (dh, dk).
+XSF_HOST_DEVICE inline double bivariate_normal_sf(double dh, double dk, double r) {
+    // Survival function of the standard bivariate normal distribution.
     //
-    // dh, dk: the values at which to evaluate the CDF
-    // r: the correlation coefficient, must be in [-1, 1]
+    // Return P(X > dh, Y > dk) for a standard bivariate normal vector 
+    // (X, Y) with correlation r.
+    //
+    // dh, dk are the lower limits of the upper tail, and r must satisfy
+    // -1 <= r <= 1.
     //
     // Adapted from the MATLAB original implementation by Dr. Alan Genz;
     // see license information in _qmvnt.py
     // In the comments, phid is the CDF of the standard normal distribution.
 
     double p;
-    if (bivariate_normal_cdf_boundary(dh, dk, r, p)) {
+    if (bivariate_normal_sf_boundary(dh, dk, r, p)) {
         return p;
     }
     // else, tp = 2*pi; h = dh; k = dk; hk = h*k; bvn = 0;

--- a/include/xsf/stats.h
+++ b/include/xsf/stats.h
@@ -315,7 +315,7 @@ constexpr double bvn_x20[10] = {0.9931285991850949, 0.9639719272779138, 0.912234
 XSF_HOST_DEVICE inline double bivariate_normal_sf(double dh, double dk, double r) {
     // Survival function of the standard bivariate normal distribution.
     //
-    // Return P(X > dh, Y > dk) for a standard bivariate normal vector 
+    // Return P(X > dh, Y > dk) for a standard bivariate normal vector
     // (X, Y) with correlation r.
     //
     // dh, dk are the lower limits of the upper tail, and r must satisfy

--- a/tests/xsf_tests/test_bivariate_normal_sf.cpp
+++ b/tests/xsf_tests/test_bivariate_normal_sf.cpp
@@ -1,9 +1,9 @@
 #include "../testing_utils.h"
 #include <xsf/stats.h>
 
-TEST_CASE("bivariate normal CDF test", "[bivariate_normal_cdf][xsf_tests]") {
+TEST_CASE("bivariate normal SF test", "[bivariate_normal_sf][xsf_tests]") {
 
-    SECTION("bivariate normal CDF infinite inputs") {
+    SECTION("bivariate normal SF infinite inputs") {
         // test cases with infinite inputs
         using test_case = std::tuple<double, double, double, double, double>;
         auto [dh, dk, r, expected, rtol] = GENERATE(
@@ -14,31 +14,31 @@ TEST_CASE("bivariate normal CDF test", "[bivariate_normal_cdf][xsf_tests]") {
             test_case{-std::numeric_limits<double>::infinity(), 1.0, 0.5, xsf::ndtr(-1.0), 1e-13},
             test_case{1.0, -std::numeric_limits<double>::infinity(), 0.5, xsf::ndtr(-1.0), 1e-13}
         );
-        const double output = xsf::bivariate_normal_cdf(dh, dk, r);
+        const double output = xsf::bivariate_normal_sf(dh, dk, r);
         const auto rel_error = xsf::extended_relative_error(output, expected);
         CAPTURE(dh, dk, r, output, expected, rtol, rel_error);
         REQUIRE(rel_error <= rtol);
     }
 
-    SECTION("bivariate normal CDF analytical dh=0, dk=0") {
-        // bivariate_normal_cdf(0, 0, r) = 0.25 + asin(r)/(2*pi)
+    SECTION("bivariate normal SF analytical dh=0, dk=0") {
+        // bivariate_normal_sf(0, 0, r) = 0.25 + asin(r)/(2*pi)
         double dh = 0.0;
         double dk = 0.0;
         double r = GENERATE(-1.0, -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0);
         double expected = 0.25 + std::asin(r) / (2 * M_PI);
-        const double output = xsf::bivariate_normal_cdf(dh, dk, r);
+        const double output = xsf::bivariate_normal_sf(dh, dk, r);
         const auto rel_error = xsf::extended_relative_error(output, expected);
         double rtol = 1e-13;
         CAPTURE(dh, dk, r, output, expected, rtol, rel_error);
         REQUIRE(rel_error <= rtol);
     }
 
-    SECTION("bivariate normal CDF r=0 independence") {
-        // bivariate_normal_cdf(h, k, 0) = ndtr(-h) * ndtr(-dk)
+    SECTION("bivariate normal SF r=0 independence") {
+        // bivariate_normal_sf(h, k, 0) = ndtr(-h) * ndtr(-dk)
         double dh = GENERATE(-1.0, 0.0, 1.0, 2.0);
         double dk = GENERATE(-1.0, 0.0, 1.0, 2.0);
         double r = 0.0;
-        const double output = xsf::bivariate_normal_cdf(dh, dk, r);
+        const double output = xsf::bivariate_normal_sf(dh, dk, r);
         const double expected = xsf::ndtr(-dh) * xsf::ndtr(-dk);
         const auto rel_error = xsf::extended_relative_error(output, expected);
         double rtol = 1e-13;
@@ -46,7 +46,7 @@ TEST_CASE("bivariate normal CDF test", "[bivariate_normal_cdf][xsf_tests]") {
         REQUIRE(rel_error <= rtol);
     }
 
-    SECTION("bivariate normal CDF scipy reference values") {
+    SECTION("bivariate normal SF scipy reference values") {
         // Reference values computed with scipy.stats._stats_pythran._bvnu using:
         //
         // import numpy as np
@@ -157,7 +157,7 @@ TEST_CASE("bivariate normal CDF test", "[bivariate_normal_cdf][xsf_tests]") {
 
         constexpr double rtol = 1e-10;
         constexpr double atol = 1e-10;
-        const double output = xsf::bivariate_normal_cdf(dh, dk, r);
+        const double output = xsf::bivariate_normal_sf(dh, dk, r);
         CAPTURE(dh, dk, r, output, expected, rtol, atol);
         CHECK(output >= 0.0);
         CHECK(output <= 1.0);
@@ -168,17 +168,17 @@ TEST_CASE("bivariate normal CDF test", "[bivariate_normal_cdf][xsf_tests]") {
         }
     }
 
-    SECTION("bivariate normal CDF symmetry h,k") {
-        // bivariate_normal_cdf(h, k, r) == bivariate_normal_cdf(k, h, r)
-        REQUIRE(xsf::bivariate_normal_cdf(1.0, 2.0, 0.5) == xsf::bivariate_normal_cdf(2.0, 1.0, 0.5));
+    SECTION("bivariate normal SF symmetry h,k") {
+        // bivariate_normal_sf(h, k, r) == bivariate_normal_sf(k, h, r)
+        REQUIRE(xsf::bivariate_normal_sf(1.0, 2.0, 0.5) == xsf::bivariate_normal_sf(2.0, 1.0, 0.5));
     }
 
-    SECTION("bivariate normal CDF complementarity") {
-        // bivariate_normal_cdf(h, k, r) + bivariate_normal_cdf(h, -k, -r) == ndtr(-h)
+    SECTION("bivariate normal SF complementarity") {
+        // bivariate_normal_sf(h, k, r) + bivariate_normal_sf(h, -k, -r) == ndtr(-h)
         double dh = GENERATE(-1.0, 0.0, 1.0, 2.0);
         double dk = GENERATE(-1.0, 0.0, 1.0, 2.0);
         double r = GENERATE(-1.0, -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0);
-        double output = xsf::bivariate_normal_cdf(dh, dk, r) + xsf::bivariate_normal_cdf(dh, -dk, -r);
+        double output = xsf::bivariate_normal_sf(dh, dk, r) + xsf::bivariate_normal_sf(dh, -dk, -r);
         double expected = xsf::ndtr(-dh);
         const auto rel_error = xsf::extended_relative_error(output, expected);
         double rtol = 1e-13;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
While working on translating the MATLAB code for the trivariate normal distribution on https://github.com/scipy/xsf/issues/98, I noticed that the name `bivariate_normal_cdf` in https://github.com/scipy/xsf/pull/112 is incorrect. This is really the survival function as it computes $P(X > dh, Y>dk)$.

I have renamed everything to `bivariate_normal_sf` and updated the documentation. 

If we agree with the changes, I will follow up with a SciPy PR.

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.