### PR TITLE
ENH: add float overload for `hyperu`

### DIFF
--- a/include/xsf/hyperu.h
+++ b/include/xsf/hyperu.h
@@ -36,4 +36,8 @@ inline double hyperu(double a, double b, double x) {
     return hypu(a, b, x);
 }
 
+inline float hyperu(float a, float b, float x) {
+    return static_cast<float>(hyperu(static_cast<double>(a), static_cast<double>(b), static_cast<double>(x)));
+}
+
 } // namespace xsf


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Add missing float overload for `hyperu`.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI.