### PR TITLE
ENH: add eval_zernike_radial kernel and C++ tests

### DIFF
--- a/include/xsf/zernike.h
+++ b/include/xsf/zernike.h
@@ -1,0 +1,156 @@
+#pragma once
+
+#include "config.h"
+#include "error.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <vector>
+
+namespace xsf {
+
+namespace detail {
+
+enum class zernike_arg_status {
+    ok,
+    domain,
+    nan
+};
+
+inline zernike_arg_status validate_zernike_radial_args(
+    std::ptrdiff_t n, std::ptrdiff_t m, double rho, std::ptrdiff_t &m_abs
+) {
+    if (std::isnan(rho)) {
+        return zernike_arg_status::nan;
+    }
+
+    if (n < 0 || m == std::numeric_limits<std::ptrdiff_t>::min()) {
+        return zernike_arg_status::domain;
+    }
+
+    m_abs = m < 0 ? -m : m;
+
+    if (m_abs > n || ((n - m_abs) & 1) != 0 || rho < 0.0 || rho > 1.0) {
+        return zernike_arg_status::domain;
+    }
+
+    return zernike_arg_status::ok;
+}
+
+inline double zernike_radial_domain_error(const char *func_name) {
+    set_error(func_name, SF_ERROR_DOMAIN, nullptr);
+    return std::numeric_limits<double>::quiet_NaN();
+}
+
+} // namespace detail
+
+inline double eval_zernike_radial_barmak(std::ptrdiff_t n, std::ptrdiff_t m, double rho) {
+    std::ptrdiff_t m_abs = 0;
+    const auto status = detail::validate_zernike_radial_args(n, m, rho, m_abs);
+
+    if (status == detail::zernike_arg_status::nan) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    if (status == detail::zernike_arg_status::domain) {
+        return detail::zernike_radial_domain_error("eval_zernike_radial");
+    }
+
+    try {
+        const std::size_t width = static_cast<std::size_t>(n) + 3;
+        std::vector<double> prev2(width, 0.0);
+        std::vector<double> prev1(width, 0.0);
+        std::vector<double> current(width, 0.0);
+
+        prev1[0] = 1.0;
+
+        if (n == 0) {
+            return prev1[static_cast<std::size_t>(m_abs)];
+        }
+
+        for (std::ptrdiff_t nn = 1; nn <= n; ++nn) {
+            std::fill(current.begin(), current.end(), 0.0);
+
+            for (std::ptrdiff_t mm = 0; mm <= nn; ++mm) {
+                if (((nn - mm) & 1) != 0) {
+                    continue;
+                }
+
+                double left = 0.0;
+                double right = 0.0;
+                double grand = 0.0;
+
+                const std::ptrdiff_t m_left = mm == 0 ? 1 : mm - 1;
+
+                if (m_left <= nn - 1) {
+                    left = prev1[static_cast<std::size_t>(m_left)];
+                }
+                if (mm + 1 <= nn - 1) {
+                    right = prev1[static_cast<std::size_t>(mm + 1)];
+                }
+                if (nn >= 2) {
+                    grand = prev2[static_cast<std::size_t>(mm)];
+                }
+
+                current[static_cast<std::size_t>(mm)] = rho * (left + right) - grand;
+            }
+
+            prev2.swap(prev1);
+            prev1.swap(current);
+        }
+
+        return prev1[static_cast<std::size_t>(m_abs)];
+    } catch (...) {
+        set_error("eval_zernike_radial", SF_ERROR_MEMORY, nullptr);
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+}
+
+inline double eval_zernike_radial_kintner(std::ptrdiff_t n, std::ptrdiff_t m, double rho) {
+    std::ptrdiff_t m_abs = 0;
+    const auto status = detail::validate_zernike_radial_args(n, m, rho, m_abs);
+
+    if (status == detail::zernike_arg_status::nan) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    if (status == detail::zernike_arg_status::domain) {
+        return detail::zernike_radial_domain_error("eval_zernike_radial_kintner");
+    }
+
+    const double rho2 = rho * rho;
+
+    if (n == m_abs) {
+        return std::pow(rho, static_cast<double>(m_abs));
+    }
+
+    double r_nm4 = std::pow(rho, static_cast<double>(m_abs));
+    double r_nm2 = ((static_cast<double>(m_abs) + 2.0) * rho2 - (static_cast<double>(m_abs) + 1.0)) * r_nm4;
+
+    if (n == m_abs + 2) {
+        return r_nm2;
+    }
+
+    for (std::ptrdiff_t current = m_abs + 4; current <= n; current += 2) {
+        const double cd = static_cast<double>(current);
+        const double md = static_cast<double>(m_abs);
+
+        const double a =
+            2.0 * (cd - 1.0) * (2.0 * cd * (cd - 2.0) * rho2 - md * md - cd * (cd - 2.0));
+        const double b = cd * (cd + md - 2.0) * (cd - md - 2.0);
+        const double denom = (cd + md) * (cd - md) * (cd - 2.0);
+
+        const double r_n = (a * r_nm2 - b * r_nm4) / denom;
+
+        r_nm4 = r_nm2;
+        r_nm2 = r_n;
+    }
+
+    return r_nm2;
+}
+
+inline double eval_zernike_radial(std::ptrdiff_t n, std::ptrdiff_t m, double rho) {
+    return eval_zernike_radial_barmak(n, m, rho);
+}
+
+} // namespace xsf

--- a/tests/xsf_tests/test_zernike.cpp
+++ b/tests/xsf_tests/test_zernike.cpp
@@ -1,0 +1,113 @@
+#include "../testing_utils.h"
+
+#include <cmath>
+#include <cstddef>
+#include <limits>
+#include <tuple>
+
+#include <xsf/zernike.h>
+
+namespace {
+
+void require_close(double value, double expected, double tol = 1e-14) {
+    CAPTURE(value, expected, tol);
+    REQUIRE(std::abs(value - expected) <= tol);
+}
+
+double factorial(std::ptrdiff_t n) {
+    double value = 1.0;
+
+    for (std::ptrdiff_t i = 2; i <= n; ++i) {
+        value *= static_cast<double>(i);
+    }
+
+    return value;
+}
+
+double zernike_radial_factorial_reference(std::ptrdiff_t n, std::ptrdiff_t m, double rho) {
+    m = m < 0 ? -m : m;
+    double value = 0.0;
+    double sign = 1.0;
+
+    for (std::ptrdiff_t k = 0; k <= (n - m) / 2; ++k) {
+        const double coeff =
+            sign * factorial(n - k) /
+            (factorial(k) * factorial((n + m) / 2 - k) * factorial((n - m) / 2 - k));
+
+        value += coeff * std::pow(rho, static_cast<double>(n - 2 * k));
+        sign = -sign;
+    }
+
+    return value;
+}
+
+} // namespace
+
+TEST_CASE("zernike radial low-order exact polynomials", "[zernike][xsf_tests]") {
+    const double rho = 0.25;
+    const double rho2 = rho * rho;
+    const double rho4 = rho2 * rho2;
+
+    require_close(xsf::eval_zernike_radial(0, 0, rho), 1.0);
+    require_close(xsf::eval_zernike_radial(1, 1, rho), rho);
+    require_close(xsf::eval_zernike_radial(2, 0, rho), 2.0 * rho2 - 1.0);
+    require_close(xsf::eval_zernike_radial(2, 2, rho), rho2);
+    require_close(xsf::eval_zernike_radial(4, 0, rho), 6.0 * rho4 - 6.0 * rho2 + 1.0);
+    require_close(xsf::eval_zernike_radial(4, 2, rho), 4.0 * rho4 - 3.0 * rho2);
+    require_close(xsf::eval_zernike_radial(4, 4, rho), rho4);
+}
+
+TEST_CASE("zernike radial identities", "[zernike][xsf_tests]") {
+    for (std::ptrdiff_t n = 0; n <= 20; ++n) {
+        require_close(xsf::eval_zernike_radial(n, n, 0.3), std::pow(0.3, static_cast<double>(n)));
+        require_close(xsf::eval_zernike_radial(n, n, 1.0), 1.0);
+
+        for (std::ptrdiff_t m = 0; m <= n; ++m) {
+            if (((n - m) & 1) != 0) {
+                continue;
+            }
+
+            require_close(xsf::eval_zernike_radial(n, m, 1.0), 1.0, 2e-13);
+            require_close(xsf::eval_zernike_radial(n, -m, 0.6), xsf::eval_zernike_radial(n, m, 0.6));
+        }
+    }
+}
+
+TEST_CASE("zernike radial agrees with factorial definition", "[zernike][xsf_tests]") {
+    using test_case = std::tuple<std::ptrdiff_t, std::ptrdiff_t, double>;
+    auto [n, m, rho] = GENERATE(
+        test_case{6, 0, 0.2}, test_case{6, 2, 0.4}, test_case{8, 4, 0.7}, test_case{10, 0, 0.3},
+        test_case{12, 6, 0.9}, test_case{14, 2, 0.5}, test_case{18, 8, 0.75}
+    );
+
+    const double output = xsf::eval_zernike_radial(n, m, rho);
+    const double expected = zernike_radial_factorial_reference(n, m, rho);
+    const double error = xsf::extended_relative_error(output, expected);
+
+    CAPTURE(n, m, rho, output, expected, error);
+    REQUIRE(error <= 5e-13);
+}
+
+TEST_CASE("zernike radial barmak and kintner methods agree", "[zernike][xsf_tests]") {
+    using test_case = std::tuple<std::ptrdiff_t, std::ptrdiff_t, double>;
+    auto [n, m, rho] = GENERATE(
+        test_case{0, 0, 0.0}, test_case{2, 0, 0.25}, test_case{5, 1, 0.5}, test_case{20, 0, 0.7},
+        test_case{32, 12, 0.8}, test_case{50, 10, 0.7}, test_case{80, 30, 0.6}, test_case{100, 50, 0.9}
+    );
+
+    const double barmak = xsf::eval_zernike_radial_barmak(n, m, rho);
+    const double kintner = xsf::eval_zernike_radial_kintner(n, m, rho);
+    const double error = xsf::extended_relative_error(barmak, kintner);
+
+    CAPTURE(n, m, rho, barmak, kintner, error);
+    REQUIRE(error <= 5e-12);
+}
+
+TEST_CASE("zernike radial domain handling", "[zernike][xsf_tests]") {
+    REQUIRE(std::isnan(xsf::eval_zernike_radial(-1, 0, 0.5)));
+    REQUIRE(std::isnan(xsf::eval_zernike_radial(2, 3, 0.5)));
+    REQUIRE(std::isnan(xsf::eval_zernike_radial(2, 1, 0.5)));
+    REQUIRE(std::isnan(xsf::eval_zernike_radial(2, 0, -0.1)));
+    REQUIRE(std::isnan(xsf::eval_zernike_radial(2, 0, 1.1)));
+    REQUIRE(std::isnan(xsf::eval_zernike_radial(0, 0, std::numeric_limits<double>::quiet_NaN())));
+}


### PR DESCRIPTION
Thanks for review!


**Title:**
```text
ENH: add eval_zernike_radial kernel and C++ tests
```

**Description:**
```markdown
## Summary

Adds the Zernike radial polynomial evaluation kernel `xsf::eval_zernike_radial(n, m, rho)` as a header-only C++ implementation, along with C++ tests.

Part of scipy/scipy#25118.

## Algorithm Choice

The direct factorial definition of the Zernike radial polynomial suffers from overflow and precision loss for moderate orders. To solve this, I implemented two recurrence relations:

1. **Kintner recurrence** (`eval_zernike_radial_kintner`): A classic 3-term recurrence in `n` that operates in O(1) memory space.
2. **Barmak recurrence** (`eval_zernike_radial_barmak`): A 2D recurrence relation.

I considered manual python implementation using original definition containing factorials that showed divergence and bad asymptotic on high orders (due to factorials) and Jacobi polynomial formula using existing scipy.special.eval_jacobi function that performed slow and not accurate. For the better implementation I tested Prata, Barmak, Kintner and Q-recursive formulas on my benchmarks. Barmak and Kintner recurrence methods vastly outperform others and are highly stable. Between the two, **Barmak performed slightly better** in my tests, so `eval_zernike_radial` defaults to using the Barmak implementation. The Kintner implementation is retained in the header for internal benchmarking and cross-validation, but will not be exposed to the SciPy Python API.

## Implementation Details

- **Header**: `include/xsf/zernike.h` — all logic is inline in `namespace xsf` and `namespace xsf::detail`.
- **Error handling**: Returns `NaN` and calls `set_error("eval_zernike_radial", SF_ERROR_DOMAIN, ...)` for:
  - `n < 0`
  - `|m| > n`
  - `(n - |m|)` is odd
  - `rho < 0` or `rho > 1`
  - `rho` is `NaN`
- **Negative `m`**: Folded using `|m|` so `R_n^{-m}(ρ) = R_n^{m}(ρ)`.
- **Memory Safety**: The Barmak recurrence requires tracking previous rows of coefficients. This implementation uses `std::vector` with a `try-catch` block to safely handle potential allocation failures, returning `NaN` and calling `set_error` with `SF_ERROR_MEMORY` if allocation fails.

## Tests

`tests/xsf_tests/test_zernike.cpp` covers 5 test suites:

1. **Low-order exact polynomials**: Verifies exact analytical values for `n=0..4` (e.g., `R₀⁰=1`, `R₁¹=ρ`, `R₂⁰=2ρ²−1`, `R₄²=4ρ⁴−3ρ²`).
2. **Identities**: For `n ≤ 20`, verifies `R_n^n(ρ) = ρⁿ`, `R_n^m(1.0) = 1.0`, and `R_n^{-m}(ρ) = R_n^m(ρ)`.
3. **Agreement with factorial definition**: Compares recurrence output against a direct factorial reference implementation for moderate orders up to `n=18`, ensuring relative error ≤ 5e-13.
4. **Barmak vs Kintner agreement**: Cross-validates the two recurrence methods against each other for high orders up to `n=100` (e.g., `n=100, m=50`), ensuring relative error ≤ 5e-12.
5. **Domain handling**: Verifies `NaN` is returned for `n < 0`, `|m| > n`, odd `(n - |m|)`, `ρ` outside `[0, 1]`, and `ρ = NaN`.

## AI Use Declaration
AI Codex and z.ai were used when composing initial folder with my work to match submission requirements (where and what file to paste and how to fork repo, git add and commit pull request).
```



