### PR TITLE
ENH: Add `jacobi` and `shifted jacobi` to XSF

### DIFF
--- a/include/xsf/orthogonal_eval.h
+++ b/include/xsf/orthogonal_eval.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "binom.h"
+#include "config.h"
+#include "hyp2f1.h"
+
+namespace xsf {
+
+// Jacobi
+
+template <typename T>
+XSF_HOST_DEVICE inline T eval_jacobi(double n, double alpha, double beta, T x) {
+    double a, b, c, d;
+    T g;
+
+    if (alpha == -1 and std::abs(beta) == 1) {
+        if (n == 0) {
+            return 1.0;
+        } else if (n == 1) {
+            return 0.5 * (1.0 + beta) * (x - 1.0);
+        } else if (n > 1) {
+            return ((n + beta) / (2.0 * n)) * (x - 1) * eval_jacobi(n - 1, 1, beta, x);
+        }
+    }
+
+    d = binom(n + alpha, n);
+    a = -n;
+    b = n + alpha + beta + 1;
+    c = alpha + 1;
+    g = 0.5 * (1 - x);
+    return d * hyp2f1(a, b, c, g);
+}
+
+XSF_HOST_DEVICE inline double eval_jacobi_l(int n, double alpha, double beta, double x) {
+    int kk;
+    double p, d;
+    double k, t;
+
+    if (n < 0) {
+        return eval_jacobi(n, alpha, beta, x);
+    } else if (n == 0) {
+        return 1.0;
+    } else if (n == 1) {
+        return 0.5 * (2 * (alpha + 1) + (alpha + beta + 2) * (x - 1));
+    } else if (alpha == -1 and std::abs(beta) == 1) {
+        return ((n + beta) / (2.0 * n)) * (x - 1) * eval_jacobi(n - 1, 1, beta, x);
+    } else {
+        d = (alpha + beta + 2) * (x - 1) / (2 * (alpha + 1));
+        p = d + 1;
+        for (kk = 0; kk < n - 1; kk++) {
+            k = kk + 1.0;
+            t = 2 * k + alpha + beta;
+            d = ((t * (t + 1) * (t + 2)) * (x - 1) * p + 2 * k * (k + beta) * (t + 2) * d) /
+                (2 * (k + alpha + 1) * (k + alpha + beta + 1) * t);
+            p = d + p;
+        }
+        return binom(n + alpha, n) * p;
+    }
+}
+
+template <typename T>
+XSF_HOST_DEVICE inline float eval_jacobi(float n, float alpha, float beta, T x) {
+    return eval_jacobi(
+        static_cast<double>(n), static_cast<double>(alpha), static_cast<double>(beta), static_cast<double>(x)
+    );
+}
+
+XSF_HOST_DEVICE inline float eval_jacobi_l(int n, float alpha, float beta, float x) {
+    return eval_jacobi_l(n, static_cast<double>(alpha), static_cast<double>(beta), static_cast<double>(x));
+}
+
+// Shifted Jacobi
+
+template <typename T>
+XSF_HOST_DEVICE inline T eval_sh_jacobi(double n, double p, double q, T x) {
+    return eval_jacobi(n, p - q, q - 1, 2 * x - 1) / binom(2 * n + p - 1, n);
+}
+
+XSF_HOST_DEVICE inline double eval_sh_jacobi_l(int n, double p, double q, double x) {
+    return eval_jacobi_l(n, p - q, q - 1, 2 * x - 1) / binom(2 * n + p - 1, n);
+}
+
+template <typename T>
+XSF_HOST_DEVICE inline T eval_sh_jacobi(float n, float p, float q, T x) {
+    return eval_sh_jacobi(
+        static_cast<double>(n), static_cast<double>(p), static_cast<double>(q), static_cast<double>(x)
+    );
+}
+
+XSF_HOST_DEVICE inline float eval_sh_jacobi_l(int n, float p, float q, float x) {
+    return eval_sh_jacobi_l(n, static_cast<double>(p), static_cast<double>(q), static_cast<double>(x));
+}
+
+} // namespace xsf

--- a/include/xsf/orthogonal_eval.h
+++ b/include/xsf/orthogonal_eval.h
@@ -31,8 +31,8 @@ namespace detail {
         return d * hyp2f1(a, b, c, g);
     }
 
-    XSF_HOST_DEVICE inline double eval_jacobi_l(long n, double alpha, double beta, double x) {
-        long kk;
+    XSF_HOST_DEVICE inline double eval_jacobi_l(std::ptrdiff_t n, double alpha, double beta, double x) {
+        std::ptrdiff_t kk;
         double p, d;
         double k, t;
 
@@ -83,11 +83,11 @@ XSF_HOST_DEVICE inline std::complex<float> eval_jacobi(float n, float alpha, flo
     ));
 }
 
-XSF_HOST_DEVICE inline double eval_jacobi(long n, double alpha, double beta, double x) {
+XSF_HOST_DEVICE inline double eval_jacobi(std::ptrdiff_t n, double alpha, double beta, double x) {
     return detail::eval_jacobi_l(n, alpha, beta, x);
 }
 
-XSF_HOST_DEVICE inline float eval_jacobi(long n, float alpha, float beta, float x) {
+XSF_HOST_DEVICE inline float eval_jacobi(std::ptrdiff_t n, float alpha, float beta, float x) {
     return detail::eval_jacobi_l(n, static_cast<double>(alpha), static_cast<double>(beta), static_cast<double>(x));
 }
 
@@ -97,7 +97,7 @@ XSF_HOST_DEVICE inline double eval_sh_jacobi(double n, double p, double q, doubl
     return detail::eval_jacobi(n, p - q, q - 1.0, 2.0 * x - 1.0) / binom(2.0 * n + p - 1.0, n);
 }
 
-XSF_HOST_DEVICE inline double eval_sh_jacobi(long n, double p, double q, double x) {
+XSF_HOST_DEVICE inline double eval_sh_jacobi(std::ptrdiff_t n, double p, double q, double x) {
     return detail::eval_jacobi_l(n, p - q, q - 1.0, 2.0 * x - 1.0) / binom(2.0 * n + p - 1.0, n);
 }
 
@@ -109,7 +109,7 @@ XSF_HOST_DEVICE inline float eval_sh_jacobi(float n, float p, float q, float x) 
            binom(2.0 * static_cast<double>(n) + static_cast<double>(p) - 1.0, static_cast<double>(n));
 }
 
-XSF_HOST_DEVICE inline float eval_sh_jacobi(long n, float p, float q, float x) {
+XSF_HOST_DEVICE inline float eval_sh_jacobi(std::ptrdiff_t n, float p, float q, float x) {
     return detail::eval_jacobi_l(
                n, static_cast<double>(p) - static_cast<double>(q), static_cast<double>(q) - 1.0,
                2.0 * static_cast<double>(x) - 1.0

--- a/include/xsf/orthogonal_eval.h
+++ b/include/xsf/orthogonal_eval.h
@@ -1,38 +1,60 @@
 #pragma once
 
+#include <cmath>
+#include <complex>
+#include <cstddef>
+
 #include "binom.h"
 #include "config.h"
 #include "hyp2f1.h"
 
 namespace xsf {
 
-// Jacobi
+namespace detail {
 
-template <typename T>
-XSF_HOST_DEVICE inline T eval_jacobi(double n, double alpha, double beta, T x) {
-    double a, b, c, d;
-    T g;
+    template <typename T>
+    XSF_HOST_DEVICE inline T eval_jacobi_impl(double n, double alpha, double beta, T x) {
+        double a, b, c, d;
+        T g;
 
-    if (alpha == -1 and std::abs(beta) == 1) {
-        if (n == 0) {
-            return 1.0;
-        } else if (n == 1) {
-            return 0.5 * (1.0 + beta) * (x - 1.0);
-        } else if (n > 1) {
-            return ((n + beta) / (2.0 * n)) * (x - 1) * eval_jacobi(n - 1, 1, beta, x);
+        if (alpha == -1 && std::abs(beta) == 1) {
+            if (n == 0) {
+                return 1.0;
+            } else if (n == 1) {
+                return 0.5 * (1.0 + beta) * (x - 1.0);
+            } else if (n > 1) {
+                return ((n + beta) / (2.0 * n)) * (x - 1.0) * eval_jacobi_impl(n - 1.0, 1.0, beta, x);
+            }
         }
+
+        d = binom(n + alpha, n);
+        a = -n;
+        b = n + alpha + beta + 1.0;
+        c = alpha + 1.0;
+        g = 0.5 * (1.0 - x);
+        return d * hyp2f1(a, b, c, g);
     }
 
-    d = binom(n + alpha, n);
-    a = -n;
-    b = n + alpha + beta + 1;
-    c = alpha + 1;
-    g = 0.5 * (1 - x);
-    return d * hyp2f1(a, b, c, g);
+} // namespace detail
+
+// Jacobi
+
+XSF_HOST_DEVICE inline double eval_jacobi(double n, double alpha, double beta, double x) {
+    return detail::eval_jacobi_impl(n, alpha, beta, x);
 }
 
-XSF_HOST_DEVICE inline double eval_jacobi_l(int n, double alpha, double beta, double x) {
-    int kk;
+XSF_HOST_DEVICE inline float eval_jacobi(float n, float alpha, float beta, float x) {
+    return eval_jacobi(
+        static_cast<double>(n), static_cast<double>(alpha), static_cast<double>(beta), static_cast<double>(x)
+    );
+}
+
+XSF_HOST_DEVICE inline std::complex<double> eval_jacobi(double n, double alpha, double beta, std::complex<double> x) {
+    return detail::eval_jacobi_impl(n, alpha, beta, x);
+}
+
+XSF_HOST_DEVICE inline double eval_jacobi_l(std::ptrdiff_t n, double alpha, double beta, double x) {
+    std::ptrdiff_t kk;
     double p, d;
     double k, t;
 
@@ -41,54 +63,49 @@ XSF_HOST_DEVICE inline double eval_jacobi_l(int n, double alpha, double beta, do
     } else if (n == 0) {
         return 1.0;
     } else if (n == 1) {
-        return 0.5 * (2 * (alpha + 1) + (alpha + beta + 2) * (x - 1));
-    } else if (alpha == -1 and std::abs(beta) == 1) {
-        return ((n + beta) / (2.0 * n)) * (x - 1) * eval_jacobi(n - 1, 1, beta, x);
+        return 0.5 * (2.0 * (alpha + 1.0) + (alpha + beta + 2.0) * (x - 1.0));
+    } else if (alpha == -1 && std::abs(beta) == 1) {
+        return ((n + beta) / (2.0 * n)) * (x - 1.0) * eval_jacobi(n - 1.0, 1.0, beta, x);
     } else {
-        d = (alpha + beta + 2) * (x - 1) / (2 * (alpha + 1));
-        p = d + 1;
+        d = (alpha + beta + 2.0) * (x - 1.0) / (2.0 * (alpha + 1.0));
+        p = d + 1.0;
         for (kk = 0; kk < n - 1; kk++) {
             k = kk + 1.0;
-            t = 2 * k + alpha + beta;
-            d = ((t * (t + 1) * (t + 2)) * (x - 1) * p + 2 * k * (k + beta) * (t + 2) * d) /
-                (2 * (k + alpha + 1) * (k + alpha + beta + 1) * t);
+            t = 2.0 * k + alpha + beta;
+            d = ((t * (t + 1.0) * (t + 2.0)) * (x - 1.0) * p + 2.0 * k * (k + beta) * (t + 2.0) * d) /
+                (2.0 * (k + alpha + 1.0) * (k + alpha + beta + 1.0) * t);
             p = d + p;
         }
         return binom(n + alpha, n) * p;
     }
 }
 
-template <typename T>
-XSF_HOST_DEVICE inline float eval_jacobi(float n, float alpha, float beta, T x) {
-    return eval_jacobi(
-        static_cast<double>(n), static_cast<double>(alpha), static_cast<double>(beta), static_cast<double>(x)
-    );
-}
-
-XSF_HOST_DEVICE inline float eval_jacobi_l(int n, float alpha, float beta, float x) {
+XSF_HOST_DEVICE inline float eval_jacobi_l(std::ptrdiff_t n, float alpha, float beta, float x) {
     return eval_jacobi_l(n, static_cast<double>(alpha), static_cast<double>(beta), static_cast<double>(x));
 }
 
 // Shifted Jacobi
 
-template <typename T>
-XSF_HOST_DEVICE inline T eval_sh_jacobi(double n, double p, double q, T x) {
-    return eval_jacobi(n, p - q, q - 1, 2 * x - 1) / binom(2 * n + p - 1, n);
+XSF_HOST_DEVICE inline double eval_sh_jacobi(double n, double p, double q, double x) {
+    return eval_jacobi(n, p - q, q - 1.0, 2.0 * x - 1.0) / binom(2.0 * n + p - 1.0, n);
 }
 
-XSF_HOST_DEVICE inline double eval_sh_jacobi_l(int n, double p, double q, double x) {
-    return eval_jacobi_l(n, p - q, q - 1, 2 * x - 1) / binom(2 * n + p - 1, n);
+XSF_HOST_DEVICE inline double eval_sh_jacobi_l(std::ptrdiff_t n, double p, double q, double x) {
+    return eval_jacobi_l(n, p - q, q - 1.0, 2.0 * x - 1.0) / binom(2.0 * n + p - 1.0, n);
 }
 
-template <typename T>
-XSF_HOST_DEVICE inline T eval_sh_jacobi(float n, float p, float q, T x) {
+XSF_HOST_DEVICE inline float eval_sh_jacobi(float n, float p, float q, float x) {
     return eval_sh_jacobi(
         static_cast<double>(n), static_cast<double>(p), static_cast<double>(q), static_cast<double>(x)
     );
 }
 
-XSF_HOST_DEVICE inline float eval_sh_jacobi_l(int n, float p, float q, float x) {
+XSF_HOST_DEVICE inline float eval_sh_jacobi_l(std::ptrdiff_t n, float p, float q, float x) {
     return eval_sh_jacobi_l(n, static_cast<double>(p), static_cast<double>(q), static_cast<double>(x));
+}
+
+XSF_HOST_DEVICE inline std::complex<double> eval_sh_jacobi(double n, double p, double q, std::complex<double> x) {
+    return eval_jacobi(n, p - q, q - 1.0, 2.0 * x - 1.0) / binom(2.0 * n + p - 1.0, n);
 }
 
 } // namespace xsf

--- a/include/xsf/orthogonal_eval.h
+++ b/include/xsf/orthogonal_eval.h
@@ -102,9 +102,11 @@ XSF_HOST_DEVICE inline double eval_sh_jacobi(long n, double p, double q, double 
 }
 
 XSF_HOST_DEVICE inline float eval_sh_jacobi(float n, float p, float q, float x) {
-    return eval_sh_jacobi(
-        static_cast<double>(n), static_cast<double>(p), static_cast<double>(q), static_cast<double>(x)
-    );
+    return detail::eval_jacobi(
+               static_cast<double>(n), static_cast<double>(p) - static_cast<double>(q), static_cast<double>(q) - 1.0,
+               2.0 * static_cast<double>(x) - 1.0
+           ) /
+           binom(2.0 * static_cast<double>(n) + static_cast<double>(p) - 1.0, static_cast<double>(n));
 }
 
 XSF_HOST_DEVICE inline float eval_sh_jacobi(long n, float p, float q, float x) {

--- a/include/xsf/orthogonal_eval.h
+++ b/include/xsf/orthogonal_eval.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#include <cmath>
-#include <complex>
-#include <cstddef>
-
 #include "binom.h"
 #include "config.h"
 #include "hyp2f1.h"
@@ -13,7 +9,7 @@ namespace xsf {
 namespace detail {
 
     template <typename T>
-    XSF_HOST_DEVICE inline T eval_jacobi_impl(double n, double alpha, double beta, T x) {
+    XSF_HOST_DEVICE inline T eval_jacobi(double n, double alpha, double beta, T x) {
         double a, b, c, d;
         T g;
 
@@ -23,7 +19,7 @@ namespace detail {
             } else if (n == 1) {
                 return 0.5 * (1.0 + beta) * (x - 1.0);
             } else if (n > 1) {
-                return ((n + beta) / (2.0 * n)) * (x - 1.0) * eval_jacobi_impl(n - 1.0, 1.0, beta, x);
+                return ((n + beta) / (2.0 * n)) * (x - 1.0) * eval_jacobi(n - 1.0, 1.0, beta, x);
             }
         }
 
@@ -35,63 +31,74 @@ namespace detail {
         return d * hyp2f1(a, b, c, g);
     }
 
+    XSF_HOST_DEVICE inline double eval_jacobi_l(long n, double alpha, double beta, double x) {
+        long kk;
+        double p, d;
+        double k, t;
+
+        if (n < 0) {
+            return eval_jacobi(n, alpha, beta, x);
+        } else if (n == 0) {
+            return 1.0;
+        } else if (n == 1) {
+            return 0.5 * (2.0 * (alpha + 1.0) + (alpha + beta + 2.0) * (x - 1.0));
+        } else if (alpha == -1 && std::abs(beta) == 1) {
+            return ((n + beta) / (2.0 * n)) * (x - 1.0) * eval_jacobi(n - 1.0, 1.0, beta, x);
+        } else {
+            d = (alpha + beta + 2.0) * (x - 1.0) / (2.0 * (alpha + 1.0));
+            p = d + 1.0;
+            for (kk = 0; kk < n - 1; kk++) {
+                k = kk + 1.0;
+                t = 2.0 * k + alpha + beta;
+                d = ((t * (t + 1.0) * (t + 2.0)) * (x - 1.0) * p + 2.0 * k * (k + beta) * (t + 2.0) * d) /
+                    (2.0 * (k + alpha + 1.0) * (k + alpha + beta + 1.0) * t);
+                p = d + p;
+            }
+            return binom(n + alpha, n) * p;
+        }
+    }
+
 } // namespace detail
 
 // Jacobi
 
 XSF_HOST_DEVICE inline double eval_jacobi(double n, double alpha, double beta, double x) {
-    return detail::eval_jacobi_impl(n, alpha, beta, x);
+    return detail::eval_jacobi(n, alpha, beta, x);
 }
 
 XSF_HOST_DEVICE inline float eval_jacobi(float n, float alpha, float beta, float x) {
-    return eval_jacobi(
+    return detail::eval_jacobi(
         static_cast<double>(n), static_cast<double>(alpha), static_cast<double>(beta), static_cast<double>(x)
     );
 }
 
 XSF_HOST_DEVICE inline std::complex<double> eval_jacobi(double n, double alpha, double beta, std::complex<double> x) {
-    return detail::eval_jacobi_impl(n, alpha, beta, x);
+    return detail::eval_jacobi(n, alpha, beta, x);
 }
 
-XSF_HOST_DEVICE inline double eval_jacobi_l(std::ptrdiff_t n, double alpha, double beta, double x) {
-    std::ptrdiff_t kk;
-    double p, d;
-    double k, t;
-
-    if (n < 0) {
-        return eval_jacobi(n, alpha, beta, x);
-    } else if (n == 0) {
-        return 1.0;
-    } else if (n == 1) {
-        return 0.5 * (2.0 * (alpha + 1.0) + (alpha + beta + 2.0) * (x - 1.0));
-    } else if (alpha == -1 && std::abs(beta) == 1) {
-        return ((n + beta) / (2.0 * n)) * (x - 1.0) * eval_jacobi(n - 1.0, 1.0, beta, x);
-    } else {
-        d = (alpha + beta + 2.0) * (x - 1.0) / (2.0 * (alpha + 1.0));
-        p = d + 1.0;
-        for (kk = 0; kk < n - 1; kk++) {
-            k = kk + 1.0;
-            t = 2.0 * k + alpha + beta;
-            d = ((t * (t + 1.0) * (t + 2.0)) * (x - 1.0) * p + 2.0 * k * (k + beta) * (t + 2.0) * d) /
-                (2.0 * (k + alpha + 1.0) * (k + alpha + beta + 1.0) * t);
-            p = d + p;
-        }
-        return binom(n + alpha, n) * p;
-    }
+XSF_HOST_DEVICE inline std::complex<float> eval_jacobi(float n, float alpha, float beta, std::complex<float> x) {
+    return static_cast<std::complex<float>>(detail::eval_jacobi(
+        static_cast<double>(n), static_cast<double>(alpha), static_cast<double>(beta),
+        static_cast<std::complex<double>>(x)
+    ));
 }
 
-XSF_HOST_DEVICE inline float eval_jacobi_l(std::ptrdiff_t n, float alpha, float beta, float x) {
-    return eval_jacobi_l(n, static_cast<double>(alpha), static_cast<double>(beta), static_cast<double>(x));
+XSF_HOST_DEVICE inline double eval_jacobi(long n, double alpha, double beta, double x) {
+    return detail::eval_jacobi_l(n, alpha, beta, x);
+}
+
+XSF_HOST_DEVICE inline float eval_jacobi(long n, float alpha, float beta, float x) {
+    return detail::eval_jacobi_l(n, static_cast<double>(alpha), static_cast<double>(beta), static_cast<double>(x));
 }
 
 // Shifted Jacobi
 
 XSF_HOST_DEVICE inline double eval_sh_jacobi(double n, double p, double q, double x) {
-    return eval_jacobi(n, p - q, q - 1.0, 2.0 * x - 1.0) / binom(2.0 * n + p - 1.0, n);
+    return detail::eval_jacobi(n, p - q, q - 1.0, 2.0 * x - 1.0) / binom(2.0 * n + p - 1.0, n);
 }
 
-XSF_HOST_DEVICE inline double eval_sh_jacobi_l(std::ptrdiff_t n, double p, double q, double x) {
-    return eval_jacobi_l(n, p - q, q - 1.0, 2.0 * x - 1.0) / binom(2.0 * n + p - 1.0, n);
+XSF_HOST_DEVICE inline double eval_sh_jacobi(long n, double p, double q, double x) {
+    return detail::eval_jacobi_l(n, p - q, q - 1.0, 2.0 * x - 1.0) / binom(2.0 * n + p - 1.0, n);
 }
 
 XSF_HOST_DEVICE inline float eval_sh_jacobi(float n, float p, float q, float x) {
@@ -100,12 +107,26 @@ XSF_HOST_DEVICE inline float eval_sh_jacobi(float n, float p, float q, float x) 
     );
 }
 
-XSF_HOST_DEVICE inline float eval_sh_jacobi_l(std::ptrdiff_t n, float p, float q, float x) {
-    return eval_sh_jacobi_l(n, static_cast<double>(p), static_cast<double>(q), static_cast<double>(x));
+XSF_HOST_DEVICE inline float eval_sh_jacobi(long n, float p, float q, float x) {
+    return detail::eval_jacobi_l(
+               n, static_cast<double>(p) - static_cast<double>(q), static_cast<double>(q) - 1.0,
+               2.0 * static_cast<double>(x) - 1.0
+           ) /
+           binom(2.0 * n + static_cast<double>(p) - 1.0, n);
 }
 
 XSF_HOST_DEVICE inline std::complex<double> eval_sh_jacobi(double n, double p, double q, std::complex<double> x) {
-    return eval_jacobi(n, p - q, q - 1.0, 2.0 * x - 1.0) / binom(2.0 * n + p - 1.0, n);
+    return detail::eval_jacobi(n, p - q, q - 1.0, 2.0 * x - 1.0) / binom(2.0 * n + p - 1.0, n);
+}
+
+XSF_HOST_DEVICE inline std::complex<float> eval_sh_jacobi(float n, float p, float q, std::complex<float> x) {
+    return static_cast<std::complex<float>>(
+        detail::eval_jacobi(
+            static_cast<double>(n), static_cast<double>(p) - static_cast<double>(q), static_cast<double>(q) - 1.0,
+            2.0 * static_cast<std::complex<double>>(x) - 1.0
+        ) /
+        binom(2.0 * static_cast<double>(n) + static_cast<double>(p) - 1.0, static_cast<double>(n))
+    );
 }
 
 } // namespace xsf

--- a/tests/xsf_tests/test_orthogonal_eval.cpp
+++ b/tests/xsf_tests/test_orthogonal_eval.cpp
@@ -1,0 +1,107 @@
+#include "../testing_utils.h"
+
+#include <xsf/orthogonal_eval.h>
+
+TEST_CASE("eval_jacobi real values", "[eval_jacobi][xsf_tests]") {
+    using test_case = std::tuple<double, double, double, double, double>;
+
+    auto [n, alpha, beta, x, expected] = GENERATE(
+        test_case{2, 0.0, 0.0, 0.5, -0.125}, test_case{3, 1.0, 1.0, -0.3, 0.71100000000000019},
+        test_case{4, 0.5, 1.5, 0.2, 0.54993750000000008}, test_case{0, 2.0, 3.0, 0.7, 1.0},
+        test_case{1, -0.5, 0.5, 0.4, -0.099999999999999978}, test_case{5, 2.0, -0.5, -0.6, -0.27551999999999993}
+    );
+
+    const double result = xsf::eval_jacobi(n, alpha, beta, x);
+    const double error = xsf::extended_relative_error(result, expected);
+    CAPTURE(n, alpha, beta, x, result, expected, error);
+    REQUIRE(error <= 1e-12);
+}
+
+TEST_CASE("eval_jacobi_l integer order", "[eval_jacobi][xsf_tests]") {
+    using test_case = std::tuple<int, double, double, double, double>;
+
+    auto [n, alpha, beta, x, expected] = GENERATE(
+        test_case{2, 0.0, 0.0, 0.5, -0.125}, test_case{3, 1.0, 1.0, -0.3, 0.71100000000000019},
+        test_case{4, 0.5, 1.5, 0.2, 0.54993750000000008}, test_case{0, 2.0, 3.0, 0.7, 1.0},
+        test_case{1, -0.5, 0.5, 0.4, -0.099999999999999978}, test_case{5, 2.0, -0.5, -0.6, -0.27551999999999988}
+    );
+
+    const double result = xsf::eval_jacobi_l(n, alpha, beta, x);
+    const double error = xsf::extended_relative_error(result, expected);
+    CAPTURE(n, alpha, beta, x, result, expected, error);
+    REQUIRE(error <= 1e-12);
+}
+
+TEST_CASE("eval_jacobi degenerate alpha=-1 |beta|=1", "[eval_jacobi][xsf_tests]") {
+    using test_case = std::tuple<int, double, double>;
+
+    auto [n, x, expected] = GENERATE(
+        test_case{0, 0.3, 1.0}, test_case{1, 0.3, -0.69999999999999996}, test_case{2, 0.3, -0.315},
+        test_case{3, 0.3, 0.19250000000000023}
+    );
+
+    const double from_double = xsf::eval_jacobi(static_cast<double>(n), -1.0, 1.0, x);
+    const double from_l = xsf::eval_jacobi_l(n, -1.0, 1.0, x);
+    CAPTURE(n, x, from_double, from_l, expected);
+    REQUIRE(xsf::extended_relative_error(from_double, expected) <= 1e-12);
+    REQUIRE(xsf::extended_relative_error(from_l, expected) <= 1e-12);
+}
+
+TEST_CASE("eval_jacobi float overloads", "[eval_jacobi][xsf_tests]") {
+    auto [n, alpha, beta, x] = GENERATE(
+        std::tuple<float, float, float, float>{2.0F, 0.0F, 0.0F, 0.5F},
+        std::tuple<float, float, float, float>{4.0F, 0.5F, 1.5F, 0.2F},
+        std::tuple<float, float, float, float>{5.0F, 2.0F, -0.5F, -0.6F}
+    );
+
+    const float result = xsf::eval_jacobi(n, alpha, beta, x);
+    const float expected = static_cast<float>(xsf::eval_jacobi(
+        static_cast<double>(n), static_cast<double>(alpha), static_cast<double>(beta), static_cast<double>(x)
+    ));
+    CAPTURE(n, alpha, beta, x, result, expected);
+    REQUIRE(result == expected);
+}
+
+TEST_CASE("eval_sh_jacobi real values", "[eval_sh_jacobi][xsf_tests]") {
+    using test_case = std::tuple<double, double, double, double, double>;
+
+    auto [n, p, q, x, expected] = GENERATE(
+        test_case{2, 3.0, 1.0, 0.5, -0.016666666666666698}, test_case{3, 2.0, 1.0, 0.3, 0.01128571428571429},
+        test_case{4, 4.0, 2.0, 0.7, -0.0035363636363636357}, test_case{0, 2.0, 1.0, 0.4, 1.0},
+        test_case{1, 3.0, 2.0, 0.6, 0.099999999999999978}, test_case{5, 5.0, 3.0, 0.2, 0.00079552447552447498}
+    );
+
+    const double result = xsf::eval_sh_jacobi(n, p, q, x);
+    const double error = xsf::extended_relative_error(result, expected);
+    CAPTURE(n, p, q, x, result, expected, error);
+    REQUIRE(error <= 1e-12);
+}
+
+TEST_CASE("eval_sh_jacobi_l integer order", "[eval_sh_jacobi][xsf_tests]") {
+    using test_case = std::tuple<int, double, double, double, double>;
+
+    auto [n, p, q, x, expected] = GENERATE(
+        test_case{2, 3.0, 1.0, 0.5, -0.016666666666666673}, test_case{3, 2.0, 1.0, 0.3, 0.011285714285714286},
+        test_case{4, 4.0, 2.0, 0.7, -0.0035363636363636352}, test_case{0, 2.0, 1.0, 0.4, 1.0},
+        test_case{1, 3.0, 2.0, 0.6, 0.099999999999999978}, test_case{5, 5.0, 3.0, 0.2, 0.00079552447552447584}
+    );
+
+    const double result = xsf::eval_sh_jacobi_l(n, p, q, x);
+    const double error = xsf::extended_relative_error(result, expected);
+    CAPTURE(n, p, q, x, result, expected, error);
+    REQUIRE(error <= 1e-12);
+}
+
+TEST_CASE("eval_sh_jacobi float overloads", "[eval_sh_jacobi][xsf_tests]") {
+    auto [n, p, q, x] = GENERATE(
+        std::tuple<float, float, float, float>{2.0F, 3.0F, 1.0F, 0.5F},
+        std::tuple<float, float, float, float>{4.0F, 4.0F, 2.0F, 0.7F}
+    );
+
+    const float result = xsf::eval_sh_jacobi(n, p, q, x);
+    const float expected = static_cast<float>(xsf::eval_sh_jacobi(
+        static_cast<double>(n), static_cast<double>(p), static_cast<double>(q), static_cast<double>(x)
+    ));
+    CAPTURE(n, p, q, x, result, expected);
+    REQUIRE(result == expected);
+}

--- a/tests/xsf_tests/test_orthogonal_eval.cpp
+++ b/tests/xsf_tests/test_orthogonal_eval.cpp
@@ -2,106 +2,246 @@
 
 #include <xsf/orthogonal_eval.h>
 
-TEST_CASE("eval_jacobi real values", "[eval_jacobi][xsf_tests]") {
-    using test_case = std::tuple<double, double, double, double, double>;
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <tuple>
+#include <utility>
+#include <vector>
 
-    auto [n, alpha, beta, x, expected] = GENERATE(
-        test_case{2, 0.0, 0.0, 0.5, -0.125}, test_case{3, 1.0, 1.0, -0.3, 0.71100000000000019},
-        test_case{4, 0.5, 1.5, 0.2, 0.54993750000000008}, test_case{0, 2.0, 3.0, 0.7, 1.0},
-        test_case{1, -0.5, 0.5, 0.4, -0.099999999999999978}, test_case{5, 2.0, -0.5, -0.6, -0.27551999999999993}
-    );
+namespace {
 
-    const double result = xsf::eval_jacobi(n, alpha, beta, x);
-    const double error = xsf::extended_relative_error(result, expected);
-    CAPTURE(n, alpha, beta, x, result, expected, error);
-    REQUIRE(error <= 1e-12);
+using Coefficients = std::vector<double>;
+using Parameters = std::vector<double>;
+using Range = std::pair<double, double>;
+
+double binom_int(double a, int k) {
+    double out = 1.0;
+    for (int j = 0; j < k; ++j) {
+        out *= (a - j) / (j + 1.0);
+    }
+    return out;
 }
 
-TEST_CASE("eval_jacobi_l integer order", "[eval_jacobi][xsf_tests]") {
-    using test_case = std::tuple<int, double, double, double, double>;
-
-    auto [n, alpha, beta, x, expected] = GENERATE(
-        test_case{2, 0.0, 0.0, 0.5, -0.125}, test_case{3, 1.0, 1.0, -0.3, 0.71100000000000019},
-        test_case{4, 0.5, 1.5, 0.2, 0.54993750000000008}, test_case{0, 2.0, 3.0, 0.7, 1.0},
-        test_case{1, -0.5, 0.5, 0.4, -0.099999999999999978}, test_case{5, 2.0, -0.5, -0.6, -0.27551999999999988}
-    );
-
-    const double result = xsf::eval_jacobi_l(n, alpha, beta, x);
-    const double error = xsf::extended_relative_error(result, expected);
-    CAPTURE(n, alpha, beta, x, result, expected, error);
-    REQUIRE(error <= 1e-12);
+Coefficients linear_power(double c0, double c1, int n) {
+    Coefficients out(n + 1, 0.0);
+    for (int j = 0; j <= n; ++j) {
+        out[j] = binom_int(n, j) * std::pow(c0, n - j) * std::pow(c1, j);
+    }
+    return out;
 }
 
-TEST_CASE("eval_jacobi degenerate alpha=-1 |beta|=1", "[eval_jacobi][xsf_tests]") {
-    using test_case = std::tuple<int, double, double>;
-
-    auto [n, x, expected] = GENERATE(
-        test_case{0, 0.3, 1.0}, test_case{1, 0.3, -0.69999999999999996}, test_case{2, 0.3, -0.315},
-        test_case{3, 0.3, 0.19250000000000023}
-    );
-
-    const double from_double = xsf::eval_jacobi(static_cast<double>(n), -1.0, 1.0, x);
-    const double from_l = xsf::eval_jacobi_l(n, -1.0, 1.0, x);
-    CAPTURE(n, x, from_double, from_l, expected);
-    REQUIRE(xsf::extended_relative_error(from_double, expected) <= 1e-12);
-    REQUIRE(xsf::extended_relative_error(from_l, expected) <= 1e-12);
+Coefficients multiply(const Coefficients &a, const Coefficients &b) {
+    Coefficients out(a.size() + b.size() - 1, 0.0);
+    for (std::size_t i = 0; i < a.size(); ++i) {
+        for (std::size_t j = 0; j < b.size(); ++j) {
+            out[i + j] += a[i] * b[j];
+        }
+    }
+    return out;
 }
 
-TEST_CASE("eval_jacobi float overloads", "[eval_jacobi][xsf_tests]") {
-    auto [n, alpha, beta, x] = GENERATE(
-        std::tuple<float, float, float, float>{2.0F, 0.0F, 0.0F, 0.5F},
-        std::tuple<float, float, float, float>{4.0F, 0.5F, 1.5F, 0.2F},
-        std::tuple<float, float, float, float>{5.0F, 2.0F, -0.5F, -0.6F}
-    );
-
-    const float result = xsf::eval_jacobi(n, alpha, beta, x);
-    const float expected = static_cast<float>(xsf::eval_jacobi(
-        static_cast<double>(n), static_cast<double>(alpha), static_cast<double>(beta), static_cast<double>(x)
-    ));
-    CAPTURE(n, alpha, beta, x, result, expected);
-    REQUIRE(result == expected);
+double polyval(const Coefficients &coeffs, double x) {
+    double out = 0.0;
+    for (auto it = coeffs.rbegin(); it != coeffs.rend(); ++it) {
+        out = out * x + *it;
+    }
+    return out;
 }
 
-TEST_CASE("eval_sh_jacobi real values", "[eval_sh_jacobi][xsf_tests]") {
-    using test_case = std::tuple<double, double, double, double, double>;
-
-    auto [n, p, q, x, expected] = GENERATE(
-        test_case{2, 3.0, 1.0, 0.5, -0.016666666666666698}, test_case{3, 2.0, 1.0, 0.3, 0.01128571428571429},
-        test_case{4, 4.0, 2.0, 0.7, -0.0035363636363636357}, test_case{0, 2.0, 1.0, 0.4, 1.0},
-        test_case{1, 3.0, 2.0, 0.6, 0.099999999999999978}, test_case{5, 5.0, 3.0, 0.2, 0.00079552447552447498}
-    );
-
-    const double result = xsf::eval_sh_jacobi(n, p, q, x);
-    const double error = xsf::extended_relative_error(result, expected);
-    CAPTURE(n, p, q, x, result, expected, error);
-    REQUIRE(error <= 1e-12);
+double sample(double a, double b, int i) {
+    constexpr double step = 0.7548776662466927;
+    const double u = std::fmod(step * (i + 1), 1.0);
+    return a + (b - a) * u;
 }
 
-TEST_CASE("eval_sh_jacobi_l integer order", "[eval_sh_jacobi][xsf_tests]") {
-    using test_case = std::tuple<int, double, double, double, double>;
+template <typename CoefficientsFunc, typename EvalFunc>
+void check_poly(
+    CoefficientsFunc coefficients_func, EvalFunc eval_func, const std::vector<Range> &param_ranges, Range x_range,
+    double rtol, int nn = 10, int nparam = 10, int nx = 10
+) {
+    for (int n = 0; n < nn; ++n) {
+        const int ncases = param_ranges.empty() ? 1 : nparam;
+        for (int ip = 0; ip < ncases; ++ip) {
+            Parameters params;
+            params.reserve(param_ranges.size());
+            for (std::size_t k = 0; k < param_ranges.size(); ++k) {
+                params.push_back(sample(param_ranges[k].first, param_ranges[k].second, 17 * n + nparam * k + ip));
+            }
+            const auto coeffs = coefficients_func(n, params);
 
-    auto [n, p, q, x, expected] = GENERATE(
-        test_case{2, 3.0, 1.0, 0.5, -0.016666666666666673}, test_case{3, 2.0, 1.0, 0.3, 0.011285714285714286},
-        test_case{4, 4.0, 2.0, 0.7, -0.0035363636363636352}, test_case{0, 2.0, 1.0, 0.4, 1.0},
-        test_case{1, 3.0, 2.0, 0.6, 0.099999999999999978}, test_case{5, 5.0, 3.0, 0.2, 0.00079552447552447584}
-    );
+            for (int ix = 0; ix < nx; ++ix) {
+                double x = sample(x_range.first, x_range.second, 31 * n + 13 * ip + ix);
+                if (ix == 0) {
+                    x = x_range.first;
+                } else if (ix == 1) {
+                    x = x_range.second;
+                }
 
-    const double result = xsf::eval_sh_jacobi_l(n, p, q, x);
-    const double error = xsf::extended_relative_error(result, expected);
-    CAPTURE(n, p, q, x, result, expected, error);
-    REQUIRE(error <= 1e-12);
+                const double out = eval_func(n, params, x);
+                const double expected = polyval(coeffs, x);
+                const double error = xsf::extended_absolute_error(out, expected);
+                const double tol = 1e-12 + rtol * std::abs(expected);
+                CAPTURE(n, params, x, out, expected, error, tol);
+                REQUIRE(error <= tol);
+            }
+        }
+    }
 }
 
-TEST_CASE("eval_sh_jacobi float overloads", "[eval_sh_jacobi][xsf_tests]") {
-    auto [n, p, q, x] = GENERATE(
-        std::tuple<float, float, float, float>{2.0F, 3.0F, 1.0F, 0.5F},
-        std::tuple<float, float, float, float>{4.0F, 4.0F, 2.0F, 0.7F}
+template <typename IntDegreeEvalFunc, typename DoubleDegreeEvalFunc>
+void check_recurrence(
+    IntDegreeEvalFunc int_degree_eval, DoubleDegreeEvalFunc double_degree_eval, const std::vector<Range> &param_ranges,
+    Range x_range, double rtol = 1e-8, int nn = 10, int nparam = 10, int nx = 10
+) {
+    for (int n = 0; n < nn; ++n) {
+        const int ncases = param_ranges.empty() ? 1 : nparam;
+        for (int ip = 0; ip < ncases; ++ip) {
+            Parameters params;
+            params.reserve(param_ranges.size());
+            for (std::size_t k = 0; k < param_ranges.size(); ++k) {
+                params.push_back(sample(param_ranges[k].first, param_ranges[k].second, 19 * n + nparam * k + ip));
+            }
+
+            for (int ix = 0; ix < nx; ++ix) {
+                double x = sample(x_range.first, x_range.second, 37 * n + 11 * ip + ix);
+                if (ix == 0) {
+                    x = x_range.first;
+                } else if (ix == 1) {
+                    x = x_range.second;
+                }
+
+                const double out = int_degree_eval(n, params, x);
+                const double expected = double_degree_eval(n, params, x);
+                const double error = xsf::extended_absolute_error(out, expected);
+                const double tol = 1e-12 + rtol * std::abs(expected);
+                CAPTURE(n, params, x, out, expected, error, tol);
+                REQUIRE(error <= tol);
+            }
+        }
+    }
+}
+
+} // namespace
+
+TEST_CASE("eval_jacobi matches constructed polynomials", "[eval_jacobi][xsf_tests]") {
+    check_poly(
+        [](int n, const Parameters &params) {
+            const double alpha = params[0];
+            const double beta = params[1];
+            Coefficients out(n + 1, 0.0);
+            const double scale = std::ldexp(1.0, -n);
+            for (int m = 0; m <= n; ++m) {
+                const double c = scale * binom_int(n + alpha, m) * binom_int(n + beta, n - m);
+                const auto term = multiply(linear_power(-1.0, 1.0, n - m), linear_power(1.0, 1.0, m));
+                for (int j = 0; j <= n; ++j) {
+                    out[j] += c * term[j];
+                }
+            }
+            return out;
+        },
+        [](int n, const Parameters &params, double x) {
+            return xsf::eval_jacobi(static_cast<double>(n), params[0], params[1], x);
+        },
+        {{-0.99, 10.0}, {-0.99, 10.0}}, {-1.0, 1.0}, 1e-5
+    );
+}
+
+TEST_CASE("eval_sh_jacobi matches constructed polynomials", "[eval_sh_jacobi][xsf_tests]") {
+    check_poly(
+        [](int n, const Parameters &params) {
+            const double p = params[0];
+            const double q = params[1];
+            const double alpha = p - q;
+            const double beta = q - 1.0;
+            const double scale = 1.0 / xsf::binom(2.0 * n + p - 1.0, n);
+            Coefficients out(n + 1, 0.0);
+            for (int m = 0; m <= n; ++m) {
+                const double c = scale * binom_int(n + alpha, m) * binom_int(n + beta, n - m);
+                const auto term = multiply(linear_power(-1.0, 1.0, n - m), linear_power(0.0, 1.0, m));
+                for (int j = 0; j <= n; ++j) {
+                    out[j] += c * term[j];
+                }
+            }
+            return out;
+        },
+        [](int n, const Parameters &params, double x) {
+            return xsf::eval_sh_jacobi(static_cast<double>(n), params[0], params[1], x);
+        },
+        {{1.0, 10.0}, {0.0, 1.0}}, {0.0, 1.0}, 1e-5
+    );
+}
+
+TEST_CASE("eval_jacobi recurrence overload", "[eval_jacobi][xsf_tests]") {
+    check_recurrence(
+        [](int n, const Parameters &params, double x) { return xsf::eval_jacobi_l(n, params[0], params[1], x); },
+        [](int n, const Parameters &params, double x) {
+            return xsf::eval_jacobi(static_cast<double>(n), params[0], params[1], x);
+        },
+        {{-0.99, 10.0}, {-0.99, 10.0}}, {-1.0, 1.0}
+    );
+}
+
+TEST_CASE("eval_sh_jacobi recurrence overload", "[eval_sh_jacobi][xsf_tests]") {
+    check_recurrence(
+        [](int n, const Parameters &params, double x) { return xsf::eval_sh_jacobi_l(n, params[0], params[1], x); },
+        [](int n, const Parameters &params, double x) {
+            return xsf::eval_sh_jacobi(static_cast<double>(n), params[0], params[1], x);
+        },
+        {{1.0, 10.0}, {0.0, 1.0}}, {0.0, 1.0}
+    );
+}
+
+TEST_CASE("eval_jacobi alpha=-1 beta=1", "[eval_jacobi][xsf_tests]") {
+    using test_case = std::tuple<int, std::array<double, 11>>;
+    // gh-7001 - expected values were computed with mathematica.
+    auto [n, expected] = GENERATE(
+        test_case{0, {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0}},
+        test_case{1, {-2.0, -1.8, -1.6, -1.4, -1.2, -1.0, -0.8, -0.6, -0.4, -0.2, 0.0}},
+        test_case{2, {3.0, 2.16, 1.44, 0.84, 0.36, 0.0, -0.24, -0.36, -0.36, -0.24, 0.0}},
+        test_case{3, {-4.0, -1.98, -0.64, 0.14, 0.48, 0.5, 0.32, 0.06, -0.16, -0.22, 0.0}},
+        test_case{4, {5.0, 1.332, -0.288, -0.658, -0.408, 0.0, 0.272, 0.282, 0.072, -0.148, 0.0}},
+        test_case{5, {-6.0, -0.43308, 0.79104, 0.36876, -0.21312, -0.375, -0.14208, 0.15804, 0.19776, -0.04812, 0.0}}
     );
 
-    const float result = xsf::eval_sh_jacobi(n, p, q, x);
-    const float expected = static_cast<float>(xsf::eval_sh_jacobi(
-        static_cast<double>(n), static_cast<double>(p), static_cast<double>(q), static_cast<double>(x)
-    ));
-    CAPTURE(n, p, q, x, result, expected);
-    REQUIRE(result == expected);
+    for (std::size_t j = 0; j < expected.size(); ++j) {
+        const double x = -1.0 + 0.2 * static_cast<double>(j);
+        auto out = xsf::eval_jacobi_l(n, -1.0, 1.0, x);
+        auto error = xsf::extended_absolute_error(out, expected[j]);
+        auto tol = 1e-14 + 1e-10 * std::abs(expected[j]);
+        CAPTURE(n, x, out, expected[j], error, tol);
+        REQUIRE(error <= tol);
+
+        out = xsf::eval_jacobi(static_cast<double>(n), -1.0, 1.0, x);
+        error = xsf::extended_absolute_error(out, expected[j]);
+        CAPTURE(n, x, out, expected[j], error, tol);
+        REQUIRE(error <= tol);
+    }
+}
+
+TEST_CASE("eval_jacobi alpha=-1 beta=-1", "[eval_jacobi][xsf_tests]") {
+    using test_case = std::tuple<int, std::array<double, 11>>;
+    // gh-7001 - expected values were computed with mathematica.
+    auto [n, expected] = GENERATE(
+        test_case{0, {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0}},
+        test_case{1, {0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0}},
+        test_case{2, {0.0, -0.09, -0.16, -0.21, -0.24, -0.25, -0.24, -0.21, -0.16, -0.09, 0.0}},
+        test_case{3, {0.0, 0.144, 0.192, 0.168, 0.096, 0.0, -0.096, -0.168, -0.192, -0.144, 0.0}},
+        test_case{4, {0.0, -0.1485, -0.096, 0.0315, 0.144, 0.1875, 0.144, 0.0315, -0.096, -0.1485, 0.0}},
+        test_case{5, {0.0, 0.10656, -0.04608, -0.15792, -0.13056, 0.0, 0.13056, 0.15792, 0.04608, -0.10656, 0.0}}
+    );
+
+    for (std::size_t j = 0; j < expected.size(); ++j) {
+        const double x = -1.0 + 0.2 * static_cast<double>(j);
+        auto out = xsf::eval_jacobi_l(n, -1.0, -1.0, x);
+        auto error = xsf::extended_absolute_error(out, expected[j]);
+        auto tol = 1e-14 + 1e-10 * std::abs(expected[j]);
+        CAPTURE(n, x, out, expected[j], error, tol);
+        REQUIRE(error <= tol);
+
+        out = xsf::eval_jacobi(static_cast<double>(n), -1.0, -1.0, x);
+        error = xsf::extended_absolute_error(out, expected[j]);
+        CAPTURE(n, x, out, expected[j], error, tol);
+        REQUIRE(error <= tol);
+    }
 }

--- a/tests/xsf_tests/test_orthogonal_eval.cpp
+++ b/tests/xsf_tests/test_orthogonal_eval.cpp
@@ -320,7 +320,7 @@ TEST_CASE("eval_sh_jacobi matches SciPy complex<float> reference values", "[eval
 TEST_CASE("eval_jacobi recurrence overload", "[eval_jacobi][xsf_tests]") {
     // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestRecurrence.test_jacobi
     check_recurrence(
-        [](long n, const std::vector<double> &params, double x) {
+        [](std::ptrdiff_t n, const std::vector<double> &params, double x) {
             return xsf::eval_jacobi(n, params[0], params[1], x);
         },
         [](double n, const std::vector<double> &params, double x) {
@@ -333,7 +333,7 @@ TEST_CASE("eval_jacobi recurrence overload", "[eval_jacobi][xsf_tests]") {
 TEST_CASE("eval_sh_jacobi recurrence overload", "[eval_sh_jacobi][xsf_tests]") {
     // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestRecurrence.test_sh_jacobi
     check_recurrence(
-        [](long n, const std::vector<double> &params, double x) {
+        [](std::ptrdiff_t n, const std::vector<double> &params, double x) {
             return xsf::eval_sh_jacobi(n, params[0], params[1], x);
         },
         [](double n, const std::vector<double> &params, double x) {
@@ -358,7 +358,7 @@ TEST_CASE("eval_jacobi alpha=-1 beta=1", "[eval_jacobi][xsf_tests]") {
 
     for (std::size_t j = 0; j < expected.size(); ++j) {
         const double x = -1.0 + 0.2 * static_cast<double>(j);
-        auto out = xsf::eval_jacobi(static_cast<long>(n), -1.0, 1.0, x);
+        auto out = xsf::eval_jacobi(static_cast<std::ptrdiff_t>(n), -1.0, 1.0, x);
         auto error = xsf::extended_absolute_error(out, expected[j]);
         auto tol = 1e-14 + 1e-10 * std::abs(expected[j]);
         CAPTURE(n, x, out, expected[j], error, tol);
@@ -386,7 +386,7 @@ TEST_CASE("eval_jacobi alpha=-1 beta=-1", "[eval_jacobi][xsf_tests]") {
 
     for (std::size_t j = 0; j < expected.size(); ++j) {
         const double x = -1.0 + 0.2 * static_cast<double>(j);
-        auto out = xsf::eval_jacobi(static_cast<long>(n), -1.0, -1.0, x);
+        auto out = xsf::eval_jacobi(static_cast<std::ptrdiff_t>(n), -1.0, -1.0, x);
         auto error = xsf::extended_absolute_error(out, expected[j]);
         auto tol = 1e-14 + 1e-10 * std::abs(expected[j]);
         CAPTURE(n, x, out, expected[j], error, tol);

--- a/tests/xsf_tests/test_orthogonal_eval.cpp
+++ b/tests/xsf_tests/test_orthogonal_eval.cpp
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <cmath>
+#include <complex>
 #include <cstddef>
 #include <tuple>
 #include <utility>
@@ -24,7 +25,7 @@ double binom_int(double a, int k) {
 }
 
 Coefficients linear_power(double c0, double c1, int n) {
-    Coefficients out(n + 1, 0.0);
+    Coefficients out(n + 1.0, 0.0);
     for (int j = 0; j <= n; ++j) {
         out[j] = binom_int(n, j) * std::pow(c0, n - j) * std::pow(c1, j);
     }
@@ -41,8 +42,9 @@ Coefficients multiply(const Coefficients &a, const Coefficients &b) {
     return out;
 }
 
-double polyval(const Coefficients &coeffs, double x) {
-    double out = 0.0;
+template <typename T>
+T polyval(const Coefficients &coeffs, T x) {
+    T out = 0.0;
     for (auto it = coeffs.rbegin(); it != coeffs.rend(); ++it) {
         out = out * x + *it;
     }
@@ -78,8 +80,35 @@ void check_poly(
                     x = x_range.second;
                 }
 
-                const double out = eval_func(n, params, x);
+                const auto out = eval_func(n, params, x);
                 const double expected = polyval(coeffs, x);
+                const double error = xsf::extended_absolute_error(out, expected);
+                const double tol = 1e-12 + rtol * std::abs(expected);
+                CAPTURE(n, params, x, out, expected, error, tol);
+                REQUIRE(error <= tol);
+            }
+        }
+    }
+}
+
+template <typename CoefficientsFunc, typename EvalFunc>
+void check_complex_poly(
+    CoefficientsFunc coefficients_func, EvalFunc eval_func, const std::vector<std::pair<double, double>> &param_ranges,
+    const std::vector<std::complex<double>> &xs, double rtol, int nn = 10, int nparam = 10
+) {
+    for (int n = 0; n < nn; ++n) {
+        const int ncases = param_ranges.empty() ? 1 : nparam;
+        for (int ip = 0; ip < ncases; ++ip) {
+            Parameters params;
+            params.reserve(param_ranges.size());
+            for (std::size_t k = 0; k < param_ranges.size(); ++k) {
+                params.push_back(sample(param_ranges[k].first, param_ranges[k].second, 23 * n + nparam * k + ip));
+            }
+            const auto coeffs = coefficients_func(n, params);
+
+            for (const auto &x : xs) {
+                const auto out = eval_func(n, params, x);
+                const auto expected = polyval(coeffs, x);
                 const double error = xsf::extended_absolute_error(out, expected);
                 const double tol = 1e-12 + rtol * std::abs(expected);
                 CAPTURE(n, params, x, out, expected, error, tol);
@@ -125,11 +154,12 @@ void check_recurrence(
 } // namespace
 
 TEST_CASE("eval_jacobi matches constructed polynomials", "[eval_jacobi][xsf_tests]") {
+    // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestPolys.test_jacobi
     check_poly(
         [](int n, const Parameters &params) {
             const double alpha = params[0];
             const double beta = params[1];
-            Coefficients out(n + 1, 0.0);
+            Coefficients out(n + 1.0, 0.0);
             const double scale = std::ldexp(1.0, -n);
             for (int m = 0; m <= n; ++m) {
                 const double c = scale * binom_int(n + alpha, m) * binom_int(n + beta, n - m);
@@ -140,14 +170,37 @@ TEST_CASE("eval_jacobi matches constructed polynomials", "[eval_jacobi][xsf_test
             }
             return out;
         },
-        [](int n, const Parameters &params, double x) {
-            return xsf::eval_jacobi(static_cast<double>(n), params[0], params[1], x);
+        [](double n, const Parameters &params, double x) { return xsf::eval_jacobi(n, params[0], params[1], x); },
+        {{-0.99, 10.0}, {-0.99, 10.0}}, {-1.0, 1.0}, 1e-5
+    );
+}
+
+TEST_CASE("eval_jacobi supports complex inputs", "[eval_jacobi][xsf_tests]") {
+    // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestPolys.test_jacobi for complex inputs
+    check_complex_poly(
+        [](double n, const Parameters &params) {
+            const double alpha = params[0];
+            const double beta = params[1];
+            Coefficients out(n + 1.0, 0.0);
+            const double scale = std::ldexp(1.0, -n);
+            for (int m = 0; m <= n; ++m) {
+                const double c = scale * binom_int(n + alpha, m) * binom_int(n + beta, n - m);
+                const auto term = multiply(linear_power(-1.0, 1.0, n - m), linear_power(1.0, 1.0, m));
+                for (int j = 0; j <= n; ++j) {
+                    out[j] += c * term[j];
+                }
+            }
+            return out;
+        },
+        [](double n, const Parameters &params, std::complex<double> x) {
+            return xsf::eval_jacobi(n, params[0], params[1], x);
         },
         {{-0.99, 10.0}, {-0.99, 10.0}}, {-1.0, 1.0}, 1e-5
     );
 }
 
 TEST_CASE("eval_sh_jacobi matches constructed polynomials", "[eval_sh_jacobi][xsf_tests]") {
+    // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestPolys.test_sh_jacobi
     check_poly(
         [](int n, const Parameters &params) {
             const double p = params[0];
@@ -165,34 +218,61 @@ TEST_CASE("eval_sh_jacobi matches constructed polynomials", "[eval_sh_jacobi][xs
             }
             return out;
         },
-        [](int n, const Parameters &params, double x) {
-            return xsf::eval_sh_jacobi(static_cast<double>(n), params[0], params[1], x);
+        [](double n, const Parameters &params, double x) { return xsf::eval_sh_jacobi(n, params[0], params[1], x); },
+        {{1.0, 10.0}, {0.0, 1.0}}, {0.0, 1.0}, 1e-5
+    );
+}
+
+TEST_CASE("eval_sh_jacobi for complex inputs", "[eval_sh_jacobi][xsf_tests]") {
+    // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestPolys.test_sh_jacobi for complex inputs
+    check_complex_poly(
+        [](double n, const Parameters &params) {
+            const double p = params[0];
+            const double q = params[1];
+            const double alpha = p - q;
+            const double beta = q - 1.0;
+            const double scale = 1.0 / xsf::binom(2.0 * n + p - 1.0, n);
+            Coefficients out(n + 1, 0.0);
+            for (int m = 0; m <= n; ++m) {
+                const double c = scale * binom_int(n + alpha, m) * binom_int(n + beta, n - m);
+                const auto term = multiply(linear_power(-1.0, 1.0, n - m), linear_power(0.0, 1.0, m));
+                for (int j = 0; j <= n; ++j) {
+                    out[j] += c * term[j];
+                }
+            }
+            return out;
+        },
+        [](double n, const Parameters &params, std::complex<double> x) {
+            return xsf::eval_sh_jacobi(n, params[0], params[1], x);
         },
         {{1.0, 10.0}, {0.0, 1.0}}, {0.0, 1.0}, 1e-5
     );
 }
 
 TEST_CASE("eval_jacobi recurrence overload", "[eval_jacobi][xsf_tests]") {
+    // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestRecurrence.test_jacobi
     check_recurrence(
-        [](int n, const Parameters &params, double x) { return xsf::eval_jacobi_l(n, params[0], params[1], x); },
-        [](int n, const Parameters &params, double x) {
-            return xsf::eval_jacobi(static_cast<double>(n), params[0], params[1], x);
+        [](std::ptrdiff_t n, const Parameters &params, double x) {
+            return xsf::eval_jacobi_l(n, params[0], params[1], x);
         },
+        [](double n, const Parameters &params, double x) { return xsf::eval_jacobi(n, params[0], params[1], x); },
         {{-0.99, 10.0}, {-0.99, 10.0}}, {-1.0, 1.0}
     );
 }
 
 TEST_CASE("eval_sh_jacobi recurrence overload", "[eval_sh_jacobi][xsf_tests]") {
+    // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestRecurrence.test_sh_jacobi
     check_recurrence(
-        [](int n, const Parameters &params, double x) { return xsf::eval_sh_jacobi_l(n, params[0], params[1], x); },
-        [](int n, const Parameters &params, double x) {
-            return xsf::eval_sh_jacobi(static_cast<double>(n), params[0], params[1], x);
+        [](std::ptrdiff_t n, const Parameters &params, double x) {
+            return xsf::eval_sh_jacobi_l(n, params[0], params[1], x);
         },
+        [](double n, const Parameters &params, double x) { return xsf::eval_sh_jacobi(n, params[0], params[1], x); },
         {{1.0, 10.0}, {0.0, 1.0}}, {0.0, 1.0}
     );
 }
 
 TEST_CASE("eval_jacobi alpha=-1 beta=1", "[eval_jacobi][xsf_tests]") {
+    // Mirrors scipy/special/tests/test_orthogonal_eval.py::test_jacobi_alpha_minus_one_beta_plus_one
     using test_case = std::tuple<int, std::array<double, 11>>;
     // gh-7001 - expected values were computed with mathematica.
     auto [n, expected] = GENERATE(
@@ -220,6 +300,7 @@ TEST_CASE("eval_jacobi alpha=-1 beta=1", "[eval_jacobi][xsf_tests]") {
 }
 
 TEST_CASE("eval_jacobi alpha=-1 beta=-1", "[eval_jacobi][xsf_tests]") {
+    // Mirrors scipy/special/tests/test_orthogonal_eval.py::test_jacobi_alpha_minus_one_beta_minus_one
     using test_case = std::tuple<int, std::array<double, 11>>;
     // gh-7001 - expected values were computed with mathematica.
     auto [n, expected] = GENERATE(

--- a/tests/xsf_tests/test_orthogonal_eval.cpp
+++ b/tests/xsf_tests/test_orthogonal_eval.cpp
@@ -1,13 +1,9 @@
+#include "../../include/xsf/config.h"
 #include "../testing_utils.h"
 
 #include <xsf/orthogonal_eval.h>
 
 #include <array>
-#include <cmath>
-#include <complex>
-#include <cstddef>
-#include <tuple>
-#include <utility>
 #include <vector>
 
 namespace {
@@ -21,7 +17,7 @@ double binom_int(double a, int k) {
 }
 
 std::vector<double> linear_power(double c0, double c1, int n) {
-    std::vector<double> out(n + 1.0, 0.0);
+    std::vector<double> out(n + 1, 0.0);
     for (int j = 0; j <= n; ++j) {
         out[j] = binom_int(n, j) * std::pow(c0, n - j) * std::pow(c1, j);
     }
@@ -194,7 +190,7 @@ TEST_CASE("eval_jacobi supports complex inputs", "[eval_jacobi][xsf_tests]") {
         [](double n, const std::vector<double> &params, std::complex<double> x) {
             return xsf::eval_jacobi(n, params[0], params[1], x);
         },
-        {{-0.99, 10.0}, {-0.99, 10.0}}, {-1.0, 1.0}, 1e-5
+        {{-0.99, 10.0}, {-0.99, 10.0}}, {{-0.75, -0.25}, {-0.25, 0.5}, {0.0, -0.5}, {0.5, 0.25}, {0.75, -0.75}}, 1e-5
     );
 }
 
@@ -246,7 +242,7 @@ TEST_CASE("eval_sh_jacobi for complex inputs", "[eval_sh_jacobi][xsf_tests]") {
         [](double n, const std::vector<double> &params, std::complex<double> x) {
             return xsf::eval_sh_jacobi(n, params[0], params[1], x);
         },
-        {{1.0, 10.0}, {0.0, 1.0}}, {0.0, 1.0}, 1e-5
+        {{1.0, 10.0}, {0.0, 1.0}}, {{0.1, 0.2}, {0.25, -0.3}, {0.5, 0.4}, {0.75, -0.2}, {0.9, 0.1}}, 1e-5
     );
 }
 
@@ -254,7 +250,7 @@ TEST_CASE("eval_jacobi recurrence overload", "[eval_jacobi][xsf_tests]") {
     // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestRecurrence.test_jacobi
     check_recurrence(
         [](std::ptrdiff_t n, const std::vector<double> &params, double x) {
-            return xsf::eval_jacobi_l(n, params[0], params[1], x);
+            return xsf::eval_jacobi(n, params[0], params[1], x);
         },
         [](double n, const std::vector<double> &params, double x) {
             return xsf::eval_jacobi(n, params[0], params[1], x);
@@ -267,7 +263,7 @@ TEST_CASE("eval_sh_jacobi recurrence overload", "[eval_sh_jacobi][xsf_tests]") {
     // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestRecurrence.test_sh_jacobi
     check_recurrence(
         [](std::ptrdiff_t n, const std::vector<double> &params, double x) {
-            return xsf::eval_sh_jacobi_l(n, params[0], params[1], x);
+            return xsf::eval_sh_jacobi(n, params[0], params[1], x);
         },
         [](double n, const std::vector<double> &params, double x) {
             return xsf::eval_sh_jacobi(n, params[0], params[1], x);
@@ -291,7 +287,7 @@ TEST_CASE("eval_jacobi alpha=-1 beta=1", "[eval_jacobi][xsf_tests]") {
 
     for (std::size_t j = 0; j < expected.size(); ++j) {
         const double x = -1.0 + 0.2 * static_cast<double>(j);
-        auto out = xsf::eval_jacobi_l(n, -1.0, 1.0, x);
+        auto out = xsf::eval_jacobi(static_cast<long>(n), -1.0, 1.0, x);
         auto error = xsf::extended_absolute_error(out, expected[j]);
         auto tol = 1e-14 + 1e-10 * std::abs(expected[j]);
         CAPTURE(n, x, out, expected[j], error, tol);
@@ -319,7 +315,7 @@ TEST_CASE("eval_jacobi alpha=-1 beta=-1", "[eval_jacobi][xsf_tests]") {
 
     for (std::size_t j = 0; j < expected.size(); ++j) {
         const double x = -1.0 + 0.2 * static_cast<double>(j);
-        auto out = xsf::eval_jacobi_l(n, -1.0, -1.0, x);
+        auto out = xsf::eval_jacobi(static_cast<long>(n), -1.0, -1.0, x);
         auto error = xsf::extended_absolute_error(out, expected[j]);
         auto tol = 1e-14 + 1e-10 * std::abs(expected[j]);
         CAPTURE(n, x, out, expected[j], error, tol);

--- a/tests/xsf_tests/test_orthogonal_eval.cpp
+++ b/tests/xsf_tests/test_orthogonal_eval.cpp
@@ -12,10 +12,6 @@
 
 namespace {
 
-using Coefficients = std::vector<double>;
-using Parameters = std::vector<double>;
-using Range = std::pair<double, double>;
-
 double binom_int(double a, int k) {
     double out = 1.0;
     for (int j = 0; j < k; ++j) {
@@ -24,16 +20,16 @@ double binom_int(double a, int k) {
     return out;
 }
 
-Coefficients linear_power(double c0, double c1, int n) {
-    Coefficients out(n + 1.0, 0.0);
+std::vector<double> linear_power(double c0, double c1, int n) {
+    std::vector<double> out(n + 1.0, 0.0);
     for (int j = 0; j <= n; ++j) {
         out[j] = binom_int(n, j) * std::pow(c0, n - j) * std::pow(c1, j);
     }
     return out;
 }
 
-Coefficients multiply(const Coefficients &a, const Coefficients &b) {
-    Coefficients out(a.size() + b.size() - 1, 0.0);
+std::vector<double> multiply(const std::vector<double> &a, const std::vector<double> &b) {
+    std::vector<double> out(a.size() + b.size() - 1, 0.0);
     for (std::size_t i = 0; i < a.size(); ++i) {
         for (std::size_t j = 0; j < b.size(); ++j) {
             out[i + j] += a[i] * b[j];
@@ -43,7 +39,7 @@ Coefficients multiply(const Coefficients &a, const Coefficients &b) {
 }
 
 template <typename T>
-T polyval(const Coefficients &coeffs, T x) {
+T polyval(const std::vector<double> &coeffs, T x) {
     T out = 0.0;
     for (auto it = coeffs.rbegin(); it != coeffs.rend(); ++it) {
         out = out * x + *it;
@@ -59,13 +55,13 @@ double sample(double a, double b, int i) {
 
 template <typename CoefficientsFunc, typename EvalFunc>
 void check_poly(
-    CoefficientsFunc coefficients_func, EvalFunc eval_func, const std::vector<Range> &param_ranges, Range x_range,
-    double rtol, int nn = 10, int nparam = 10, int nx = 10
+    CoefficientsFunc coefficients_func, EvalFunc eval_func, const std::vector<std::pair<double, double>> &param_ranges,
+    std::pair<double, double> x_range, double rtol, int nn = 10, int nparam = 10, int nx = 10
 ) {
     for (int n = 0; n < nn; ++n) {
         const int ncases = param_ranges.empty() ? 1 : nparam;
         for (int ip = 0; ip < ncases; ++ip) {
-            Parameters params;
+            std::vector<double> params;
             params.reserve(param_ranges.size());
             for (std::size_t k = 0; k < param_ranges.size(); ++k) {
                 params.push_back(sample(param_ranges[k].first, param_ranges[k].second, 17 * n + nparam * k + ip));
@@ -99,7 +95,7 @@ void check_complex_poly(
     for (int n = 0; n < nn; ++n) {
         const int ncases = param_ranges.empty() ? 1 : nparam;
         for (int ip = 0; ip < ncases; ++ip) {
-            Parameters params;
+            std::vector<double> params;
             params.reserve(param_ranges.size());
             for (std::size_t k = 0; k < param_ranges.size(); ++k) {
                 params.push_back(sample(param_ranges[k].first, param_ranges[k].second, 23 * n + nparam * k + ip));
@@ -120,13 +116,14 @@ void check_complex_poly(
 
 template <typename IntDegreeEvalFunc, typename DoubleDegreeEvalFunc>
 void check_recurrence(
-    IntDegreeEvalFunc int_degree_eval, DoubleDegreeEvalFunc double_degree_eval, const std::vector<Range> &param_ranges,
-    Range x_range, double rtol = 1e-8, int nn = 10, int nparam = 10, int nx = 10
+    IntDegreeEvalFunc int_degree_eval, DoubleDegreeEvalFunc double_degree_eval,
+    const std::vector<std::pair<double, double>> &param_ranges, std::pair<double, double> x_range, double rtol = 1e-8,
+    int nn = 10, int nparam = 10, int nx = 10
 ) {
     for (int n = 0; n < nn; ++n) {
         const int ncases = param_ranges.empty() ? 1 : nparam;
         for (int ip = 0; ip < ncases; ++ip) {
-            Parameters params;
+            std::vector<double> params;
             params.reserve(param_ranges.size());
             for (std::size_t k = 0; k < param_ranges.size(); ++k) {
                 params.push_back(sample(param_ranges[k].first, param_ranges[k].second, 19 * n + nparam * k + ip));
@@ -156,10 +153,10 @@ void check_recurrence(
 TEST_CASE("eval_jacobi matches constructed polynomials", "[eval_jacobi][xsf_tests]") {
     // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestPolys.test_jacobi
     check_poly(
-        [](int n, const Parameters &params) {
+        [](int n, const std::vector<double> &params) {
             const double alpha = params[0];
             const double beta = params[1];
-            Coefficients out(n + 1.0, 0.0);
+            std::vector<double> out(n + 1.0, 0.0);
             const double scale = std::ldexp(1.0, -n);
             for (int m = 0; m <= n; ++m) {
                 const double c = scale * binom_int(n + alpha, m) * binom_int(n + beta, n - m);
@@ -170,7 +167,9 @@ TEST_CASE("eval_jacobi matches constructed polynomials", "[eval_jacobi][xsf_test
             }
             return out;
         },
-        [](double n, const Parameters &params, double x) { return xsf::eval_jacobi(n, params[0], params[1], x); },
+        [](double n, const std::vector<double> &params, double x) {
+            return xsf::eval_jacobi(n, params[0], params[1], x);
+        },
         {{-0.99, 10.0}, {-0.99, 10.0}}, {-1.0, 1.0}, 1e-5
     );
 }
@@ -178,10 +177,10 @@ TEST_CASE("eval_jacobi matches constructed polynomials", "[eval_jacobi][xsf_test
 TEST_CASE("eval_jacobi supports complex inputs", "[eval_jacobi][xsf_tests]") {
     // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestPolys.test_jacobi for complex inputs
     check_complex_poly(
-        [](double n, const Parameters &params) {
+        [](double n, const std::vector<double> &params) {
             const double alpha = params[0];
             const double beta = params[1];
-            Coefficients out(n + 1.0, 0.0);
+            std::vector<double> out(n + 1.0, 0.0);
             const double scale = std::ldexp(1.0, -n);
             for (int m = 0; m <= n; ++m) {
                 const double c = scale * binom_int(n + alpha, m) * binom_int(n + beta, n - m);
@@ -192,7 +191,7 @@ TEST_CASE("eval_jacobi supports complex inputs", "[eval_jacobi][xsf_tests]") {
             }
             return out;
         },
-        [](double n, const Parameters &params, std::complex<double> x) {
+        [](double n, const std::vector<double> &params, std::complex<double> x) {
             return xsf::eval_jacobi(n, params[0], params[1], x);
         },
         {{-0.99, 10.0}, {-0.99, 10.0}}, {-1.0, 1.0}, 1e-5
@@ -202,13 +201,13 @@ TEST_CASE("eval_jacobi supports complex inputs", "[eval_jacobi][xsf_tests]") {
 TEST_CASE("eval_sh_jacobi matches constructed polynomials", "[eval_sh_jacobi][xsf_tests]") {
     // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestPolys.test_sh_jacobi
     check_poly(
-        [](int n, const Parameters &params) {
+        [](int n, const std::vector<double> &params) {
             const double p = params[0];
             const double q = params[1];
             const double alpha = p - q;
             const double beta = q - 1.0;
             const double scale = 1.0 / xsf::binom(2.0 * n + p - 1.0, n);
-            Coefficients out(n + 1, 0.0);
+            std::vector<double> out(n + 1, 0.0);
             for (int m = 0; m <= n; ++m) {
                 const double c = scale * binom_int(n + alpha, m) * binom_int(n + beta, n - m);
                 const auto term = multiply(linear_power(-1.0, 1.0, n - m), linear_power(0.0, 1.0, m));
@@ -218,7 +217,9 @@ TEST_CASE("eval_sh_jacobi matches constructed polynomials", "[eval_sh_jacobi][xs
             }
             return out;
         },
-        [](double n, const Parameters &params, double x) { return xsf::eval_sh_jacobi(n, params[0], params[1], x); },
+        [](double n, const std::vector<double> &params, double x) {
+            return xsf::eval_sh_jacobi(n, params[0], params[1], x);
+        },
         {{1.0, 10.0}, {0.0, 1.0}}, {0.0, 1.0}, 1e-5
     );
 }
@@ -226,13 +227,13 @@ TEST_CASE("eval_sh_jacobi matches constructed polynomials", "[eval_sh_jacobi][xs
 TEST_CASE("eval_sh_jacobi for complex inputs", "[eval_sh_jacobi][xsf_tests]") {
     // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestPolys.test_sh_jacobi for complex inputs
     check_complex_poly(
-        [](double n, const Parameters &params) {
+        [](double n, const std::vector<double> &params) {
             const double p = params[0];
             const double q = params[1];
             const double alpha = p - q;
             const double beta = q - 1.0;
             const double scale = 1.0 / xsf::binom(2.0 * n + p - 1.0, n);
-            Coefficients out(n + 1, 0.0);
+            std::vector<double> out(n + 1, 0.0);
             for (int m = 0; m <= n; ++m) {
                 const double c = scale * binom_int(n + alpha, m) * binom_int(n + beta, n - m);
                 const auto term = multiply(linear_power(-1.0, 1.0, n - m), linear_power(0.0, 1.0, m));
@@ -242,7 +243,7 @@ TEST_CASE("eval_sh_jacobi for complex inputs", "[eval_sh_jacobi][xsf_tests]") {
             }
             return out;
         },
-        [](double n, const Parameters &params, std::complex<double> x) {
+        [](double n, const std::vector<double> &params, std::complex<double> x) {
             return xsf::eval_sh_jacobi(n, params[0], params[1], x);
         },
         {{1.0, 10.0}, {0.0, 1.0}}, {0.0, 1.0}, 1e-5
@@ -252,10 +253,12 @@ TEST_CASE("eval_sh_jacobi for complex inputs", "[eval_sh_jacobi][xsf_tests]") {
 TEST_CASE("eval_jacobi recurrence overload", "[eval_jacobi][xsf_tests]") {
     // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestRecurrence.test_jacobi
     check_recurrence(
-        [](std::ptrdiff_t n, const Parameters &params, double x) {
+        [](std::ptrdiff_t n, const std::vector<double> &params, double x) {
             return xsf::eval_jacobi_l(n, params[0], params[1], x);
         },
-        [](double n, const Parameters &params, double x) { return xsf::eval_jacobi(n, params[0], params[1], x); },
+        [](double n, const std::vector<double> &params, double x) {
+            return xsf::eval_jacobi(n, params[0], params[1], x);
+        },
         {{-0.99, 10.0}, {-0.99, 10.0}}, {-1.0, 1.0}
     );
 }
@@ -263,10 +266,12 @@ TEST_CASE("eval_jacobi recurrence overload", "[eval_jacobi][xsf_tests]") {
 TEST_CASE("eval_sh_jacobi recurrence overload", "[eval_sh_jacobi][xsf_tests]") {
     // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestRecurrence.test_sh_jacobi
     check_recurrence(
-        [](std::ptrdiff_t n, const Parameters &params, double x) {
+        [](std::ptrdiff_t n, const std::vector<double> &params, double x) {
             return xsf::eval_sh_jacobi_l(n, params[0], params[1], x);
         },
-        [](double n, const Parameters &params, double x) { return xsf::eval_sh_jacobi(n, params[0], params[1], x); },
+        [](double n, const std::vector<double> &params, double x) {
+            return xsf::eval_sh_jacobi(n, params[0], params[1], x);
+        },
         {{1.0, 10.0}, {0.0, 1.0}}, {0.0, 1.0}
     );
 }

--- a/tests/xsf_tests/test_orthogonal_eval.cpp
+++ b/tests/xsf_tests/test_orthogonal_eval.cpp
@@ -158,7 +158,7 @@ void check_recurrence(
 } // namespace
 
 TEST_CASE("eval_jacobi matches constructed polynomials", "[eval_jacobi][xsf_tests]") {
-    // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestPolys.test_jacobi
+    // https://github.com/scipy/scipy/blob/a125578782dd3213fb57fda0f4b97c70dd054b1d/scipy/special/tests/test_orthogonal_eval.py#L77-L80
     check_poly(
         [](int n, const std::vector<double> &params) {
             const double alpha = params[0];
@@ -182,7 +182,8 @@ TEST_CASE("eval_jacobi matches constructed polynomials", "[eval_jacobi][xsf_test
 }
 
 TEST_CASE("eval_jacobi supports complex inputs", "[eval_jacobi][xsf_tests]") {
-    // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestPolys.test_jacobi for complex inputs
+    // for complex inputs
+    // https://github.com/scipy/scipy/blob/a125578782dd3213fb57fda0f4b97c70dd054b1d/scipy/special/tests/test_orthogonal_eval.py#L77-L80
     check_complex_poly(
         [](double n, const std::vector<double> &params) {
             const double alpha = params[0];
@@ -236,7 +237,7 @@ TEST_CASE("eval_jacobi matches SciPy complex<float> reference values", "[eval_ja
 }
 
 TEST_CASE("eval_sh_jacobi matches constructed polynomials", "[eval_sh_jacobi][xsf_tests]") {
-    // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestPolys.test_sh_jacobi
+    // https://github.com/scipy/scipy/blob/a125578782dd3213fb57fda0f4b97c70dd054b1d/scipy/special/tests/test_orthogonal_eval.py#L82-L85
     check_poly(
         [](int n, const std::vector<double> &params) {
             const double p = params[0];
@@ -262,7 +263,8 @@ TEST_CASE("eval_sh_jacobi matches constructed polynomials", "[eval_sh_jacobi][xs
 }
 
 TEST_CASE("eval_sh_jacobi for complex inputs", "[eval_sh_jacobi][xsf_tests]") {
-    // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestPolys.test_sh_jacobi for complex inputs
+    // for complex inputs
+    // https://github.com/scipy/scipy/blob/a125578782dd3213fb57fda0f4b97c70dd054b1d/scipy/special/tests/test_orthogonal_eval.py#L82-L85
     check_complex_poly(
         [](double n, const std::vector<double> &params) {
             const double p = params[0];
@@ -318,7 +320,7 @@ TEST_CASE("eval_sh_jacobi matches SciPy complex<float> reference values", "[eval
 }
 
 TEST_CASE("eval_jacobi recurrence overload", "[eval_jacobi][xsf_tests]") {
-    // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestRecurrence.test_jacobi
+    // https://github.com/scipy/scipy/blob/a125578782dd3213fb57fda0f4b97c70dd054b1d/scipy/special/tests/test_orthogonal_eval.py#L185-L188
     check_recurrence(
         [](std::ptrdiff_t n, const std::vector<double> &params, double x) {
             return xsf::eval_jacobi(n, params[0], params[1], x);
@@ -331,7 +333,7 @@ TEST_CASE("eval_jacobi recurrence overload", "[eval_jacobi][xsf_tests]") {
 }
 
 TEST_CASE("eval_sh_jacobi recurrence overload", "[eval_sh_jacobi][xsf_tests]") {
-    // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestRecurrence.test_sh_jacobi
+    // https://github.com/scipy/scipy/blob/a125578782dd3213fb57fda0f4b97c70dd054b1d/scipy/special/tests/test_orthogonal_eval.py#L190-L192
     check_recurrence(
         [](std::ptrdiff_t n, const std::vector<double> &params, double x) {
             return xsf::eval_sh_jacobi(n, params[0], params[1], x);
@@ -344,7 +346,7 @@ TEST_CASE("eval_sh_jacobi recurrence overload", "[eval_sh_jacobi][xsf_tests]") {
 }
 
 TEST_CASE("eval_jacobi alpha=-1 beta=1", "[eval_jacobi][xsf_tests]") {
-    // Mirrors scipy/special/tests/test_orthogonal_eval.py::test_jacobi_alpha_minus_one_beta_plus_one
+    // https://github.com/scipy/scipy/blob/a125578782dd3213fb57fda0f4b97c70dd054b1d/scipy/special/tests/test_orthogonal_eval.py#L293-L329
     using test_case = std::tuple<int, std::array<double, 11>>;
     // gh-7001 - expected values were computed with mathematica.
     auto [n, expected] = GENERATE(
@@ -372,7 +374,7 @@ TEST_CASE("eval_jacobi alpha=-1 beta=1", "[eval_jacobi][xsf_tests]") {
 }
 
 TEST_CASE("eval_jacobi alpha=-1 beta=-1", "[eval_jacobi][xsf_tests]") {
-    // Mirrors scipy/special/tests/test_orthogonal_eval.py::test_jacobi_alpha_minus_one_beta_minus_one
+    // https://github.com/scipy/scipy/blob/a125578782dd3213fb57fda0f4b97c70dd054b1d/scipy/special/tests/test_orthogonal_eval.py#L332-L383
     using test_case = std::tuple<int, std::array<double, 11>>;
     // gh-7001 - expected values were computed with mathematica.
     auto [n, expected] = GENERATE(

--- a/tests/xsf_tests/test_orthogonal_eval.cpp
+++ b/tests/xsf_tests/test_orthogonal_eval.cpp
@@ -1,6 +1,8 @@
 #include "../../include/xsf/config.h"
 #include "../testing_utils.h"
 
+#include <xsf/cephes/polevl.h>
+#include <xsf/evalpoly.h>
 #include <xsf/orthogonal_eval.h>
 
 #include <array>
@@ -34,13 +36,22 @@ std::vector<double> multiply(const std::vector<double> &a, const std::vector<dou
     return out;
 }
 
-template <typename T>
-T polyval(const std::vector<double> &coeffs, T x) {
-    T out = 0.0;
-    for (auto it = coeffs.rbegin(); it != coeffs.rend(); ++it) {
-        out = out * x + *it;
+double polyval(const std::vector<double> &coeffs, double x) {
+    if (coeffs.size() == 1) {
+        return coeffs[0];
     }
-    return out;
+
+    const std::vector<double> reversed(coeffs.rbegin(), coeffs.rend());
+    return xsf::cephes::polevl(x, reversed.data(), reversed.size() - 1);
+}
+
+std::complex<double> polyval(const std::vector<double> &coeffs, std::complex<double> x) {
+    if (coeffs.size() == 1) {
+        return coeffs[0];
+    }
+
+    const std::vector<double> reversed(coeffs.rbegin(), coeffs.rend());
+    return xsf::cevalpoly(reversed.data(), reversed.size() - 1, x);
 }
 
 double sample(double a, double b, int i) {
@@ -74,7 +85,7 @@ void check_poly(
 
                 const auto out = eval_func(n, params, x);
                 const double expected = polyval(coeffs, x);
-                const double error = xsf::extended_absolute_error(out, expected);
+                const double error = xsf::extended_absolute_error(static_cast<double>(out), expected);
                 const double tol = 1e-12 + rtol * std::abs(expected);
                 CAPTURE(n, params, x, out, expected, error, tol);
                 REQUIRE(error <= tol);
@@ -101,7 +112,7 @@ void check_complex_poly(
             for (const auto &x : xs) {
                 const auto out = eval_func(n, params, x);
                 const auto expected = polyval(coeffs, x);
-                const double error = xsf::extended_absolute_error(out, expected);
+                const double error = xsf::extended_absolute_error(static_cast<std::complex<double>>(out), expected);
                 const double tol = 1e-12 + rtol * std::abs(expected);
                 CAPTURE(n, params, x, out, expected, error, tol);
                 REQUIRE(error <= tol);
@@ -194,6 +205,36 @@ TEST_CASE("eval_jacobi supports complex inputs", "[eval_jacobi][xsf_tests]") {
     );
 }
 
+TEST_CASE("eval_jacobi matches SciPy complex<double> reference values", "[eval_jacobi][xsf_tests]") {
+    using test_case = std::tuple<double, double, double, std::complex<double>, std::complex<double>>;
+    auto [n, alpha, beta, x, expected] = GENERATE(
+        test_case{2.0, 0.25, 1.5, {0.2, -0.3}, {-0.9910156249999997, 0.035625000000000136}},
+        test_case{4.0, 2.5, -0.4, {-0.35, 0.6}, {5.171472426694353, 0.8954783753906292}},
+        test_case{6.0, 0.75, 3.25, {0.9, -0.2}, {-7.36364426660156, 1.1136538789062485}}
+    );
+
+    const auto out = xsf::eval_jacobi(n, alpha, beta, x);
+    const double error = xsf::extended_absolute_error(out, expected);
+    const double tol = 1e-12 + 1e-12 * std::abs(expected);
+    CAPTURE(n, alpha, beta, x, out, expected, error, tol);
+    REQUIRE(error <= tol);
+}
+
+TEST_CASE("eval_jacobi matches SciPy complex<float> reference values", "[eval_jacobi][xsf_tests]") {
+    using test_case = std::tuple<float, float, float, std::complex<float>, std::complex<float>>;
+    auto [n, alpha, beta, x, expected] = GENERATE(
+        test_case{2.0f, 0.25f, 1.5f, {0.2f, -0.3f}, {-0.99101567f, 0.035624996f}},
+        test_case{4.0f, 2.5f, -0.4f, {-0.35f, 0.6f}, {5.171473f, 0.8954783f}},
+        test_case{6.0f, 0.75f, 3.25f, {0.9f, -0.2f}, {-7.363643f, 1.1136553f}}
+    );
+
+    const auto out = xsf::eval_jacobi(n, alpha, beta, x);
+    const double error = xsf::extended_absolute_error(out, expected);
+    const double tol = 1e-6 + 1e-5 * std::abs(expected);
+    CAPTURE(n, alpha, beta, x, out, expected, error, tol);
+    REQUIRE(error <= tol);
+}
+
 TEST_CASE("eval_sh_jacobi matches constructed polynomials", "[eval_sh_jacobi][xsf_tests]") {
     // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestPolys.test_sh_jacobi
     check_poly(
@@ -246,10 +287,40 @@ TEST_CASE("eval_sh_jacobi for complex inputs", "[eval_sh_jacobi][xsf_tests]") {
     );
 }
 
+TEST_CASE("eval_sh_jacobi matches SciPy complex<double> reference values", "[eval_sh_jacobi][xsf_tests]") {
+    using test_case = std::tuple<double, double, double, std::complex<double>, std::complex<double>>;
+    auto [n, p, q, x, expected] = GENERATE(
+        test_case{2.0, 1.25, 0.5, {0.2, 0.1}, {-0.05687782805429855, -0.030588235294117673}},
+        test_case{4.0, 3.5, 0.25, {0.8, -0.15}, {-0.005872881652661048, -0.043102675807164974}},
+        test_case{5.0, 2.0, 0.75, {-0.1, 0.4}, {0.09778388908617434, -0.07075225852272753}}
+    );
+
+    const auto out = xsf::eval_sh_jacobi(n, p, q, x);
+    const double error = xsf::extended_absolute_error(out, expected);
+    const double tol = 1e-12 + 1e-12 * std::abs(expected);
+    CAPTURE(n, p, q, x, out, expected, error, tol);
+    REQUIRE(error <= tol);
+}
+
+TEST_CASE("eval_sh_jacobi matches SciPy complex<float> reference values", "[eval_sh_jacobi][xsf_tests]") {
+    using test_case = std::tuple<float, float, float, std::complex<float>, std::complex<float>>;
+    auto [n, p, q, x, expected] = GENERATE(
+        test_case{3.0f, 1.5f, 0.125f, {0.15f, 0.35f}, {0.074561186f, -0.05201661f}},
+        test_case{5.0f, 4.25f, 0.625f, {0.6f, -0.25f}, {0.0034959577f, 0.009585135f}},
+        test_case{6.0f, 2.75f, 0.9f, {-0.2f, 0.3f}, {-0.0819409f, 0.004271384f}}
+    );
+
+    const auto out = xsf::eval_sh_jacobi(n, p, q, x);
+    const double error = xsf::extended_absolute_error(out, expected);
+    const double tol = 1e-6 + 1e-5 * std::abs(expected);
+    CAPTURE(n, p, q, x, out, expected, error, tol);
+    REQUIRE(error <= tol);
+}
+
 TEST_CASE("eval_jacobi recurrence overload", "[eval_jacobi][xsf_tests]") {
     // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestRecurrence.test_jacobi
     check_recurrence(
-        [](std::ptrdiff_t n, const std::vector<double> &params, double x) {
+        [](long n, const std::vector<double> &params, double x) {
             return xsf::eval_jacobi(n, params[0], params[1], x);
         },
         [](double n, const std::vector<double> &params, double x) {
@@ -262,7 +333,7 @@ TEST_CASE("eval_jacobi recurrence overload", "[eval_jacobi][xsf_tests]") {
 TEST_CASE("eval_sh_jacobi recurrence overload", "[eval_sh_jacobi][xsf_tests]") {
     // Mirrors scipy/special/tests/test_orthogonal_eval.py::TestRecurrence.test_sh_jacobi
     check_recurrence(
-        [](std::ptrdiff_t n, const std::vector<double> &params, double x) {
+        [](long n, const std::vector<double> &params, double x) {
             return xsf::eval_sh_jacobi(n, params[0], params[1], x);
         },
         [](double n, const std::vector<double> &params, double x) {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
Follows: #170

#### What does this implement/fix?
<!--Please explain your changes.-->
- C++ port of Jacobi and Shifted Jacobi in [scipy/special/orthogonal_eval.pxd](https://github.com/scipy/scipy/blob/main/scipy/special/orthogonal_eval.pxd) to XSF

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I used Augment to draft the test cases. The rest is mine.