### PR TITLE
ENH: add float overloads

### DIFF
--- a/include/xsf/cephes/erfinv.h
+++ b/include/xsf/cephes/erfinv.h
@@ -72,5 +72,7 @@ namespace cephes {
         }
     }
 
+    XSF_HOST_DEVICE inline float erfcinv(float y) { return static_cast<float>(erfcinv(static_cast<double>(y))); }
+
 } // namespace cephes
 } // namespace xsf

--- a/include/xsf/cephes/expn.h
+++ b/include/xsf/cephes/expn.h
@@ -258,5 +258,7 @@ namespace cephes {
         return ans;
     }
 
+    XSF_HOST_DEVICE inline float expn(int n, float x) { return static_cast<float>(expn(n, static_cast<double>(x))); }
+
 } // namespace cephes
 } // namespace xsf

--- a/include/xsf/cephes/igam.h
+++ b/include/xsf/cephes/igam.h
@@ -162,6 +162,10 @@ namespace cephes {
             return res;
         }
 
+        XSF_HOST_DEVICE inline float igam_fac(float a, float x) {
+            return igam_fac(static_cast<double>(a), static_cast<double>(x));
+        }
+
         /* Compute igamc using DLMF 8.9.2. */
         XSF_HOST_DEVICE inline double igamc_continued_fraction(double a, double x) {
             int i;

--- a/include/xsf/cephes/kn.h
+++ b/include/xsf/cephes/kn.h
@@ -239,5 +239,7 @@ namespace cephes {
         return (ans);
     }
 
+    XSF_HOST_DEVICE inline float kn(int n, float x) { return static_cast<float>(kn(n, static_cast<double>(x))); }
+
 } // namespace cephes
 } // namespace xsf

--- a/include/xsf/cephes/kolmogorov.h
+++ b/include/xsf/cephes/kolmogorov.h
@@ -345,12 +345,16 @@ namespace cephes {
         return detail::_kolmogorov(x).sf;
     }
 
+    XSF_HOST_DEVICE inline float kolmogorov(float x) { return static_cast<float>(kolmogorov(static_cast<double>(x))); }
+
     XSF_HOST_DEVICE inline double kolmogc(double x) {
         if (std::isnan(x)) {
             return std::numeric_limits<double>::quiet_NaN();
         }
         return detail::_kolmogorov(x).cdf;
     }
+
+    XSF_HOST_DEVICE inline float kolmogc(float x) { return static_cast<float>(kolmogc(static_cast<double>(x))); }
 
     XSF_HOST_DEVICE inline double kolmogp(double x) {
         if (std::isnan(x)) {
@@ -362,6 +366,8 @@ namespace cephes {
         return -detail::_kolmogorov(x).pdf;
     }
 
+    XSF_HOST_DEVICE inline float kolmogp(float x) { return static_cast<float>(kolmogp(static_cast<double>(x))); }
+
     /* Functional inverse of Kolmogorov survival statistic for two-sided test.
      * Finds x such that kolmogorov(x) = p.
      */
@@ -372,6 +378,8 @@ namespace cephes {
         return detail::_kolmogi(p, 1 - p);
     }
 
+    XSF_HOST_DEVICE inline float kolmogi(float p) { return static_cast<float>(kolmogi(static_cast<double>(p))); }
+
     /* Functional inverse of Kolmogorov cumulative statistic for two-sided test.
      * Finds x such that kolmogc(x) = p = (or kolmogorov(x) = 1-p).
      */
@@ -381,6 +389,8 @@ namespace cephes {
         }
         return detail::_kolmogi(1 - p, p);
     }
+
+    XSF_HOST_DEVICE inline float kolmogci(float p) { return static_cast<float>(kolmogci(static_cast<double>(p))); }
 
     namespace detail {
 

--- a/include/xsf/cephes/lanczos.h
+++ b/include/xsf/cephes/lanczos.h
@@ -113,5 +113,9 @@ namespace cephes {
     XSF_HOST_DEVICE double lanczos_sum_expg_scaled(double x) {
         return ratevl(x, detail::lanczos_sum_expg_scaled_num, 12, detail::lanczos_sum_expg_scaled_denom, 12);
     }
+
+    XSF_HOST_DEVICE inline float lanczos_sum_expg_scaled(float x) {
+        return static_cast<float>(lanczos_sum_expg_scaled(static_cast<double>(x)));
+    }
 } // namespace cephes
 } // namespace xsf

--- a/include/xsf/cephes/poch.h
+++ b/include/xsf/cephes/poch.h
@@ -81,5 +81,9 @@ namespace cephes {
 
         return r * std::exp(lgam(a + m) - lgam(a)) * gammasgn(a + m) * gammasgn(a);
     }
+
+    XSF_HOST_DEVICE inline float poch(float a, float m) {
+        return static_cast<float>(poch(static_cast<double>(a), static_cast<double>(m)));
+    }
 } // namespace cephes
 } // namespace xsf

--- a/include/xsf/cephes/round.h
+++ b/include/xsf/cephes/round.h
@@ -70,5 +70,7 @@ namespace cephes {
         return (y);
     }
 
+    inline float round(float x) { return static_cast<float>(round(static_cast<double>(x))); }
+
 } // namespace cephes
 } // namespace xsf

--- a/include/xsf/cephes/round.h
+++ b/include/xsf/cephes/round.h
@@ -43,7 +43,7 @@
 namespace xsf {
 namespace cephes {
 
-    double round(double x) {
+    XSF_HOST_DEVICE inline double round(double x) {
         double y, r;
 
         /* Largest integer <= x */
@@ -70,7 +70,7 @@ namespace cephes {
         return (y);
     }
 
-    inline float round(float x) { return static_cast<float>(round(static_cast<double>(x))); }
+    XSF_HOST_DEVICE inline float round(float x) { return static_cast<float>(round(static_cast<double>(x))); }
 
 } // namespace cephes
 } // namespace xsf

--- a/include/xsf/cephes/spence.h
+++ b/include/xsf/cephes/spence.h
@@ -123,5 +123,7 @@ namespace cephes {
         return (y);
     }
 
+    XSF_HOST_DEVICE inline float spence(float x) { return static_cast<float>(spence(static_cast<double>(x))); }
+
 } // namespace cephes
 } // namespace xsf

--- a/include/xsf/cephes/struve.h
+++ b/include/xsf/cephes/struve.h
@@ -171,6 +171,13 @@ namespace cephes {
             return sum;
         }
 
+        XSF_HOST_DEVICE inline float struve_asymp_large_z(float v, float z, int is_h, float *err) {
+            double err_d;
+            double out = struve_asymp_large_z(static_cast<double>(v), static_cast<double>(z), is_h, &err_d);
+            *err = static_cast<float>(err_d);
+            return static_cast<float>(out);
+        }
+
         /*
          * Power series for Struve H and L
          * https://dlmf.nist.gov/11.2.1
@@ -247,6 +254,13 @@ namespace cephes {
             return sum;
         }
 
+        XSF_HOST_DEVICE inline float struve_power_series(float v, float z, int is_h, float *err) {
+            double err_d;
+            double out = struve_power_series(static_cast<double>(v), static_cast<double>(z), is_h, &err_d);
+            *err = static_cast<float>(err_d);
+            return static_cast<float>(out);
+        }
+
         /*
          * Bessel series
          * https://dlmf.nist.gov/11.4.19
@@ -289,6 +303,13 @@ namespace cephes {
             *err += 1e-300 * std::abs(cterm);
 
             return sum;
+        }
+
+        XSF_HOST_DEVICE inline float struve_bessel_series(float v, float z, int is_h, float *err) {
+            double err_d;
+            double out = struve_bessel_series(static_cast<double>(v), static_cast<double>(z), is_h, &err_d);
+            *err = static_cast<float>(err_d);
+            return static_cast<float>(out);
         }
 
         XSF_HOST_DEVICE inline double struve_hl(double v, double z, int is_h) {

--- a/include/xsf/cephes/unity.h
+++ b/include/xsf/cephes/unity.h
@@ -182,5 +182,7 @@ namespace cephes {
         }
     }
 
+    XSF_HOST_DEVICE inline float lgam1p(float x) { return static_cast<float>(lgam1p(static_cast<double>(x))); }
+
 } // namespace cephes
 } // namespace xsf

--- a/include/xsf/cephes/yn.h
+++ b/include/xsf/cephes/yn.h
@@ -114,5 +114,7 @@ namespace cephes {
         return (sign * an);
     }
 
+    XSF_HOST_DEVICE inline float yn(int n, float x) { return static_cast<float>(yn(n, static_cast<double>(x))); }
+
 } // namespace cephes
 } // namespace xsf

--- a/include/xsf/cpu/stats.h
+++ b/include/xsf/cpu/stats.h
@@ -8,23 +8,43 @@ namespace cpu {
 
     inline double kolmogorov(double x) { return cephes::kolmogorov(x); }
 
+    inline float kolmogorov(float x) { return static_cast<float>(kolmogorov(static_cast<double>(x))); }
+
     inline double kolmogc(double x) { return cephes::kolmogc(x); }
+
+    inline float kolmogc(float x) { return static_cast<float>(kolmogc(static_cast<double>(x))); }
 
     inline double kolmogi(double x) { return cephes::kolmogi(x); }
 
+    inline float kolmogi(float x) { return static_cast<float>(kolmogi(static_cast<double>(x))); }
+
     inline double kolmogci(double x) { return cephes::kolmogci(x); }
+
+    inline float kolmogci(float x) { return static_cast<float>(kolmogci(static_cast<double>(x))); }
 
     inline double kolmogp(double x) { return cephes::kolmogp(x); }
 
+    inline float kolmogp(float x) { return static_cast<float>(kolmogp(static_cast<double>(x))); }
+
     inline double smirnov(int n, double x) { return cephes::smirnov(n, x); }
+
+    inline float smirnov(int n, float x) { return static_cast<float>(smirnov(n, static_cast<double>(x))); }
 
     inline double smirnovc(int n, double x) { return cephes::smirnovc(n, x); }
 
+    inline float smirnovc(int n, float x) { return static_cast<float>(smirnovc(n, static_cast<double>(x))); }
+
     inline double smirnovi(int n, double x) { return cephes::smirnovi(n, x); }
+
+    inline float smirnovi(int n, float x) { return static_cast<float>(smirnovi(n, static_cast<double>(x))); }
 
     inline double smirnovci(int n, double x) { return cephes::smirnovci(n, x); }
 
+    inline float smirnovci(int n, float x) { return static_cast<float>(smirnovci(n, static_cast<double>(x))); }
+
     inline double smirnovp(int n, double x) { return cephes::smirnovp(n, x); }
+
+    inline float smirnovp(int n, float x) { return static_cast<float>(smirnovp(n, static_cast<double>(x))); }
 
     inline double cdf_cvm_inf(double x) {
         // CDF of the Cramer-von Mises test statistic (infinite sample limit).

--- a/include/xsf/specfun.h
+++ b/include/xsf/specfun.h
@@ -110,4 +110,8 @@ inline double pmv(double m, double v, double x) {
     return out;
 }
 
+inline float pmv(float m, float v, float x) {
+    return static_cast<float>(pmv(static_cast<double>(m), static_cast<double>(v), static_cast<double>(x)));
+}
+
 } // namespace xsf

--- a/include/xsf/stats.h
+++ b/include/xsf/stats.h
@@ -22,9 +22,21 @@ namespace xsf {
 
 XSF_HOST_DEVICE inline double bdtr(double k, int n, double p) { return cephes::bdtr(k, n, p); }
 
+XSF_HOST_DEVICE inline float bdtr(float k, int n, float p) {
+    return static_cast<float>(bdtr(static_cast<double>(k), n, static_cast<double>(p)));
+}
+
 XSF_HOST_DEVICE inline double bdtri(double k, int n, double y) { return cephes::bdtri(k, n, y); }
 
+XSF_HOST_DEVICE inline float bdtri(float k, int n, float y) {
+    return static_cast<float>(bdtri(static_cast<double>(k), n, static_cast<double>(y)));
+}
+
 XSF_HOST_DEVICE inline double bdtrc(double k, int n, double p) { return cephes::bdtrc(k, n, p); }
+
+XSF_HOST_DEVICE inline float bdtrc(float k, int n, float p) {
+    return static_cast<float>(bdtrc(static_cast<double>(k), n, static_cast<double>(p)));
+}
 
 XSF_HOST_DEVICE inline double chdtr(double df, double x) { return cephes::chdtr(df, x); }
 
@@ -36,15 +48,39 @@ XSF_HOST_DEVICE inline float chdtrc(float df, float x) { return static_cast<floa
 
 XSF_HOST_DEVICE inline double chdtri(double df, double y) { return cephes::chdtri(df, y); }
 
+XSF_HOST_DEVICE inline float chdtri(float df, float y) {
+    return static_cast<float>(chdtri(static_cast<double>(df), static_cast<double>(y)));
+}
+
 XSF_HOST_DEVICE inline double fdtr(double a, double b, double x) { return cephes::fdtr(a, b, x); }
+
+XSF_HOST_DEVICE inline float fdtr(float a, float b, float x) {
+    return static_cast<float>(fdtr(static_cast<double>(a), static_cast<double>(b), static_cast<double>(x)));
+}
 
 XSF_HOST_DEVICE inline double fdtrc(double a, double b, double x) { return cephes::fdtrc(a, b, x); }
 
+XSF_HOST_DEVICE inline float fdtrc(float a, float b, float x) {
+    return static_cast<float>(fdtrc(static_cast<double>(a), static_cast<double>(b), static_cast<double>(x)));
+}
+
 XSF_HOST_DEVICE inline double fdtri(double a, double b, double y) { return cephes::fdtri(a, b, y); }
+
+XSF_HOST_DEVICE inline float fdtri(float a, float b, float y) {
+    return static_cast<float>(fdtri(static_cast<double>(a), static_cast<double>(b), static_cast<double>(y)));
+}
 
 XSF_HOST_DEVICE inline double gdtr(double a, double b, double x) { return cephes::gdtr(a, b, x); }
 
+XSF_HOST_DEVICE inline float gdtr(float a, float b, float x) {
+    return static_cast<float>(gdtr(static_cast<double>(a), static_cast<double>(b), static_cast<double>(x)));
+}
+
 XSF_HOST_DEVICE inline double gdtrc(double a, double b, double x) { return cephes::gdtrc(a, b, x); }
+
+XSF_HOST_DEVICE inline float gdtrc(float a, float b, float x) {
+    return static_cast<float>(gdtrc(static_cast<double>(a), static_cast<double>(b), static_cast<double>(x)));
+}
 
 XSF_HOST_DEVICE XSF_HOST_DEVICE inline double ndtr(double x) { return cephes::ndtr(x); }
 
@@ -145,6 +181,10 @@ XSF_HOST_DEVICE inline std::complex<float> log_ndtr(std::complex<float> z) {
 }
 
 XSF_HOST_DEVICE inline double nbdtr(int k, int n, double p) { return cephes::nbdtr(k, n, p); }
+
+XSF_HOST_DEVICE inline float nbdtr(int k, int n, float p) {
+    return static_cast<float>(nbdtr(k, n, static_cast<double>(p)));
+}
 
 XSF_HOST_DEVICE inline bool bivariate_normal_sf_boundary(double dh, double dk, double r, double &p) {
     // Handles degenerate cases for bivariate_normal_sf (infinite arguments or zero correlation).
@@ -320,11 +360,19 @@ XSF_HOST_DEVICE inline double bivariate_normal_sf(double dh, double dk, double r
 
 XSF_HOST_DEVICE inline double nbdtrc(int k, int n, double p) { return cephes::nbdtrc(k, n, p); }
 
+XSF_HOST_DEVICE inline float nbdtrc(int k, int n, float p) {
+    return static_cast<float>(nbdtrc(k, n, static_cast<double>(p)));
+}
+
 XSF_HOST_DEVICE inline float bivariate_normal_sf(float dh, float dk, float r) {
     return bivariate_normal_sf(static_cast<double>(dh), static_cast<double>(dk), static_cast<double>(r));
 }
 
 XSF_HOST_DEVICE inline double nbdtri(int k, int n, double p) { return cephes::nbdtri(k, n, p); }
+
+XSF_HOST_DEVICE inline float nbdtri(int k, int n, float p) {
+    return static_cast<float>(nbdtri(k, n, static_cast<double>(p)));
+}
 
 XSF_HOST_DEVICE inline double ndtri(double x) { return cephes::ndtri(x); }
 
@@ -363,16 +411,30 @@ XSF_HOST_DEVICE XSF_HOST_DEVICE inline float nrdtrisd(float mean, float p, float
 
 XSF_HOST_DEVICE inline double owens_t(double h, double a) { return cephes::owens_t(h, a); }
 
+XSF_HOST_DEVICE inline float owens_t(float h, float a) {
+    return static_cast<float>(owens_t(static_cast<double>(h), static_cast<double>(a)));
+}
+
 XSF_HOST_DEVICE inline double pdtr(double k, double m) { return cephes::pdtr(k, m); }
+
+XSF_HOST_DEVICE inline float pdtr(float k, float m) {
+    return static_cast<float>(pdtr(static_cast<double>(k), static_cast<double>(m)));
+}
 
 XSF_HOST_DEVICE inline double pdtrc(double k, double m) { return cephes::pdtrc(k, m); }
 
+XSF_HOST_DEVICE inline float pdtrc(float k, float m) {
+    return static_cast<float>(pdtrc(static_cast<double>(k), static_cast<double>(m)));
+}
+
 XSF_HOST_DEVICE inline double pdtri(int k, double y) { return cephes::pdtri(k, y); }
+
+XSF_HOST_DEVICE inline float pdtri(int k, float y) { return static_cast<float>(pdtri(k, static_cast<double>(y))); }
 
 XSF_HOST_DEVICE inline double tukeylambdacdf(double x, double lmbda) { return cephes::tukeylambdacdf(x, lmbda); }
 
-XSF_HOST_DEVICE inline float tukeylambdacdf(float x, double lmbda) {
-    return tukeylambdacdf(static_cast<double>(x), static_cast<double>(lmbda));
+XSF_HOST_DEVICE inline float tukeylambdacdf(float x, float lmbda) {
+    return static_cast<float>(tukeylambdacdf(static_cast<double>(x), static_cast<double>(lmbda)));
 }
 
 namespace detail {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
None

#### What does this implement/fix?

- Add float overloads. This is needed to clean up `scipy/special/functions.json`
- Added `XSF_HOST_DEVICE` in cephes/round.h following @steppi 's suggestion 
- Update float overload definition for `tukeylambdacdf`

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I started manually and then asked Codex to update the rest. I then checked and added a few more it missed.