### PR TITLE
BUG: handle huge complex inputs in `gamma` and `rgamma`

### DIFF
--- a/include/xsf/gamma.h
+++ b/include/xsf/gamma.h
@@ -57,7 +57,25 @@ XSF_HOST_DEVICE inline std::complex<double> gamma(std::complex<double> z) {
         set_error("gamma", SF_ERROR_SINGULAR, NULL);
         return {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
     }
-    return std::exp(loggamma(z));
+
+    if (z.real() <= -std::ldexp(1.0, std::numeric_limits<double>::digits)) {
+        return {0.0, std::copysign(0.0, z.imag())};
+    }
+
+    std::complex<double> lg = loggamma(z);
+    if (lg.real() == -std::numeric_limits<double>::infinity()) {
+        return {0.0, std::copysign(0.0, z.imag())};
+    }
+    const double max = std::numeric_limits<double>::max();
+    if (lg.real() > std::log(max) && z.imag() == 0.0) {
+        return {std::numeric_limits<double>::infinity(), std::copysign(0.0, z.imag())};
+    }
+    if (lg.real() > std::log(max) && z.real() > std::sqrt(max) && std::abs(z.imag()) > std::sqrt(max)) {
+        return {
+            -std::numeric_limits<double>::infinity(), std::copysign(std::numeric_limits<double>::infinity(), z.imag())
+        };
+    }
+    return std::exp(lg);
 }
 
 XSF_HOST_DEVICE inline std::complex<float> gamma(std::complex<float> z) {

--- a/include/xsf/loggamma.h
+++ b/include/xsf/loggamma.h
@@ -160,7 +160,11 @@ XSF_HOST_DEVICE inline std::complex<double> rgamma(std::complex<double> z) {
         // Zeros at 0, -1, -2, ...
         return 0.0;
     }
-    return std::exp(-loggamma(z));
+    std::complex<double> lg = loggamma(z);
+    if (lg.real() == std::numeric_limits<double>::infinity()) {
+        return {0.0, std::copysign(0.0, z.imag())};
+    }
+    return std::exp(-lg);
 }
 
 XSF_HOST_DEVICE inline std::complex<float> rgamma(std::complex<float> z) {

--- a/tests/scipy_special_tests/test_gamma.cpp
+++ b/tests/scipy_special_tests/test_gamma.cpp
@@ -24,6 +24,40 @@ TEST_CASE("gamma D->D scipy_special_tests", "[gamma][D->D][scipy_special_tests]"
     REQUIRE(error <= tol);
 }
 
+TEST_CASE("gamma D->D huge negative inputs underflow to zero", "[gamma][D->D][scipy_special_tests]") {
+    SET_FP_FORMAT()
+    auto z = GENERATE(
+        std::complex<double>{-8.98847e307, -10.0}, std::complex<double>{-8.98847e307, 1e-30},
+        std::complex<double>{-8.98847e307, 2.99808e154}
+    );
+
+    auto out = xsf::gamma(z);
+    CAPTURE(z, out);
+    REQUIRE(out.real() == 0.0);
+    REQUIRE(out.imag() == 0.0);
+}
+
+TEST_CASE("gamma D->D positive real axis overflows", "[gamma][D->D][scipy_special_tests]") {
+    SET_FP_FORMAT()
+    auto z = GENERATE(std::complex<double>{2.99808e154, 0.0}, std::complex<double>{8.98847e307, 0.0});
+
+    auto out = xsf::gamma(z);
+    CAPTURE(z);
+    CAPTURE(out);
+    REQUIRE(out.real() == std::numeric_limits<double>::infinity());
+    REQUIRE(out.imag() == 0.0);
+}
+
+TEST_CASE("gamma D->D balanced huge inputs overflow", "[gamma][D->D][scipy_special_tests]") {
+    SET_FP_FORMAT()
+    auto z = GENERATE(std::complex<double>{2.99808e154, 2.99808e154}, std::complex<double>{2.99808e154, -2.99808e154});
+
+    auto out = xsf::gamma(z);
+    CAPTURE(z, out);
+    REQUIRE(out.real() == -std::numeric_limits<double>::infinity());
+    REQUIRE(out.imag() == std::copysign(std::numeric_limits<double>::infinity(), z.imag()));
+}
+
 TEST_CASE("gamma d->d scipy_special_tests", "[gamma][d->d][scipy_special_tests]") {
     SET_FP_FORMAT()
     auto [input, output, tol] = GENERATE(

--- a/tests/scipy_special_tests/test_rgamma.cpp
+++ b/tests/scipy_special_tests/test_rgamma.cpp
@@ -24,6 +24,17 @@ TEST_CASE("rgamma D->D scipy_special_tests", "[rgamma][D->D][scipy_special_tests
     REQUIRE(error <= tol);
 }
 
+TEST_CASE("rgamma D->D huge inputs underflow to zero", "[rgamma][D->D][scipy_special_tests]") {
+    SET_FP_FORMAT()
+    auto z = GENERATE(std::complex<double>{8.98847e307, 8.98847e307}, std::complex<double>{8.98847e307, -8.98847e307});
+
+    auto out = xsf::rgamma(z);
+    CAPTURE(z, out);
+    REQUIRE(out.real() == 0.0);
+    REQUIRE(out.imag() == 0.0);
+    REQUIRE(std::signbit(out.imag()) == std::signbit(z.imag()));
+}
+
 TEST_CASE("rgamma d->d scipy_special_tests", "[rgamma][d->d][scipy_special_tests]") {
     SET_FP_FORMAT()
     auto [input, output, tol] = GENERATE(


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?
- Patch for CI failing on `ubuntu-24.04-arm`. The error seemed to occur because of an overflowed `loggamma(z)` intermediate.

- Add guardrails for `gamma` and `rgamma` preventing those.
 
- Add corresponding tests. 

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Worked with Codex on this.