### PR TITLE
ENH: add `agm` to XSF

### DIFF
--- a/include/xsf/agm.h
+++ b/include/xsf/agm.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <cmath>
+#include <limits>
+
+#include "cephes/ellpk.h"
+#include "config.h"
+
+namespace xsf {
+
+namespace detail {
+
+    XSF_HOST_DEVICE inline double agm_iter(double a, double b) {
+        // Arithmetic-geometric mean, iterative implementation
+        // a and b must be positive (not zero, not nan).
+        double amean = 0.5 * a + 0.5 * b;
+        int count = 20;
+        while (count > 0 && (amean != a && amean != b)) {
+            double gmean = std::sqrt(a) * std::sqrt(b);
+            a = amean;
+            b = gmean;
+            amean = 0.5 * a + 0.5 * b;
+            count -= 1;
+        }
+        return amean;
+    }
+
+} // namespace detail
+
+// Arithmetic-geometric mean.
+XSF_HOST_DEVICE inline double agm(double a, double b) {
+    // sqrthalfmax is std::sqrt(std::numeric_limits<double>::max() / 2)
+    // invsqrthalfmax is 1/sqrthalfmax
+    constexpr double sqrthalfmax = 9.480751908109176e+153;
+    constexpr double invsqrthalfmax = 1.0547686614863e-154;
+
+    if (std::isnan(a) || std::isnan(b)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+
+    if ((a < 0 && b > 0) || (a > 0 && b < 0)) {
+        // a and b have opposite sign.
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+
+    if ((std::isinf(a) || std::isinf(b)) && (a == 0 || b == 0)) {
+        // One value is inf and the other is 0.
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+
+    if (a == 0 || b == 0) {
+        // At least one of the arguments is 0.
+        return 0.0;
+    }
+
+    if (a == b) {
+        return a;
+    }
+
+    int sgn = 1;
+    if (a < 0) {
+        sgn = -1;
+        a = -a;
+        b = -b;
+    }
+
+    // At this point, a and b are both positive and not nan.
+
+    if ((invsqrthalfmax < a && a < sqrthalfmax) && (invsqrthalfmax < b && b < sqrthalfmax)) {
+        double e = 4 * a * b / ((a + b) * (a + b));
+        return sgn * (M_PI / 4) * (a + b) / cephes::ellpk(e);
+    }
+
+    // At least one value is "extreme" (very big or very small).
+    // Use the iteration to avoid overflow or underflow.
+
+    return sgn * detail::agm_iter(a, b);
+}
+
+inline float agm(float a, float b) { return agm(static_cast<double>(a), static_cast<double>(b)); }
+
+} // namespace xsf

--- a/include/xsf/agm.h
+++ b/include/xsf/agm.h
@@ -1,10 +1,7 @@
 #pragma once
 
-#include <cmath>
-#include <limits>
-
-#include "cephes/ellpk.h"
 #include "config.h"
+#include "cephes/ellpk.h"
 
 namespace xsf {
 

--- a/include/xsf/agm.h
+++ b/include/xsf/agm.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "config.h"
 #include "cephes/ellpk.h"
+#include "config.h"
 
 namespace xsf {
 

--- a/tests/xsf_tests/test_agm.cpp
+++ b/tests/xsf_tests/test_agm.cpp
@@ -1,0 +1,76 @@
+#include "../testing_utils.h"
+
+#include <xsf/agm.h>
+
+TEST_CASE("agm simple", "[agm][xsf_tests]") {
+    // Mirrors https://github.com/scipy/scipy/blob/v1.18.0rc1/scipy/special/tests/test_basic.py#L4444-L4455
+    const double rtol = 1e-13;
+
+    const auto gauss_constant = 1 / xsf::agm(1, std::sqrt(2));
+    const auto gauss_constant_expected = 0.834626841674073186;
+    const auto gauss_constant_rel_error = xsf::extended_relative_error(gauss_constant, gauss_constant_expected);
+    CAPTURE(gauss_constant, gauss_constant_expected, rtol, gauss_constant_rel_error);
+    REQUIRE(gauss_constant_rel_error <= rtol);
+
+    using test_case = std::tuple<double, double, double>;
+    auto [a_wolfram, b_wolfram, expected_wolfram] = GENERATE(
+        test_case{1, 1, 1}, test_case{1, 3, 1.863616783244897}, test_case{1, 5, 2.604008190530940},
+        test_case{3, 1, 1.863616783244897}, test_case{3, 3, 3}, test_case{3, 5, 3.936235503649555}
+    );
+
+    const auto output_wolfram = xsf::agm(a_wolfram, b_wolfram);
+    const auto rel_error_wolfram = xsf::extended_relative_error(output_wolfram, expected_wolfram);
+    CAPTURE(a_wolfram, b_wolfram, output_wolfram, expected_wolfram, rtol, rel_error_wolfram);
+    REQUIRE(rel_error_wolfram <= rtol);
+}
+
+TEST_CASE("agm finite cases", "[agm][xsf_tests]") {
+    // Mirrors https://github.com/scipy/scipy/blob/v1.18.0rc1/scipy/special/tests/test_basic.py#L4457-L4480
+    const double rtol = 1e-13;
+    using test_case = std::tuple<double, double, double>;
+    auto [a, b, expected] = GENERATE(
+        test_case{1, 2, 1.4567910310469068}, test_case{2, 1, 1.4567910310469068},
+        test_case{-1, -2, -1.4567910310469068},
+        test_case{24, 6, 13.458171481725614}, test_case{13, 123456789.5, 11111458.498599306},
+        test_case{1e30, 1, 2.229223055945383e+28}, test_case{1e-22, 1, 0.030182566420169886},
+        test_case{1e150, 1e180, 2.229223055945383e+178},
+        test_case{1e180, 1e-150, 2.0634722510162677e+177},
+        test_case{1e-150, 1e-170, 3.3112619670463756e-152},
+        test_case{std::numeric_limits<double>::min(), std::numeric_limits<double>::max(), 1.9892072050015473e+305},
+        test_case{
+            0.75 * std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), 1.564904312298045e+308
+        },
+        test_case{
+            std::numeric_limits<double>::min(), 3 * std::numeric_limits<double>::min(), 4.1466849866735005e-308
+        }
+    );
+
+    const auto output = xsf::agm(a, b);
+    const auto rel_error = xsf::extended_relative_error(output, expected);
+    CAPTURE(a, b, output, expected, rtol, rel_error);
+    REQUIRE(rel_error <= rtol);
+}
+
+TEST_CASE("agm zero, nan, and inf cases", "[agm][xsf_tests]") {
+    // Mirrors https://github.com/scipy/scipy/blob/v1.18.0rc1/scipy/special/tests/test_basic.py#L4482-L4499
+    REQUIRE(xsf::agm(0.0, 0.0) == 0);
+    REQUIRE(xsf::agm(99.0, 0.0) == 0);
+
+    const double inf = std::numeric_limits<double>::infinity();
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+
+    REQUIRE(std::isnan(xsf::agm(-1.0, 10.0)));
+    REQUIRE(std::isnan(xsf::agm(0, inf)));
+    REQUIRE(std::isnan(xsf::agm(inf, 0)));
+    REQUIRE(std::isnan(xsf::agm(0, -inf)));
+    REQUIRE(std::isnan(xsf::agm(-inf, 0)));
+    REQUIRE(std::isnan(xsf::agm(inf, -inf)));
+    REQUIRE(std::isnan(xsf::agm(-inf, inf)));
+    REQUIRE(std::isnan(xsf::agm(1, nan)));
+    REQUIRE(std::isnan(xsf::agm(nan, -1)));
+
+    REQUIRE(xsf::agm(1, inf) == inf);
+    REQUIRE(xsf::agm(inf, 1) == inf);
+    REQUIRE(xsf::agm(-1, -inf) == -inf);
+    REQUIRE(xsf::agm(-inf, -1) == -inf);
+}

--- a/tests/xsf_tests/test_agm.cpp
+++ b/tests/xsf_tests/test_agm.cpp
@@ -30,19 +30,15 @@ TEST_CASE("agm finite cases", "[agm][xsf_tests]") {
     using test_case = std::tuple<double, double, double>;
     auto [a, b, expected] = GENERATE(
         test_case{1, 2, 1.4567910310469068}, test_case{2, 1, 1.4567910310469068},
-        test_case{-1, -2, -1.4567910310469068},
-        test_case{24, 6, 13.458171481725614}, test_case{13, 123456789.5, 11111458.498599306},
-        test_case{1e30, 1, 2.229223055945383e+28}, test_case{1e-22, 1, 0.030182566420169886},
-        test_case{1e150, 1e180, 2.229223055945383e+178},
-        test_case{1e180, 1e-150, 2.0634722510162677e+177},
-        test_case{1e-150, 1e-170, 3.3112619670463756e-152},
+        test_case{-1, -2, -1.4567910310469068}, test_case{24, 6, 13.458171481725614},
+        test_case{13, 123456789.5, 11111458.498599306}, test_case{1e30, 1, 2.229223055945383e+28},
+        test_case{1e-22, 1, 0.030182566420169886}, test_case{1e150, 1e180, 2.229223055945383e+178},
+        test_case{1e180, 1e-150, 2.0634722510162677e+177}, test_case{1e-150, 1e-170, 3.3112619670463756e-152},
         test_case{std::numeric_limits<double>::min(), std::numeric_limits<double>::max(), 1.9892072050015473e+305},
         test_case{
             0.75 * std::numeric_limits<double>::max(), std::numeric_limits<double>::max(), 1.564904312298045e+308
         },
-        test_case{
-            std::numeric_limits<double>::min(), 3 * std::numeric_limits<double>::min(), 4.1466849866735005e-308
-        }
+        test_case{std::numeric_limits<double>::min(), 3 * std::numeric_limits<double>::min(), 4.1466849866735005e-308}
     );
 
     const auto output = xsf::agm(a, b);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
https://github.com/scipy/xsf/issues/170

Same pattern as https://github.com/scipy/xsf/pull/171

#### What does this implement/fix?
- Add arithmetic-geometric mean `agm` to XSF.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Tests were translated by Codex. I manually added the links. The rest is mine. I've kept the SciPy comments.