### PR TITLE
ENH: add NaN guardrails for `hyp0f1`

### DIFF
--- a/include/xsf/hyp0f1.h
+++ b/include/xsf/hyp0f1.h
@@ -58,6 +58,10 @@ namespace detail {
 inline double hyp0f1(double v, double z) {
     double arg, arg_exp, bess_val;
 
+    if (std::isnan(v) || std::isnan(z)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+
     // Handle poles and zeros.
     if (v <= 0.0 && v == std::floor(v)) {
         return std::numeric_limits<double>::quiet_NaN();
@@ -92,6 +96,11 @@ inline float hyp0f1(float v, float z) { return hyp0f1(static_cast<double>(v), st
 inline std::complex<double> hyp0f1(double v, std::complex<double> z) {
     std::complex<double> arg, s, t1, t2;
     std::complex<double> r;
+
+    if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
+        double nan = std::numeric_limits<double>::quiet_NaN();
+        return {nan, nan};
+    }
 
     // Handle poles and zeros.
     if (v <= 0.0 && v == std::floor(v)) {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Add NaN guardrails for hyp0f1 after https://github.com/scipy/scipy/pull/25467 is failing

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI