### PR TITLE
ENH: improve iv for tiny inputs

### DIFF
--- a/include/xsf/cephes/scipy_iv.h
+++ b/include/xsf/cephes/scipy_iv.h
@@ -76,6 +76,7 @@
 
 #include "const.h"
 #include "gamma.h"
+#include "rgamma.h"
 #include "trig.h"
 
 namespace xsf {
@@ -801,8 +802,13 @@ namespace cephes {
              */
             detail::ikv_asymptotic_uniform(v, ax, &res, NULL);
         } else {
-            /* Otherwise: Temme's method */
-            detail::ikv_temme(v, ax, &res, NULL);
+            /* Check for tiny x to avoid Wronskian overflow in ikv_temme */
+            if (ax * ax < std::abs(v + 1.0) * detail::MACHEP) {
+                res = std::pow(0.5 * ax, v) * rgamma(v + 1.0);
+            } else {
+                /* Otherwise: Temme's method */
+                detail::ikv_temme(v, ax, &res, NULL);
+            }
         }
         res *= sign;
         return res;

--- a/tests/xsf_tests/test_bessel.cpp
+++ b/tests/xsf_tests/test_bessel.cpp
@@ -1,0 +1,21 @@
+#include "../testing_utils.h"
+#include <tuple>
+#include <xsf/bessel.h>
+
+TEST_CASE("iv tiny inputs", "[bessel][xsf_tests]") {
+    using test_case = std::tuple<long, double, double, double>;
+
+    // Reference values computed with mpmath.
+    auto [n, z, ref, rtol] = GENERATE(
+        test_case{1, 1e-50, 5e-51, 1e-14}, test_case{100, 0.1, 8.45293498689205e-289, 1e-10},
+        test_case{10, 5.2250558491838786e-27, 4.0817497902418315e-273, 1e-14},
+        test_case{3, 1e-50, 2.0833333333333333e-152, 1e-14}, test_case{10, 1e-29, 2.6911444554673707e-300, 1e-8},
+        test_case{20, 1e-14, 3.919904349624791e-305, 1e-8}, test_case{200, 5, 5.065429051896385e-296, 1e-10}
+    );
+
+    double result = xsf::cyl_bessel_i(n, z); // calls cephes::iv
+    double rel_err = xsf::extended_relative_error(result, ref);
+
+    CAPTURE(n, z, result, ref, rel_err, rtol);
+    REQUIRE(rel_err <= rtol);
+}

--- a/tests/xsf_tests/test_sph_bessel.cpp
+++ b/tests/xsf_tests/test_sph_bessel.cpp
@@ -152,3 +152,21 @@ TEST_CASE("spherical_y_jac reflection derivative", "[bessel][xsf_tests]") {
     CAPTURE(n, z, result_spherical_y_jac, ref_spherical_y_jac, rel_err_spherical_y_jac, rtol);
     REQUIRE(rel_err_spherical_y_jac <= rtol);
 }
+
+TEST_CASE("spherical_i tiny inputs", "[bessel][xsf_tests]") {
+    using test_case = std::tuple<long, double, double, double>;
+
+    // Reference values computed with mpmath.
+    auto [n, z, ref, rtol] = GENERATE(
+        test_case{1, 1e-50, 3.333333333333333e-51, 1e-14}, test_case{100, 0.1, 7.463271153267418e-290, 1e-10},
+        test_case{10, 5.2250558491838786e-27, 1.10313444760931e-273, 1e-14},
+        test_case{3, 1e-50, 9.523809523809524e-153, 1e-14}, test_case{10, 1e-29, 7.273091945557419e-301, 1e-8},
+        test_case{20, 1e-14, 7.625979004892142e-306, 1e-8}, test_case{200, 5, 3.168106195219311e-297, 1e-10}
+    );
+
+    double result = xsf::sph_bessel_i(n, z);
+    double rel_err = xsf::extended_relative_error(result, ref);
+
+    CAPTURE(n, z, result, ref, rel_err, rtol);
+    REQUIRE(rel_err <= rtol);
+}

--- a/tests/xsf_tests/test_sph_bessel.cpp
+++ b/tests/xsf_tests/test_sph_bessel.cpp
@@ -4,7 +4,7 @@
 #include <xsf/bessel.h>
 #include <xsf/sph_bessel.h>
 
-TEST_CASE("spherical_j reflection complex", "[bessel][xsf_tests]") {
+TEST_CASE("spherical_j reflection complex", "[spherical_bessel][xsf_tests]") {
     using test_case = std::tuple<long, std::complex<double>, std::complex<double>, double>;
 
     // Reference values computed with mpmath.
@@ -24,7 +24,7 @@ TEST_CASE("spherical_j reflection complex", "[bessel][xsf_tests]") {
     REQUIRE(rel_err_spherical_j <= rtol);
 }
 
-TEST_CASE("spherical_j_jac reflection derivative complex", "[bessel][xsf_tests]") {
+TEST_CASE("spherical_j_jac reflection derivative complex", "[spherical_bessel][xsf_tests]") {
     using test_case = std::tuple<long, std::complex<double>, std::complex<double>, double>;
 
     // Reference values computed with mpmath.
@@ -44,7 +44,7 @@ TEST_CASE("spherical_j_jac reflection derivative complex", "[bessel][xsf_tests]"
     REQUIRE(rel_err_spherical_j_jac <= rtol);
 }
 
-TEST_CASE("spherical_j real reflection", "[bessel][xsf_tests]") {
+TEST_CASE("spherical_j real reflection", "[spherical_bessel][xsf_tests]") {
     using test_case = std::tuple<long, double, double, double>;
 
     // Reference values computed with mpmath.
@@ -62,7 +62,7 @@ TEST_CASE("spherical_j real reflection", "[bessel][xsf_tests]") {
     REQUIRE(rel_err_spherical_j <= rtol);
 }
 
-TEST_CASE("spherical_j_jac reflection derivative", "[bessel][xsf_tests]") {
+TEST_CASE("spherical_j_jac reflection derivative", "[spherical_bessel][xsf_tests]") {
     using test_case = std::tuple<long, double, double, double>;
 
     // Reference values computed with mpmath.
@@ -80,7 +80,7 @@ TEST_CASE("spherical_j_jac reflection derivative", "[bessel][xsf_tests]") {
     REQUIRE(rel_err_spherical_j_jac <= rtol);
 }
 
-TEST_CASE("spherical_y reflection complex", "[bessel][xsf_tests]") {
+TEST_CASE("spherical_y reflection complex", "[spherical_bessel][xsf_tests]") {
     using test_case = std::tuple<long, std::complex<double>, std::complex<double>, double>;
 
     // Reference values computed with mpmath.
@@ -99,7 +99,7 @@ TEST_CASE("spherical_y reflection complex", "[bessel][xsf_tests]") {
     REQUIRE(rel_err_spherical_y <= rtol);
 }
 
-TEST_CASE("spherical_y_jac reflection derivative complex", "[bessel][xsf_tests]") {
+TEST_CASE("spherical_y_jac reflection derivative complex", "[spherical_bessel][xsf_tests]") {
     using test_case = std::tuple<long, std::complex<double>, std::complex<double>, double>;
 
     // Reference values computed with mpmath.
@@ -117,7 +117,7 @@ TEST_CASE("spherical_y_jac reflection derivative complex", "[bessel][xsf_tests]"
     REQUIRE(rel_err_spherical_y_jac <= rtol);
 }
 
-TEST_CASE("spherical_y real reflection", "[bessel][xsf_tests]") {
+TEST_CASE("spherical_y real reflection", "[spherical_bessel][xsf_tests]") {
     using test_case = std::tuple<long, double, double, double>;
 
     // Reference values computed with mpmath.
@@ -135,7 +135,7 @@ TEST_CASE("spherical_y real reflection", "[bessel][xsf_tests]") {
     REQUIRE(rel_err_spherical_y <= rtol);
 }
 
-TEST_CASE("spherical_y_jac reflection derivative", "[bessel][xsf_tests]") {
+TEST_CASE("spherical_y_jac reflection derivative", "[spherical_bessel][xsf_tests]") {
     using test_case = std::tuple<long, double, double, double>;
 
     // Reference values computed with mpmath.
@@ -153,7 +153,7 @@ TEST_CASE("spherical_y_jac reflection derivative", "[bessel][xsf_tests]") {
     REQUIRE(rel_err_spherical_y_jac <= rtol);
 }
 
-TEST_CASE("spherical_i tiny inputs", "[bessel][xsf_tests]") {
+TEST_CASE("spherical_i tiny inputs", "[spherical_bessel][xsf_tests]") {
     using test_case = std::tuple<long, double, double, double>;
 
     // Reference values computed with mpmath.


### PR DESCRIPTION
#### Reference issue
Towards https://github.com/scipy/scipy/issues/25287

#### What does this implement/fix?
This PR fixes `iv` for small inputs by using the leading order of the series. The same is already done for `jv` in [this section](https://github.com/scipy/xsf/blob/6dacc318b2028e193ccbed3962704d21cf2b2442/include/xsf/cephes/jv.h#L609). By fixing `iv` we fix `spherical_i` and thereby the mentioned SciPy issue.

#### AI Generation Disclosure
LLMs created the fix, tests are mine.
