### PR TITLE
ENH: add `convex_analysis` functions to XSF

### DIFF
--- a/include/xsf/convex_analysis.h
+++ b/include/xsf/convex_analysis.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <cmath>
-#include <limits>
-
 #include "config.h"
 
 namespace xsf {

--- a/include/xsf/convex_analysis.h
+++ b/include/xsf/convex_analysis.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <cmath>
+#include <limits>
+
+#include "config.h"
+
+namespace xsf {
+
+// Elementwise function for computing entropy.
+XSF_HOST_DEVICE inline double entr(double x) {
+    if (std::isnan(x)) {
+        return x;
+    } else if (x > 0) {
+        return -x * std::log(x);
+    } else if (x == 0) {
+        return 0;
+    } else {
+        return -std::numeric_limits<double>::infinity();
+    }
+}
+
+// Elementwise function for computing Kullback-Leibler divergence.
+XSF_HOST_DEVICE inline double kl_div(double x, double y) {
+    if (std::isnan(x) || std::isnan(y)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    } else if (x > 0 && y > 0) {
+        return x * std::log(x / y) - x + y;
+    } else if (x == 0 && y >= 0) {
+        return y;
+    } else {
+        return std::numeric_limits<double>::infinity();
+    }
+}
+
+// Elementwise function for computing relative entropy.
+XSF_HOST_DEVICE inline double rel_entr(double x, double y) {
+    if (std::isnan(x) || std::isnan(y)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    if (x <= 0 || y <= 0) {
+        if (x == 0 && y >= 0) {
+            return 0;
+        }
+        return std::numeric_limits<double>::infinity();
+    }
+
+    double ratio = x / y;
+    if (0.5 < ratio && ratio < 2) {
+        // When x and y are close, this is more accurate
+        return x * std::log1p((x - y) / y);
+    }
+    if (std::numeric_limits<double>::min() < ratio && ratio < std::numeric_limits<double>::infinity()) {
+        // There are no underflow/overflow issues
+        return x * std::log(ratio);
+    }
+    // x and y are so far apart that taking x / y
+    // results in either an underflow, overflow,
+    // or subnormal number. Do the logarithm first
+    return x * (std::log(x) - std::log(y));
+}
+
+// Huber loss function.
+XSF_HOST_DEVICE inline double huber(double delta, double r) {
+    if (delta < 0) {
+        return std::numeric_limits<double>::infinity();
+    } else if (std::fabs(r) <= delta) {
+        return 0.5 * r * r;
+    } else {
+        return delta * (std::fabs(r) - 0.5 * delta);
+    }
+}
+
+// Pseudo-Huber loss function.
+XSF_HOST_DEVICE inline double pseudo_huber(double delta, double r) {
+    if (delta < 0) {
+        return std::numeric_limits<double>::infinity();
+    } else if (delta == 0 || r == 0) {
+        return 0;
+    } else {
+        double u = delta;
+        double v = r / delta;
+        // The formula is u*u*(sqrt(1 + v*v) - 1), but to maintain
+        // precision with small v, we use
+        //   sqrt(1 + v*v) - 1  =  exp(0.5*log(1 + v*v)) - 1
+        //                      =  expm1(0.5*log1p(v*v))
+        return u * u * std::expm1(0.5 * std::log1p(v * v));
+    }
+}
+
+} // namespace xsf

--- a/tests/xsf_tests/test_convex_analysis.cpp
+++ b/tests/xsf_tests/test_convex_analysis.cpp
@@ -136,8 +136,7 @@ TEST_CASE("huber", "[huber][xsf_tests]") {
     REQUIRE(xsf::extended_absolute_error(xsf::huber(2, 2.5), 2 * (2.5 - 0.5 * 2)) <= abs_tol);
 
     const std::vector<std::tuple<double, double>> cases = {
-        {-1.25, 0.5}, {0, 1}, {0.25, -0.1}, {0.25, -0.25}, {0.25, -0.5},
-        {1, 0.5},    {1, 1},  {1, 2},       {3, -4},       {5, 4},
+        {-1.25, 0.5}, {0, 1}, {0.25, -0.1}, {0.25, -0.25}, {0.25, -0.5}, {1, 0.5}, {1, 1}, {1, 2}, {3, -4}, {5, 4},
     };
 
     for (auto [delta, r] : cases) {

--- a/tests/xsf_tests/test_convex_analysis.cpp
+++ b/tests/xsf_tests/test_convex_analysis.cpp
@@ -1,0 +1,195 @@
+#include "../testing_utils.h"
+
+#include <xsf/convex_analysis.h>
+
+namespace {
+
+constexpr double rtol = 1e-13;
+constexpr double abs_tol = 1e-13;
+
+} // namespace
+
+TEST_CASE("entr", "[entr][xsf_tests]") {
+    // Mirrors https://github.com/scipy/scipy/blob/v1.18.0rc1/scipy/special/tests/test_basic.py#L4563
+    const std::vector<double> values = {0, 0.5, 1.0, std::numeric_limits<double>::infinity()};
+    const std::vector<double> signs = {-1, 1};
+
+    for (double sign : signs) {
+        for (double value : values) {
+            double x = sign * value;
+            double desired;
+            if (x < 0) {
+                desired = -std::numeric_limits<double>::infinity();
+            } else if (x == 0) {
+                desired = 0;
+            } else {
+                desired = -x * std::log(x);
+            }
+
+            auto out = xsf::entr(x);
+            auto abs_error = xsf::extended_absolute_error(out, desired);
+            auto rel_error = xsf::extended_relative_error(out, desired);
+            CAPTURE(x, out, desired, abs_error, rel_error, abs_tol, rtol);
+            REQUIRE((abs_error <= abs_tol || rel_error <= rtol));
+        }
+    }
+}
+
+TEST_CASE("kl_div", "[kl_div][xsf_tests]") {
+    // Mirrors https://github.com/scipy/scipy/blob/v1.18.0rc1/scipy/special/tests/test_basic.py#L4579
+    const std::vector<double> values = {0, 0.5, 1.0};
+    const std::vector<double> signs = {-1, 1};
+
+    for (double sgna : signs) {
+        for (double va : values) {
+            for (double sgnb : signs) {
+                for (double vb : values) {
+                    double x = sgna * va;
+                    double y = sgnb * vb;
+                    double desired;
+                    if (x < 0 || y < 0 || (y == 0 && x != 0)) {
+                        desired = std::numeric_limits<double>::infinity();
+                    } else if ((std::isinf(x) && x > 0) || (std::isinf(y) && y > 0)) {
+                        desired = std::numeric_limits<double>::infinity();
+                    } else if (x == 0) {
+                        desired = y;
+                    } else {
+                        desired = x * std::log(x / y) - x + y;
+                    }
+                    auto out = xsf::kl_div(x, y);
+                    auto abs_error = xsf::extended_absolute_error(out, desired);
+                    auto rel_error = xsf::extended_relative_error(out, desired);
+                    CAPTURE(x, y, out, desired, abs_error, rel_error, abs_tol, rtol);
+                    REQUIRE((abs_error <= abs_tol || rel_error <= rtol));
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("rel_entr", "[rel_entr][xsf_tests]") {
+    // Mirrors https://github.com/scipy/scipy/blob/v1.18.0rc1/scipy/special/tests/test_basic.py#L4601
+    const std::vector<double> values = {0, 0.5, 1.0};
+    const std::vector<double> signs = {-1, 1};
+
+    for (double sgna : signs) {
+        for (double va : values) {
+            for (double sgnb : signs) {
+                for (double vb : values) {
+                    double x = sgna * va;
+                    double y = sgnb * vb;
+                    double desired;
+                    if (x > 0 && y > 0) {
+                        desired = x * std::log(x / y);
+                    } else if (x == 0 && y >= 0) {
+                        desired = 0;
+                    } else {
+                        desired = std::numeric_limits<double>::infinity();
+                    }
+                    auto out = xsf::rel_entr(x, y);
+                    auto abs_error = xsf::extended_absolute_error(out, desired);
+                    auto rel_error = xsf::extended_relative_error(out, desired);
+                    CAPTURE(x, y, out, desired, abs_error, rel_error, abs_tol, rtol);
+                    REQUIRE((abs_error <= abs_tol || rel_error <= rtol));
+                }
+            }
+        }
+    }
+}
+
+TEST_CASE("rel_entr gh-20710 near zero", "[rel_entr][xsf_tests]") {
+    // Mirrors https://github.com/scipy/scipy/blob/v1.18.0rc1/scipy/special/tests/test_basic.py#L4619
+    const std::vector<std::tuple<double, double, double>> cases = {
+        {0.9456657713430001, 0.9456657713430094, -9.325873406851269e-15},
+        {0.48066098564791515, 0.48066098564794774, -3.258504577274724e-14},
+        {0.786048657854401, 0.7860486578542367, 1.6431300764454033e-13},
+    };
+
+    for (auto [x, y, desired] : cases) {
+        auto out = xsf::rel_entr(x, y);
+        auto rel_error = xsf::extended_relative_error(out, desired);
+        CAPTURE(x, y, out, desired, rel_error, rtol);
+        REQUIRE(rel_error <= rtol);
+    }
+}
+
+TEST_CASE("rel_entr gh-20710 overflow", "[rel_entr][xsf_tests]") {
+    // Mirrors https://github.com/scipy/scipy/blob/v1.18.0rc1/scipy/special/tests/test_basic.py#L4638
+    const std::vector<std::tuple<double, double, double>> cases = {
+        {4, 2.22e-308, 2839.139983229607},
+        {1e-200, 1e+200, -9.210340371976183e-198},
+        {2.22e-308, 1e15, -1.6493212008074475e-305},
+    };
+
+    for (auto [x, y, desired] : cases) {
+        auto out = xsf::rel_entr(x, y);
+        auto rel_error = xsf::extended_relative_error(out, desired);
+        CAPTURE(x, y, out, desired, rel_error, rtol);
+        REQUIRE(rel_error <= rtol);
+    }
+}
+
+TEST_CASE("huber", "[huber][xsf_tests]") {
+    // Mirrors https://github.com/scipy/scipy/blob/v1.18.0rc1/scipy/special/tests/test_basic.py#L4660
+    REQUIRE(xsf::huber(-1, 1.5) == std::numeric_limits<double>::infinity());
+    REQUIRE(xsf::extended_absolute_error(xsf::huber(2, 1.5), 0.5 * 1.5 * 1.5) <= abs_tol);
+    REQUIRE(xsf::extended_absolute_error(xsf::huber(2, 2.5), 2 * (2.5 - 0.5 * 2)) <= abs_tol);
+
+    const std::vector<std::tuple<double, double>> cases = {
+        {-1.25, 0.5}, {0, 1}, {0.25, -0.1}, {0.25, -0.25}, {0.25, -0.5},
+        {1, 0.5},    {1, 1},  {1, 2},       {3, -4},       {5, 4},
+    };
+
+    for (auto [delta, r] : cases) {
+        double desired;
+        if (delta < 0) {
+            desired = std::numeric_limits<double>::infinity();
+        } else if (std::abs(r) < delta) {
+            desired = 0.5 * r * r;
+        } else {
+            desired = delta * (std::abs(r) - 0.5 * delta);
+        }
+        auto out = xsf::huber(delta, r);
+        auto abs_error = xsf::extended_absolute_error(out, desired);
+        auto rel_error = xsf::extended_relative_error(out, desired);
+        CAPTURE(delta, r, out, desired, abs_error, rel_error, abs_tol, rtol);
+        REQUIRE((abs_error <= abs_tol || rel_error <= rtol));
+    }
+}
+
+TEST_CASE("pseudo_huber", "[pseudo_huber][xsf_tests]") {
+    // Mirrors https://github.com/scipy/scipy/blob/v1.18.0rc1/scipy/special/tests/test_basic.py#L4678
+    auto deltas = linspace(-5.0, 5.0, 11);
+    auto residuals = linspace(-5.0, 5.0, 11);
+    std::vector<std::tuple<double, double>> cases(deltas.size());
+    for (std::size_t i = 0; i < deltas.size(); ++i) {
+        cases[i] = {deltas[i], residuals[i]};
+    }
+    cases.push_back({0, 0.5});
+    cases.push_back({0.5, 0});
+
+    for (auto [delta, r] : cases) {
+        double desired;
+        if (delta < 0) {
+            desired = std::numeric_limits<double>::infinity();
+        } else if (!delta || !r) {
+            desired = 0;
+        } else {
+            desired = delta * delta * (std::sqrt(1 + (r / delta) * (r / delta)) - 1);
+        }
+        auto out = xsf::pseudo_huber(delta, r);
+        auto abs_error = xsf::extended_absolute_error(out, desired);
+        auto rel_error = xsf::extended_relative_error(out, desired);
+        CAPTURE(delta, r, out, desired, abs_error, rel_error, abs_tol, rtol);
+        REQUIRE((abs_error <= abs_tol || rel_error <= rtol));
+    }
+}
+
+TEST_CASE("pseudo_huber small r", "[pseudo_huber][xsf_tests]") {
+    // Mirrors https://github.com/scipy/scipy/blob/v1.18.0rc1/scipy/special/tests/test_basic.py#L4692
+    auto out = xsf::pseudo_huber(1.0, 1e-18);
+    auto desired = 5.0000000000000005e-37;
+    auto rel_error = xsf::extended_relative_error(out, desired);
+    CAPTURE(out, desired, rel_error, rtol);
+    REQUIRE(rel_error <= rtol);
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
https://github.com/scipy/xsf/issues/170

#### What does this implement/fix?
- Port [_convex_analysis.pxd](https://github.com/scipy/scipy/blob/main/scipy/special/_convex_analysis.pxd) to xsf
- Tests are direct translation of SciPy tests except for `pseudo_huber` which uses random values

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Tests were translated by Codex. I manually added the links and few things for pseudo_huber. The rest is me. I've kept the comments.