### PR TITLE
ENH: add Newtonian root finder to root finding tools

### DIFF
--- a/include/xsf/digammainv.h
+++ b/include/xsf/digammainv.h
@@ -5,9 +5,17 @@
 #include "xsf/cephes/zeta.h"
 #include "xsf/config.h"
 #include "xsf/error.h"
+#include "xsf/tools.h"
 
 namespace xsf {
 namespace detail {
+
+    struct digammainv_root_functor {
+        double y;
+        XSF_HOST_DEVICE std::pair<double, double> operator()(double x) const {
+            return {cephes::psi(x) - y, cephes::zeta(2, x)};
+        }
+    };
 
     // Initial guess for digammainv using Minka (2000):
     //   x0 = exp(y) + 0.5      if y >= -2.22
@@ -24,17 +32,12 @@ namespace detail {
     //   x_new = x_old - (psi(x_old) - y) / psi'(x_old)
     // where psi'(x) = zeta(2, x) (the trigamma function).
     XSF_HOST_DEVICE inline double digammainv_newton_raphson(double x, double y) {
-        const int max_iterations = 20; // avoid infinite loops in pathological cases
-        for (int i = 0; i < max_iterations; ++i) {
-            double psi_x = cephes::psi(x);
-            double trigamma_x = cephes::zeta(2, x);
-            double step = (psi_x - y) / trigamma_x;
-            x -= step;
-            if (std::abs(step) <= std::numeric_limits<double>::epsilon() * std::abs(x)) {
-                break;
-            }
+        auto [res, status] = find_root_newton(digammainv_root_functor{y}, x);
+        if (status == 1) {
+            set_error("digammainv", SF_ERROR_NO_RESULT, NULL);
+            return std::numeric_limits<double>::quiet_NaN();
         }
-        return x;
+        return res;
     }
 
     // Compute the inverse of the digamma function for real double input y,

--- a/include/xsf/digammainv.h
+++ b/include/xsf/digammainv.h
@@ -33,19 +33,19 @@ namespace detail {
     // where psi'(x) = zeta(2, x) (the trigamma function).
     XSF_HOST_DEVICE inline double digammainv_newton_raphson(double x, double y) {
         auto [res, status] = find_root_newton(digammainv_root_functor{y}, x);
-        if (status == 1) {
+        if (status == NewtonRootFinderStatus::MAX_ITERATIONS_EXCEEDED) {
             set_error("digammainv", SF_ERROR_NO_RESULT, NULL);
             return std::numeric_limits<double>::quiet_NaN();
         }
-        if (status == 2) {
+        if (status == NewtonRootFinderStatus::DERIVATIVE_ZERO) {
             set_error("digammainv", SF_ERROR_SINGULAR, NULL);
             return std::numeric_limits<double>::quiet_NaN();
         }
-        if (status == 3) {
+        if (status == NewtonRootFinderStatus::OBJECTIVE_RETURNED_NAN) {
             set_error("digammainv", SF_ERROR_NO_RESULT, NULL);
             return std::numeric_limits<double>::quiet_NaN();
         }
-        if (status == 4) {
+        if (status == NewtonRootFinderStatus::OBJECTIVE_RETURNED_INF) {
             set_error("digammainv", SF_ERROR_OVERFLOW, NULL);
             return res;
         }

--- a/include/xsf/digammainv.h
+++ b/include/xsf/digammainv.h
@@ -37,6 +37,18 @@ namespace detail {
             set_error("digammainv", SF_ERROR_NO_RESULT, NULL);
             return std::numeric_limits<double>::quiet_NaN();
         }
+        if (status == 2) {
+            set_error("digammainv", SF_ERROR_SINGULAR, NULL);
+            return std::numeric_limits<double>::quiet_NaN();
+        }
+        if (status == 3) {
+            set_error("digammainv", SF_ERROR_NO_RESULT, NULL);
+            return std::numeric_limits<double>::quiet_NaN();
+        }
+        if (status == 4) {
+            set_error("digammainv", SF_ERROR_OVERFLOW, NULL);
+            return res;
+        }
         return res;
     }
 

--- a/include/xsf/tools.h
+++ b/include/xsf/tools.h
@@ -422,5 +422,29 @@ namespace detail {
         return {std::numeric_limits<double>::quiet_NaN(), 1};
     }
 
+    /* Find root of a scalar function using Newton-Raphson.
+     *
+     * Function func must return a pair (f(x), f'(x)).
+     */
+    template <typename Function>
+    XSF_HOST_DEVICE inline std::pair<double, int> find_root_newton(
+        Function func, double x, double rtol = 4 * std::numeric_limits<double>::epsilon(), double atol = 0.0,
+        std::uint64_t maxiter = 100
+    ) {
+        for (std::uint64_t i = 0; i < maxiter; i++) {
+            auto [f, df] = func(x);
+            if (f == 0.0) {
+                return {x, 0};
+            }
+            double step = f / df;
+            double x_next = x - step;
+            if (x == x_next || std::abs(step) <= rtol * std::abs(x) + atol) {
+                return {x_next, 0};
+            }
+            x = x_next;
+        }
+        return {x, 1};
+    }
+
 } // namespace detail
 } // namespace xsf

--- a/include/xsf/tools.h
+++ b/include/xsf/tools.h
@@ -426,42 +426,52 @@ namespace detail {
      *
      * Function func must return a pair (f(x), f'(x)).
      */
+
+    enum class NewtonRootFinderStatus {
+        SUCCESS = 0,
+        MAX_ITERATIONS_EXCEEDED = 1,
+        DERIVATIVE_ZERO = 2,
+        OBJECTIVE_RETURNED_NAN = 3,
+        OBJECTIVE_RETURNED_INF = 4,
+        INITIAL_GUESS_RETURNED_INF = 5
+    };
+
     template <typename Function>
-    XSF_HOST_DEVICE inline std::pair<double, int> find_root_newton(
+    XSF_HOST_DEVICE inline std::pair<double, NewtonRootFinderStatus> find_root_newton(
         Function func, double x, double rtol = 4 * std::numeric_limits<double>::epsilon(), double atol = 0.0,
         std::uint64_t maxiter = 100
     ) {
         if (maxiter == 0) {
-            return {x, 1};
-        }
-        if (std::isnan(x)) {
-            return {std::numeric_limits<double>::quiet_NaN(), 3};
+            return {x, NewtonRootFinderStatus::MAX_ITERATIONS_EXCEEDED};
         }
         if (std::isinf(x)) {
-            return {x, 4};
+            return {x, NewtonRootFinderStatus::INITIAL_GUESS_RETURNED_INF};
         }
         for (std::uint64_t i = 0; i < maxiter; i++) {
             auto [f, df] = func(x);
+            if (std::isnan(f) || std::isnan(df)) {
+                return {std::numeric_limits<double>::quiet_NaN(), NewtonRootFinderStatus::OBJECTIVE_RETURNED_NAN};
+            }
             if (f == 0.0) {
-                return {x, 0};
+                return {x, NewtonRootFinderStatus::SUCCESS};
             }
             if (!std::isfinite(f) || !std::isfinite(df)) {
-                return {std::numeric_limits<double>::quiet_NaN(), 3};
+                return {std::numeric_limits<double>::quiet_NaN(), NewtonRootFinderStatus::OBJECTIVE_RETURNED_INF};
             }
             if (df == 0.0) {
-                return {std::numeric_limits<double>::quiet_NaN(), 2};
+                return {std::numeric_limits<double>::quiet_NaN(), NewtonRootFinderStatus::DERIVATIVE_ZERO};
             }
             double step = f / df;
             double x_next = x - step;
             if (!std::isfinite(x_next)) {
-                return {std::numeric_limits<double>::quiet_NaN(), 3};
+                return {std::numeric_limits<double>::quiet_NaN(), NewtonRootFinderStatus::OBJECTIVE_RETURNED_INF};
             }
             if (x == x_next || std::abs(step) <= rtol * std::abs(x) + atol) {
-                return {x_next, 0};
+                return {x_next, NewtonRootFinderStatus::SUCCESS};
             }
             x = x_next;
         }
-        return {x, 1};
+        return {x, NewtonRootFinderStatus::MAX_ITERATIONS_EXCEEDED};
     }
 
 } // namespace detail

--- a/include/xsf/tools.h
+++ b/include/xsf/tools.h
@@ -431,10 +431,28 @@ namespace detail {
         Function func, double x, double rtol = 4 * std::numeric_limits<double>::epsilon(), double atol = 0.0,
         std::uint64_t maxiter = 100
     ) {
+        if (maxiter == 0) {
+            return {x, 1};
+        }
+        if (std::isnan(x)) {
+            return {std::numeric_limits<double>::quiet_NaN(), 3};
+        }
+        if (std::isinf(x)) {
+            return {x, 4};
+        }
         for (std::uint64_t i = 0; i < maxiter; i++) {
             auto [f, df] = func(x);
-            if (f == 0.0) {
-                return {x, 0};
+            if (df == 0.0) {
+                return {std::numeric_limits<double>::quiet_NaN(), 2};
+            }
+            if (std::isnan(f) || std::isnan(df)) {
+                return {std::numeric_limits<double>::quiet_NaN(), 3};
+            }
+            if (std::isinf(f) && (f > 0)) {
+                return {std::numeric_limits<double>::infinity(), 4};
+            }
+            if (std::isinf(f) && (f < 0)) {
+                return {-std::numeric_limits<double>::infinity(), 4};
             }
             double step = f / df;
             double x_next = x - step;

--- a/include/xsf/tools.h
+++ b/include/xsf/tools.h
@@ -442,18 +442,6 @@ namespace detail {
         }
         for (std::uint64_t i = 0; i < maxiter; i++) {
             auto [f, df] = func(x);
-            if (df == 0.0) {
-                return {std::numeric_limits<double>::quiet_NaN(), 2};
-            }
-            if (std::isnan(f) || std::isnan(df)) {
-                return {std::numeric_limits<double>::quiet_NaN(), 3};
-            }
-            if (std::isinf(f) && (f > 0)) {
-                return {std::numeric_limits<double>::infinity(), 4};
-            }
-            if (std::isinf(f) && (f < 0)) {
-                return {-std::numeric_limits<double>::infinity(), 4};
-            auto [f, df] = func(x);
             if (f == 0.0) {
                 return {x, 0};
             }

--- a/include/xsf/tools.h
+++ b/include/xsf/tools.h
@@ -453,9 +453,21 @@ namespace detail {
             }
             if (std::isinf(f) && (f < 0)) {
                 return {-std::numeric_limits<double>::infinity(), 4};
+            auto [f, df] = func(x);
+            if (f == 0.0) {
+                return {x, 0};
+            }
+            if (!std::isfinite(f) || !std::isfinite(df)) {
+                return {std::numeric_limits<double>::quiet_NaN(), 3};
+            }
+            if (df == 0.0) {
+                return {std::numeric_limits<double>::quiet_NaN(), 2};
             }
             double step = f / df;
             double x_next = x - step;
+            if (!std::isfinite(x_next)) {
+                return {std::numeric_limits<double>::quiet_NaN(), 3};
+            }
             if (x == x_next || std::abs(step) <= rtol * std::abs(x) + atol) {
                 return {x_next, 0};
             }

--- a/tests/xsf_tests/test_newton_root_finder.cpp
+++ b/tests/xsf_tests/test_newton_root_finder.cpp
@@ -86,7 +86,6 @@ TEST_CASE("newton_root_finder objective returns infinity", "[newton_root_finder]
     auto [result, status] = xsf::detail::find_root_newton(inf_root_functor{inf}, 2.0);
 
     CAPTURE(inf, result, status);
-    REQUIRE(status == 4);
-    REQUIRE(std::isinf(result));
-    REQUIRE(std::signbit(result) == std::signbit(inf));
+    REQUIRE(status == 3);
+    REQUIRE(std::isnan(result));
 }

--- a/tests/xsf_tests/test_newton_root_finder.cpp
+++ b/tests/xsf_tests/test_newton_root_finder.cpp
@@ -1,0 +1,92 @@
+#include "../testing_utils.h"
+#include <xsf/tools.h>
+
+struct parabola_root_functor {
+    XSF_HOST_DEVICE std::pair<double, double> operator()(double x) const { return {x * x - 1, 2 * x}; }
+};
+
+TEST_CASE("newton_root_finder happy path", "[newton_root_finder][xsf_tests]") {
+    auto [result, status] = xsf::detail::find_root_newton(parabola_root_functor{}, 2.0);
+    CAPTURE(result, status);
+    REQUIRE(result == 1.0);
+    REQUIRE(status == 0);
+}
+
+TEST_CASE("newton_root_finder initial guess is root", "[newton_root_finder][xsf_tests]") {
+    auto [result, status] = xsf::detail::find_root_newton(parabola_root_functor{}, 1.0);
+    CAPTURE(result, status);
+    REQUIRE(result == 1.0);
+    REQUIRE(status == 0);
+}
+
+TEST_CASE("newton_root_finder respects rtol parameter", "[newton_root_finder][xsf_tests]") {
+    auto [result_default_rtol, status_default_rtol] = xsf::detail::find_root_newton(parabola_root_functor{}, 2.0);
+    auto [result_loose_rtol, status_loose_rtol] = xsf::detail::find_root_newton(parabola_root_functor{}, 2.0, 1e-4);
+    REQUIRE(status_loose_rtol == 0);
+    const double rel_error_default_rtol = xsf::extended_relative_error(result_default_rtol, 1.0);
+    const double rel_error_loose_rtol = xsf::extended_relative_error(result_loose_rtol, 1.0);
+    CAPTURE(
+        rel_error_default_rtol, rel_error_loose_rtol, result_default_rtol, status_default_rtol, result_loose_rtol,
+        status_loose_rtol
+    );
+    REQUIRE(rel_error_default_rtol < rel_error_loose_rtol);
+}
+
+TEST_CASE("newton_root_finder respects atol parameter", "[newton_root_finder][xsf_tests]") {
+    double atol = 1e-4;
+    auto [result_default_atol, status_default_atol] = xsf::detail::find_root_newton(parabola_root_functor{}, 2.0);
+    auto [result_loose_atol, status_loose_atol] =
+        xsf::detail::find_root_newton(parabola_root_functor{}, 2.0, 4 * std::numeric_limits<double>::epsilon(), atol);
+    REQUIRE(result_loose_atol < 1.0 + atol);
+    REQUIRE(status_loose_atol == 0);
+    const double rel_error_default_atol = xsf::extended_relative_error(result_default_atol, 1.0);
+    const double rel_error_loose_atol = xsf::extended_relative_error(result_loose_atol, 1.0);
+    CAPTURE(
+        rel_error_default_atol, rel_error_loose_atol, result_default_atol, status_default_atol, result_loose_atol,
+        status_loose_atol
+    );
+    REQUIRE(rel_error_default_atol < rel_error_loose_atol);
+}
+
+TEST_CASE("newton_root_finder max iterations exceeded", "[newton_root_finder][xsf_tests]") {
+    auto [result, status] = xsf::detail::find_root_newton(parabola_root_functor{}, 2.0, 1e-14, 0.0, 5);
+    CAPTURE(result, status);
+    REQUIRE(status == 1);
+}
+
+TEST_CASE("newton_root_finder derivative zero", "[newton_root_finder][xsf_tests]") {
+    // At x = 0, the derivative is zero, so the root finder should return NaN and status 2.
+    auto [result, status] = xsf::detail::find_root_newton(parabola_root_functor{}, 0.0);
+    CAPTURE(result, status);
+    REQUIRE(status == 2);
+    REQUIRE(std::isnan(result));
+}
+
+TEST_CASE("newton_root_finder objective returns NaN", "[newton_root_finder][xsf_tests]") {
+    struct nan_root_functor {
+        XSF_HOST_DEVICE std::pair<double, double> operator()(double x) const {
+            return {std::numeric_limits<double>::quiet_NaN(), 2 * x};
+        }
+    };
+    auto [result, status] = xsf::detail::find_root_newton(nan_root_functor{}, 2.0);
+    CAPTURE(result, status);
+    REQUIRE(status == 3);
+    REQUIRE(std::isnan(result));
+}
+
+TEST_CASE("newton_root_finder objective returns infinity", "[newton_root_finder][xsf_tests]") {
+    const double inf = GENERATE(std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity());
+
+    struct inf_root_functor {
+        double value;
+
+        XSF_HOST_DEVICE std::pair<double, double> operator()(double x) const { return {value, 2 * x}; }
+    };
+
+    auto [result, status] = xsf::detail::find_root_newton(inf_root_functor{inf}, 2.0);
+
+    CAPTURE(inf, result, status);
+    REQUIRE(status == 4);
+    REQUIRE(std::isinf(result));
+    REQUIRE(std::signbit(result) == std::signbit(inf));
+}

--- a/tests/xsf_tests/test_newton_root_finder.cpp
+++ b/tests/xsf_tests/test_newton_root_finder.cpp
@@ -9,20 +9,20 @@ TEST_CASE("newton_root_finder happy path", "[newton_root_finder][xsf_tests]") {
     auto [result, status] = xsf::detail::find_root_newton(parabola_root_functor{}, 2.0);
     CAPTURE(result, status);
     REQUIRE(result == 1.0);
-    REQUIRE(status == 0);
+    REQUIRE(status == xsf::detail::NewtonRootFinderStatus::SUCCESS);
 }
 
 TEST_CASE("newton_root_finder initial guess is root", "[newton_root_finder][xsf_tests]") {
     auto [result, status] = xsf::detail::find_root_newton(parabola_root_functor{}, 1.0);
     CAPTURE(result, status);
     REQUIRE(result == 1.0);
-    REQUIRE(status == 0);
+    REQUIRE(status == xsf::detail::NewtonRootFinderStatus::SUCCESS);
 }
 
 TEST_CASE("newton_root_finder respects rtol parameter", "[newton_root_finder][xsf_tests]") {
     auto [result_default_rtol, status_default_rtol] = xsf::detail::find_root_newton(parabola_root_functor{}, 2.0);
     auto [result_loose_rtol, status_loose_rtol] = xsf::detail::find_root_newton(parabola_root_functor{}, 2.0, 1e-4);
-    REQUIRE(status_loose_rtol == 0);
+    REQUIRE(status_loose_rtol == xsf::detail::NewtonRootFinderStatus::SUCCESS);
     const double rel_error_default_rtol = xsf::extended_relative_error(result_default_rtol, 1.0);
     const double rel_error_loose_rtol = xsf::extended_relative_error(result_loose_rtol, 1.0);
     CAPTURE(
@@ -38,7 +38,7 @@ TEST_CASE("newton_root_finder respects atol parameter", "[newton_root_finder][xs
     auto [result_loose_atol, status_loose_atol] =
         xsf::detail::find_root_newton(parabola_root_functor{}, 2.0, 4 * std::numeric_limits<double>::epsilon(), atol);
     REQUIRE(result_loose_atol < 1.0 + atol);
-    REQUIRE(status_loose_atol == 0);
+    REQUIRE(status_loose_atol == xsf::detail::NewtonRootFinderStatus::SUCCESS);
     const double rel_error_default_atol = xsf::extended_relative_error(result_default_atol, 1.0);
     const double rel_error_loose_atol = xsf::extended_relative_error(result_loose_atol, 1.0);
     CAPTURE(
@@ -51,14 +51,14 @@ TEST_CASE("newton_root_finder respects atol parameter", "[newton_root_finder][xs
 TEST_CASE("newton_root_finder max iterations exceeded", "[newton_root_finder][xsf_tests]") {
     auto [result, status] = xsf::detail::find_root_newton(parabola_root_functor{}, 2.0, 1e-14, 0.0, 5);
     CAPTURE(result, status);
-    REQUIRE(status == 1);
+    REQUIRE(status == xsf::detail::NewtonRootFinderStatus::MAX_ITERATIONS_EXCEEDED);
 }
 
 TEST_CASE("newton_root_finder derivative zero", "[newton_root_finder][xsf_tests]") {
     // At x = 0, the derivative is zero, so the root finder should return NaN and status 2.
     auto [result, status] = xsf::detail::find_root_newton(parabola_root_functor{}, 0.0);
     CAPTURE(result, status);
-    REQUIRE(status == 2);
+    REQUIRE(status == xsf::detail::NewtonRootFinderStatus::DERIVATIVE_ZERO);
     REQUIRE(std::isnan(result));
 }
 
@@ -70,7 +70,7 @@ TEST_CASE("newton_root_finder objective returns NaN", "[newton_root_finder][xsf_
     };
     auto [result, status] = xsf::detail::find_root_newton(nan_root_functor{}, 2.0);
     CAPTURE(result, status);
-    REQUIRE(status == 3);
+    REQUIRE(status == xsf::detail::NewtonRootFinderStatus::OBJECTIVE_RETURNED_NAN);
     REQUIRE(std::isnan(result));
 }
 
@@ -86,6 +86,6 @@ TEST_CASE("newton_root_finder objective returns infinity", "[newton_root_finder]
     auto [result, status] = xsf::detail::find_root_newton(inf_root_functor{inf}, 2.0);
 
     CAPTURE(inf, result, status);
-    REQUIRE(status == 3);
+    REQUIRE(status == xsf::detail::NewtonRootFinderStatus::OBJECTIVE_RETURNED_INF);
     REQUIRE(std::isnan(result));
 }


### PR DESCRIPTION
#### Reference issue
Follow up to #130

#### What does this implement/fix?
#130 implemented the inverse digamma function using a Newtonian root finder. I am sure that a general Newtonian root finder will be useful in future, so I added a reusable method for it. `digammainv` is then updated to use this method.

#### Additional information
The technicalities mostly follow what I saw in `tools.h`. 

#### AI Generation Disclosure
AI helped with the implementation and discussions about default parameters.
