### PR TITLE
DEV/MAINT: automate labelling when PR closes

### DIFF
--- a/.github/label-title-on-close.yml
+++ b/.github/label-title-on-close.yml
@@ -1,0 +1,7 @@
+# This file contains regexes for automatically adding labels to PRs which have been merged.
+# for use with https://github.com/github/issue-labeler.
+
+# Add the needs-release-note-decision tag to PRs that typically require a
+# mention in the release notes.
+needs-release-note-decision:
+  - '(ENH|DEP)'

--- a/.github/workflows/label-pr-on-close.yml
+++ b/.github/workflows/label-pr-on-close.yml
@@ -1,0 +1,31 @@
+name: "Label PR on Close"
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  label_pull_request:
+    name: "Label PR on Close"
+    # Permissions needed for labelling Pull Requests automatically
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication
+    permissions:
+      contents: read
+      pull-requests: write  # needed to apply label
+    runs-on: ubuntu-latest
+    steps:
+    - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
+      if: >
+        github.repository == 'scipy/xsf'
+        && github.event.pull_request.merged == true
+      with:
+        configuration-path: .github/label-title-on-close.yml
+        include-title: 1
+        include-body: 0
+        enable-versioned-regex: 0
+        repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
https://github.com/scipy/xsf/pull/176

#### What does this implement/fix?
Automation when PR closes

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI