### PR TITLE
MAINT: remove remaining ufl variable in amos

### DIFF
--- a/include/xsf/amos/amos.h
+++ b/include/xsf/amos/amos.h
@@ -1286,8 +1286,8 @@ namespace amos {
         //***END PROLOGUE  ZBESH
 
         std::complex<double> zn, zt, csgn;
-        double aa, alim, aln, arg, az, cpn, dig, elim, fmm, fn, fnul, rhpi, rl, r1m5, sgn, spn, tol, xn, xx, yn,
-            yy, bb, ascle, rtol, atol;
+        double aa, alim, aln, arg, az, cpn, dig, elim, fmm, fn, fnul, rhpi, rl, r1m5, sgn, spn, tol, xn, xx, yn, yy, bb,
+            ascle, rtol, atol;
         int i, inu, inuh, ir, k, k1, k2, mm, mr, nn, nuf, nw, nz;
 
         nz = 0;

--- a/include/xsf/amos/amos.h
+++ b/include/xsf/amos/amos.h
@@ -1286,7 +1286,7 @@ namespace amos {
         //***END PROLOGUE  ZBESH
 
         std::complex<double> zn, zt, csgn;
-        double aa, alim, aln, arg, az, cpn, dig, elim, fmm, fn, fnul, rhpi, rl, r1m5, sgn, spn, tol, ufl, xn, xx, yn,
+        double aa, alim, aln, arg, az, cpn, dig, elim, fmm, fn, fnul, rhpi, rl, r1m5, sgn, spn, tol, xn, xx, yn,
             yy, bb, ascle, rtol, atol;
         int i, inu, inuh, ir, k, k1, k2, mm, mr, nn, nuf, nw, nz;
 
@@ -1484,7 +1484,7 @@ namespace amos {
         }
         zt = std::complex<double>(0.0, -fmm);
         rtol = 1.0 / tol;
-        ascle = ufl * rtol;
+        ascle = THRESHOLD_MIN * rtol;
         for (i = 1; i < (nn + 1); i++) {
             zn = cy[i - 1];
             atol = 1.0;
@@ -2183,7 +2183,7 @@ namespace amos {
 
         double xx = std::real(z);
         double yy = std::imag(z);
-        double aa, alim, aln, arg, az, dig, elim, fn, fnul, rl, r1m5, tol, ufl, bb;
+        double aa, alim, aln, arg, az, dig, elim, fn, fnul, rl, r1m5, tol, bb;
         int k, k1, k2, mr, nn, nuf, nw, nz;
 
         *ierr = 0;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
CI is failing on https://github.com/scipy/scipy/pull/25636. It seems we forgot to remove the `ufl` variable in https://github.com/scipy/xsf/pull/132

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I asked Codex for any remaining missing cleanups 