### PR TITLE
MAINT: Add float overloads

### DIFF
--- a/include/xsf/agm.h
+++ b/include/xsf/agm.h
@@ -74,6 +74,6 @@ XSF_HOST_DEVICE inline double agm(double a, double b) {
     return sgn * detail::agm_iter(a, b);
 }
 
-inline float agm(float a, float b) { return agm(static_cast<double>(a), static_cast<double>(b)); }
+XSF_HOST_DEVICE inline float agm(float a, float b) { return agm(static_cast<double>(a), static_cast<double>(b)); }
 
 } // namespace xsf

--- a/include/xsf/convex_analysis.h
+++ b/include/xsf/convex_analysis.h
@@ -32,9 +32,7 @@ XSF_HOST_DEVICE inline double kl_div(double x, double y) {
     }
 }
 
-XSF_HOST_DEVICE inline float kl_div(float x, float y) {
-    return kl_div(static_cast<double>(x), static_cast<double>(y));
-}
+XSF_HOST_DEVICE inline float kl_div(float x, float y) { return kl_div(static_cast<double>(x), static_cast<double>(y)); }
 
 // Elementwise function for computing relative entropy.
 XSF_HOST_DEVICE inline double rel_entr(double x, double y) {

--- a/include/xsf/convex_analysis.h
+++ b/include/xsf/convex_analysis.h
@@ -17,6 +17,8 @@ XSF_HOST_DEVICE inline double entr(double x) {
     }
 }
 
+XSF_HOST_DEVICE inline float entr(float x) { return entr(static_cast<double>(x)); }
+
 // Elementwise function for computing Kullback-Leibler divergence.
 XSF_HOST_DEVICE inline double kl_div(double x, double y) {
     if (std::isnan(x) || std::isnan(y)) {
@@ -28,6 +30,10 @@ XSF_HOST_DEVICE inline double kl_div(double x, double y) {
     } else {
         return std::numeric_limits<double>::infinity();
     }
+}
+
+XSF_HOST_DEVICE inline float kl_div(float x, float y) {
+    return kl_div(static_cast<double>(x), static_cast<double>(y));
 }
 
 // Elementwise function for computing relative entropy.
@@ -57,6 +63,10 @@ XSF_HOST_DEVICE inline double rel_entr(double x, double y) {
     return x * (std::log(x) - std::log(y));
 }
 
+XSF_HOST_DEVICE inline float rel_entr(float x, float y) {
+    return rel_entr(static_cast<double>(x), static_cast<double>(y));
+}
+
 // Huber loss function.
 XSF_HOST_DEVICE inline double huber(double delta, double r) {
     if (delta < 0) {
@@ -66,6 +76,10 @@ XSF_HOST_DEVICE inline double huber(double delta, double r) {
     } else {
         return delta * (std::fabs(r) - 0.5 * delta);
     }
+}
+
+XSF_HOST_DEVICE inline float huber(float delta, float r) {
+    return huber(static_cast<double>(delta), static_cast<double>(r));
 }
 
 // Pseudo-Huber loss function.
@@ -83,6 +97,10 @@ XSF_HOST_DEVICE inline double pseudo_huber(double delta, double r) {
         //                      =  expm1(0.5*log1p(v*v))
         return u * u * std::expm1(0.5 * std::log1p(v * v));
     }
+}
+
+XSF_HOST_DEVICE inline float pseudo_huber(float delta, float r) {
+    return pseudo_huber(static_cast<double>(delta), static_cast<double>(r));
 }
 
 } // namespace xsf

--- a/include/xsf/stats.h
+++ b/include/xsf/stats.h
@@ -441,6 +441,10 @@ XSF_HOST_DEVICE inline double bivariate_normal_sf(double dh, double dk, double r
     return bvn < 0.0 ? 0.0 : (bvn > 1.0 ? 1.0 : bvn);
 }
 
+XSF_HOST_DEVICE inline float bivariate_normal_sf(float dh, float dk, float r) {
+    return bivariate_normal_sf(static_cast<double>(dh), static_cast<double>(dk), static_cast<double>(r));
+}
+
 inline double nbdtrc(int k, int n, double p) { return cephes::nbdtrc(k, n, p); }
 
 inline double nbdtri(int k, int n, double p) { return cephes::nbdtri(k, n, p); }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Needed for https://github.com/scipy/scipy/pull/25311

#### What does this implement/fix?
- Add float overloads for `convex_analysis` functions
- Add missing XSF_HOST_DEVICE for agm
- Add float overload for `bivariate_normal_sf`

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI