### PR TITLE
ENH: add integer-parameter signature in numpy.h

### DIFF
--- a/include/xsf/numpy.h
+++ b/include/xsf/numpy.h
@@ -190,6 +190,7 @@ namespace numpy {
     using D_DDDD = void (*)(cdouble, cdouble &, cdouble &, cdouble &, cdouble &);
 
     // 2 inputs, 1 output
+    using pd_d = double (*)(std::ptrdiff_t, double);
     using qf_f = float (*)(long long int, float);
     using qd_d = double (*)(long long int, double);
     using ff_f = float (*)(float, float);
@@ -236,6 +237,7 @@ namespace numpy {
     using dd_dddd = void (*)(double, double, double &, double &, double &, double &);
 
     // 3 inputs, 1 output
+    using pdd_d = double (*)(std::ptrdiff_t, double, double);
     using fff_f = float (*)(float, float, float);
     using ddd_d = double (*)(double, double, double);
     using flf_f = double (*)(double, long, double);
@@ -268,6 +270,7 @@ namespace numpy {
     using qqd_ddd = void (*)(long long int, long long int, double, double &, double &, double &);
 
     // 4 inputs, 1 output
+    using pddd_d = double (*)(std::ptrdiff_t, double, double, double);
     using llld_d = double (*)(long int, long int, long int, double);
     using qqqd_d = double (*)(long long int, long long int, long long int, double);
     using qqqF_F = cfloat (*)(long long int, long long int, long long int, cfloat);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Following https://github.com/scipy/xsf/pull/209, I was trying to use Jacobi and Shifted Jacobi polynomials from XSF. It appears those ufunc signatures will be useful for `scipy/special/_special_ufuncs.cpp` for Jacobi and the following polynomials.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Codex reviewed.