### PR TITLE
Remove constexpr uses of QuietNaN to enable nvrtc 120 support

### DIFF
--- a/include/xsf/digamma.h
+++ b/include/xsf/digamma.h
@@ -38,9 +38,8 @@ namespace detail {
     // Precondition: !std::isfinite(z.real()) || !std::isfinite(z.imag()).
     template <typename T>
     XSF_HOST_DEVICE std::complex<T> digamma_nonfinite_limit(std::complex<T> z) {
-        constexpr T qnan = std::numeric_limits<T>::quiet_NaN();
         if (std::isnan(z.real()) || !std::isfinite(z.imag()) || z.real() <= T{0})
-            return {qnan, qnan};
+            return {std::numeric_limits<T>::quiet_NaN(), std::numeric_limits<T>::quiet_NaN()};
         return {std::numeric_limits<T>::infinity(), T{0}};
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR removes a `constexpr` alias for `std::numeric_limits<T>::QuietNaN()` instead inserting this value directly where it is needed. The purpose of this PR is to unblock https://github.com/cupy/cupy/pull/10005. It was found in CI there that `constexpr` `QuietNaN` is not supported with `nvrtc 120` despite it having been part of the standard since C++11.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
