### PR TITLE
ENH: Add `boxcox` to XSF

### DIFF
--- a/include/xsf/boxcox.h
+++ b/include/xsf/boxcox.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "config.h"
+
+namespace xsf {
+
+XSF_HOST_DEVICE inline double boxcox(double x, double lmbda) {
+    /* If lmbda << 1 and log(x) < 1.0, the lmbda*log(x) product can lose
+     * precision, furthermore, expm1(x) == x for x < eps.
+     * For doubles, the range of log is -744.44 to +709.78, with eps being
+     * the smallest value produced.  This range means that we will have
+     * abs(lmbda)*log(x) < eps whenever abs(lmbda) <= eps/-log(min double)
+     * which is ~2.98e-19.
+     */
+    if (std::abs(lmbda) < 1e-19) {
+        return std::log(x);
+    } else if (lmbda * std::log(x) < 709.78) {
+        return std::expm1(lmbda * std::log(x)) / lmbda;
+    } else {
+        return std::copysign(1.0, lmbda) * std::exp(lmbda * std::log(x) - std::log(std::abs(lmbda))) - 1 / lmbda;
+    }
+}
+
+XSF_HOST_DEVICE inline float boxcox(float x, float lmbda) {
+    return (boxcox(static_cast<double>(x), static_cast<double>(lmbda)));
+}
+
+XSF_HOST_DEVICE inline double boxcox1p(double x, double lmbda) {
+    /* The argument given above in boxcox applies here with the modification
+     * that the smallest value produced by log1p is the minimum representable
+     * value, rather than eps.  The second condition here prevents underflow
+     * when log1p(x) is < eps.
+     */
+    double lgx = std::log1p(x);
+    if (std::abs(lmbda) < 1e-19 || (std::abs(lgx) < 1e-289 && std::abs(lmbda) < 1e273)) {
+        return lgx;
+    } else if (lmbda * lgx < 709.78) {
+        return std::expm1(lmbda * lgx) / lmbda;
+    } else {
+        return std::copysign(1.0, lmbda) * std::exp(lmbda * lgx - std::log(std::abs(lmbda))) - 1 / lmbda;
+    }
+}
+
+XSF_HOST_DEVICE inline float boxcox1p(float x, float lmbda) {
+    return (boxcox1p(static_cast<double>(x), static_cast<double>(lmbda)));
+}
+
+XSF_HOST_DEVICE inline double inv_boxcox(double x, double lmbda) {
+    if (lmbda == 0) {
+        return std::exp(x);
+    } else if (lmbda * x < 1.79e308) {
+        return std::exp(std::log1p(lmbda * x) / lmbda);
+    } else {
+        return std::exp((std::log(std::copysign(1.0, lmbda) * (x + 1 / lmbda)) + std::log(std::abs(lmbda))) / lmbda);
+    }
+}
+
+XSF_HOST_DEVICE inline float inv_boxcox(float x, float lmbda) {
+    return (inv_boxcox(static_cast<double>(x), static_cast<double>(lmbda)));
+}
+
+XSF_HOST_DEVICE inline double inv_boxcox1p(double x, double lmbda) {
+    if (lmbda == 0) {
+        return std::expm1(x);
+    } else if (std::abs(lmbda * x) < 1e-154) {
+        return x;
+    } else if (lmbda * x < 1.79e308) {
+        return std::expm1(std::log1p(lmbda * x) / lmbda);
+    } else {
+        return std::expm1((std::log(std::copysign(1.0, lmbda) * (x + 1 / lmbda)) + std::log(std::abs(lmbda))) / lmbda);
+    }
+}
+
+XSF_HOST_DEVICE inline float inv_boxcox1p(float x, float lmbda) {
+    return (inv_boxcox1p(static_cast<double>(x), static_cast<double>(lmbda)));
+}
+
+} // namespace xsf

--- a/include/xsf/boxcox.h
+++ b/include/xsf/boxcox.h
@@ -1,3 +1,5 @@
+// Translated from Cython to C++ by the xsf developers in 2026.
+// Original implementation by Warren Weckesser.
 #pragma once
 
 #include "config.h"

--- a/include/xsf/convex_analysis.h
+++ b/include/xsf/convex_analysis.h
@@ -1,3 +1,5 @@
+// Translated from Cython to C++ by the xsf developers in 2026.
+// Original implementation by argriffing.
 #pragma once
 
 #include "config.h"

--- a/tests/xsf_tests/test_boxcox.cpp
+++ b/tests/xsf_tests/test_boxcox.cpp
@@ -1,0 +1,193 @@
+/* C++ translation of tests from scipy/special/tests/test_boxcox.py
+ * https://github.com/scipy/scipy/blob/v1.18.0rc1/scipy/special/tests/test_boxcox.py
+ */
+
+#include "../testing_utils.h"
+
+#include <xsf/boxcox.h>
+
+TEST_CASE("boxcox basic", "[boxcox][xsf_tests]") {
+    constexpr double atol = 1.5e-7;
+    constexpr double rtol = 0.0;
+    std::vector<double> xs = {0.5, 1.0, 2.0, 4.0};
+
+    for (const auto x : xs) {
+        // lambda = 0  =>  y = log(x)
+        auto output = xsf::boxcox(x, 0.0);
+        auto expected = std::log(x);
+        auto abs_error = std::abs(output - expected);
+        auto tol = atol + rtol * std::abs(expected);
+        CAPTURE(x, output, expected, atol, rtol, abs_error, tol);
+        REQUIRE(abs_error <= tol);
+
+        // lambda = 1  =>  y = x - 1
+        output = xsf::boxcox(x, 1.0);
+        expected = x - 1.0;
+        abs_error = std::abs(output - expected);
+        tol = atol + rtol * std::abs(expected);
+        CAPTURE(x, output, expected, atol, rtol, abs_error, tol);
+        REQUIRE(abs_error <= tol);
+
+        // lambda = 2  =>  y = 0.5*(x**2 - 1)
+        output = xsf::boxcox(x, 2.0);
+        expected = 0.5 * (x * x - 1.0);
+        abs_error = std::abs(output - expected);
+        tol = atol + rtol * std::abs(expected);
+        CAPTURE(x, output, expected, atol, rtol, abs_error, tol);
+        REQUIRE(abs_error <= tol);
+    }
+
+    // x = 0 and lambda > 0  =>  y = -1 / lambda
+    for (const auto lmbda : {0.5, 1.0, 2.0}) {
+        const auto output = xsf::boxcox(0.0, lmbda);
+        const auto expected = -1.0 / lmbda;
+        const auto abs_error = std::abs(output - expected);
+        const auto tol = atol + rtol * std::abs(expected);
+        CAPTURE(lmbda, output, expected, atol, rtol, abs_error, tol);
+        REQUIRE(abs_error <= tol);
+    }
+}
+
+TEST_CASE("boxcox underflow", "[boxcox][xsf_tests]") {
+    constexpr double x = 1.0 + 1e-15;
+    constexpr double lmbda = 1e-306;
+    constexpr double rtol = 1e-14;
+    const auto output = xsf::boxcox(x, lmbda);
+    const auto expected = std::log(x);
+    const auto rel_error = xsf::extended_relative_error(output, expected);
+    CAPTURE(x, lmbda, output, expected, rtol, rel_error);
+    REQUIRE(rel_error <= rtol);
+}
+
+TEST_CASE("boxcox nonfinite", "[boxcox][xsf_tests]") {
+    using test_case = std::tuple<double, double>;
+    auto [x, lmbda] = GENERATE(test_case{-1.0, 0.5}, test_case{-1.0, 2.0}, test_case{-0.5, -1.5});
+    CAPTURE(x, lmbda);
+    REQUIRE(std::isnan(xsf::boxcox(x, lmbda)));
+
+    REQUIRE(xsf::boxcox(0.0, -2.5) == -std::numeric_limits<double>::infinity());
+    REQUIRE(xsf::boxcox(0.0, 0.0) == -std::numeric_limits<double>::infinity());
+}
+
+TEST_CASE("boxcox1p basic", "[boxcox][xsf_tests]") {
+    constexpr double atol = 1.5e-7;
+    constexpr double rtol = 0.0;
+    std::vector<double> xs = {-0.25, -1e-20, 0.0, 1e-20, 0.25, 1.0, 3.0};
+
+    for (const auto x : xs) {
+        // lambda = 0  =>  y = log(1+x)
+        auto output = xsf::boxcox1p(x, 0.0);
+        auto expected = std::log1p(x);
+        auto abs_error = std::abs(output - expected);
+        auto tol = atol + rtol * std::abs(expected);
+        CAPTURE(x, output, expected, atol, rtol, abs_error, tol);
+        REQUIRE(abs_error <= tol);
+
+        // lambda = 1  =>  y = x
+        output = xsf::boxcox1p(x, 1.0);
+        expected = x;
+        abs_error = std::abs(output - expected);
+        tol = atol + rtol * std::abs(expected);
+        CAPTURE(x, output, expected, atol, rtol, abs_error, tol);
+        REQUIRE(abs_error <= tol);
+
+        // lambda = 2  =>  y = 0.5*((1+x)**2 - 1) = 0.5*x*(2 + x)
+        output = xsf::boxcox1p(x, 2.0);
+        expected = 0.5 * x * (2.0 + x);
+        abs_error = std::abs(output - expected);
+        tol = atol + rtol * std::abs(expected);
+        CAPTURE(x, output, expected, atol, rtol, abs_error, tol);
+        REQUIRE(abs_error <= tol);
+    }
+
+    // x = -1 and lambda > 0  =>  y = -1 / lambda
+    for (const auto lmbda : {0.5, 1.0, 2.0}) {
+        const auto output = xsf::boxcox1p(-1.0, lmbda);
+        const auto expected = -1.0 / lmbda;
+        const auto abs_error = std::abs(output - expected);
+        const auto tol = atol + rtol * std::abs(expected);
+        CAPTURE(lmbda, output, expected, atol, rtol, abs_error, tol);
+        REQUIRE(abs_error <= tol);
+    }
+}
+
+TEST_CASE("boxcox1p underflow", "[boxcox][xsf_tests]") {
+    using test_case = std::tuple<double, double>;
+    auto [x, lmbda] = GENERATE(test_case{1e-15, 1e-306}, test_case{1e-306, 1e-18});
+    const double rtol = 1e-14;
+    const auto output = xsf::boxcox1p(x, lmbda);
+    const auto expected = std::log1p(x);
+    const auto rel_error = xsf::extended_relative_error(output, expected);
+    CAPTURE(x, lmbda, output, expected, rtol, rel_error);
+    REQUIRE(rel_error <= rtol);
+}
+
+TEST_CASE("boxcox1p nonfinite", "[boxcox][xsf_tests]") {
+    using test_case = std::tuple<double, double>;
+    auto [x, lmbda] = GENERATE(test_case{-2.0, 0.5}, test_case{-2.0, 2.0}, test_case{-1.5, -1.5});
+    CAPTURE(x, lmbda);
+    REQUIRE(std::isnan(xsf::boxcox1p(x, lmbda)));
+
+    REQUIRE(xsf::boxcox1p(-1.0, -2.5) == -std::numeric_limits<double>::infinity());
+    REQUIRE(xsf::boxcox1p(-1.0, 0.0) == -std::numeric_limits<double>::infinity());
+}
+
+TEST_CASE("boxcox inverse", "[boxcox][xsf_tests]") {
+    constexpr double atol = 1.5e-7;
+    constexpr double rtol = 0.0;
+    std::vector<double> xs = {0.0, 1.0, 2.0};
+    std::vector<double> lmbdas = {0.0, 1.0, 2.0};
+
+    for (std::size_t i = 0; i < xs.size(); ++i) {
+        const double x = xs[i];
+        const double lmbda = lmbdas[i];
+        const double y = xsf::boxcox(x, lmbda);
+        auto output = xsf::inv_boxcox(y, lmbda);
+        auto expected = x;
+        auto abs_error = std::abs(output - expected);
+        auto tol = atol + rtol * std::abs(expected);
+        CAPTURE(x, lmbda, y, output, expected, atol, rtol, abs_error, tol);
+        REQUIRE(abs_error <= tol);
+
+        const double y1p = xsf::boxcox1p(x, lmbda);
+        output = xsf::inv_boxcox1p(y1p, lmbda);
+        expected = x;
+        abs_error = std::abs(output - expected);
+        tol = atol + rtol * std::abs(expected);
+        CAPTURE(x, lmbda, y1p, output, expected, atol, rtol, abs_error, tol);
+        REQUIRE(abs_error <= tol);
+    }
+}
+
+TEST_CASE("inv_boxcox1p underflow", "[boxcox][xsf_tests]") {
+    constexpr double x = 1e-15;
+    constexpr double lmbda = 1e-306;
+    constexpr double rtol = 1e-14;
+    const auto output = xsf::inv_boxcox1p(x, lmbda);
+    const auto rel_error = xsf::extended_relative_error(output, x);
+    CAPTURE(x, lmbda, output, rtol, rel_error);
+    REQUIRE(rel_error <= rtol);
+}
+
+TEST_CASE("inv_boxcox premature overflow", "[boxcox][xsf_tests]") {
+    using test_case = std::tuple<double, double>;
+    auto [x, lmbda] = GENERATE(test_case{100.0, 155.0}, test_case{0.01, -155.0});
+
+    const double y = xsf::boxcox(x, lmbda);
+    CAPTURE(x, lmbda, y);
+    REQUIRE(std::isfinite(y));
+    constexpr double rtol = 1e-14;
+    auto output = xsf::inv_boxcox(y, lmbda);
+    auto rel_error = xsf::extended_relative_error(output, x);
+    CAPTURE(x, lmbda, y, output, rtol, rel_error);
+    REQUIRE(rel_error <= rtol);
+
+    const double y1p = xsf::boxcox1p(x - 1.0, lmbda);
+    CAPTURE(y1p);
+    REQUIRE(std::isfinite(y1p));
+    const auto expected = x - 1.0;
+    output = xsf::inv_boxcox1p(y1p, lmbda);
+    rel_error = xsf::extended_relative_error(output, expected);
+    CAPTURE(x, lmbda, y1p, output, expected, rtol, rel_error);
+    REQUIRE(rel_error <= rtol);
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
https://github.com/scipy/xsf/issues/170

Same pattern as https://github.com/scipy/xsf/pull/171

#### What does this implement/fix?
- C++ translation of [scipy/special/_boxcox.pxd](https://github.com/scipy/scipy/blob/main/scipy/special/_boxcox.pxd) to XSF
- Add `boxcox`, `boxcox_1p, `boxcox_inv`, `boxcox_inv1p` to XSF

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I asked Codex to translate the tests from SciPy. I then quickly checked.