### PR TITLE
ENH: improve gamma guardrail comments

### DIFF
--- a/include/xsf/gamma.h
+++ b/include/xsf/gamma.h
@@ -53,12 +53,14 @@ XSF_HOST_DEVICE inline std::complex<double> gamma(std::complex<double> z) {
     }
     // Compute Gamma(z) using loggamma.
     if (z.real() <= 0 && z == std::floor(z.real())) {
-        // Poles
+        // Gamma poles at non-positive integers.
         set_error("gamma", SF_ERROR_SINGULAR, NULL);
         return {std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN()};
     }
 
     if (z.real() <= -std::ldexp(1.0, std::numeric_limits<double>::digits)) {
+        // For real(z) <= -2**53, every representable real part has even-integer
+        // parity, and Gamma(z) underflows to signed zero.
         return {0.0, std::copysign(0.0, z.imag())};
     }
 
@@ -71,6 +73,7 @@ XSF_HOST_DEVICE inline std::complex<double> gamma(std::complex<double> z) {
         return {std::numeric_limits<double>::infinity(), std::copysign(0.0, z.imag())};
     }
     if (lg.real() > std::log(max) && z.real() > std::sqrt(max) && std::abs(z.imag()) > std::sqrt(max)) {
+        // Avoid std::exp(complex) overflow; the quadrant follows sign(imag(z)).
         return {
             -std::numeric_limits<double>::infinity(), std::copysign(std::numeric_limits<double>::infinity(), z.imag())
         };


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
https://github.com/scipy/xsf/pull/179#pullrequestreview-4459833206

#### What does this implement/fix?
- Add explanatory comments about `gamma.h` guardrails. Those were added in https://github.com/scipy/xsf/pull/179

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I asked Codex to review my comments. It updated them a little.