### PR TITLE
TST: sph_bessel_y: added tests for reflection property

### DIFF
--- a/include/xsf/sph_bessel.h
+++ b/include/xsf/sph_bessel.h
@@ -172,7 +172,8 @@ T sph_bessel_y(long n, T x) {
     }
 
     if (x < 0) {
-        return std::pow(-1, n + 1) * sph_bessel_y(n, -x);
+        T r = sph_bessel_y(n, -x);
+        return (n % 2 == 1) ? r : -r;
     }
 
     if (x == std::numeric_limits<T>::infinity() || x == -std::numeric_limits<T>::infinity()) {

--- a/tests/xsf_tests/test_sph_bessel.cpp
+++ b/tests/xsf_tests/test_sph_bessel.cpp
@@ -79,3 +79,79 @@ TEST_CASE("spherical_j_jac reflection derivative", "[bessel][xsf_tests]") {
     CAPTURE(n, z, result_spherical_j_jac, ref_spherical_j_jac, rel_err_spherical_j_jac, rtol);
     REQUIRE(rel_err_spherical_j_jac <= rtol);
 }
+
+TEST_CASE("spherical_y reflection complex", "[bessel][xsf_tests]") {
+    using test_case = std::tuple<long, std::complex<double>, std::complex<double>, double>;
+
+    // Reference values computed with mpmath.
+    auto [n, z, ref_spherical_y, rtol] = GENERATE(
+        // Even n => y_n(-z) = -y_n(z)   https://dlmf.nist.gov/10.47#E14
+        test_case{10, {5., 0}, {-26.656114405718699, 0}, 1e-14},
+        test_case{10, {-5., 0}, {26.656114405718699, 0}, 1e-14},
+        // Odd n => y_n(-z) = y_n(z)   https://dlmf.nist.gov/10.47#E14
+        test_case{7, {5., 0}, {-1.0273946388125984, 0}, 1e-14},
+        test_case{7, {-5., 0}, {-1.0273946388125984, 0}, 1e-14}
+    );
+
+    std::complex<double> result_spherical_y = xsf::sph_bessel_y(n, z);
+    double rel_err_spherical_y = xsf::extended_relative_error(result_spherical_y, ref_spherical_y);
+
+    CAPTURE(n, z, result_spherical_y, ref_spherical_y, rel_err_spherical_y, rtol);
+    REQUIRE(rel_err_spherical_y <= rtol);
+}
+
+TEST_CASE("spherical_y_jac reflection derivative complex", "[bessel][xsf_tests]") {
+    using test_case = std::tuple<long, std::complex<double>, std::complex<double>, double>;
+
+    // Reference values computed with mpmath.
+    auto [n, z, ref_spherical_y_jac, rtol] = GENERATE(
+        // Even n => y_n'(-z) = y_n'(z)   from DLMF 10.47.14 by taking the derivative with respect to z
+        test_case{10, {5., 0}, {50.954006758163679, 0}, 1e-14},
+        test_case{10, {-5., 0}, {50.954006758163679, 0}, 1e-14},
+        // Odd n => y_n'(-z) = -y_n'(z)   from DLMF 10.47.14 by taking the derivative with respect to z
+        test_case{7, {5., 0}, {1.1254238507300277, 0}, 1e-14},
+        test_case{7, {-5., 0}, {-1.1254238507300277, 0}, 1e-14}
+    );
+
+    std::complex<double> result_spherical_y_jac = xsf::sph_bessel_y_jac(n, z);
+    double rel_err_spherical_y_jac = xsf::extended_relative_error(result_spherical_y_jac, ref_spherical_y_jac);
+
+    CAPTURE(n, z, result_spherical_y_jac, ref_spherical_y_jac, rel_err_spherical_y_jac, rtol);
+    REQUIRE(rel_err_spherical_y_jac <= rtol);
+}
+
+TEST_CASE("spherical_y real reflection", "[bessel][xsf_tests]") {
+    using test_case = std::tuple<long, double, double, double>;
+
+    // Reference values computed with mpmath.
+    auto [n, z, ref_spherical_y, rtol] = GENERATE(
+        // Even n => y_n(-x) = -y_n(x)   https://dlmf.nist.gov/10.47#E14
+        test_case{10, 5., -26.656114405718699, 1e-14}, test_case{10, -5., 26.656114405718699, 1e-14},
+        // Odd n => y_n(-x) = y_n(x)   https://dlmf.nist.gov/10.47#E14
+        test_case{7, 5., -1.0273946388125984, 1e-14}, test_case{7, -5., -1.0273946388125984, 1e-14}
+    );
+
+    double result_spherical_y = xsf::sph_bessel_y(n, z);
+    double rel_err_spherical_y = xsf::extended_relative_error(result_spherical_y, ref_spherical_y);
+
+    CAPTURE(n, z, result_spherical_y, ref_spherical_y, rel_err_spherical_y, rtol);
+    REQUIRE(rel_err_spherical_y <= rtol);
+}
+
+TEST_CASE("spherical_y_jac reflection derivative", "[bessel][xsf_tests]") {
+    using test_case = std::tuple<long, double, double, double>;
+
+    // Reference values computed with mpmath.
+    auto [n, z, ref_spherical_y_jac, rtol] = GENERATE(
+        // Even n => y_n'(-x) = y_n'(x)   from DLMF 10.47.14 by taking the derivative with respect to z
+        test_case{10, 5., 50.954006758163679, 1e-14}, test_case{10, -5., 50.954006758163679, 1e-14},
+        // Odd n => y_n'(-x) = -y_n'(x)   from DLMF 10.47.14 by taking the derivative with respect to z
+        test_case{7, 5., 1.1254238507300277, 1e-14}, test_case{7, -5., -1.1254238507300277, 1e-14}
+    );
+
+    double result_spherical_y_jac = xsf::sph_bessel_y_jac(n, z);
+    double rel_err_spherical_y_jac = xsf::extended_relative_error(result_spherical_y_jac, ref_spherical_y_jac);
+
+    CAPTURE(n, z, result_spherical_y_jac, ref_spherical_y_jac, rel_err_spherical_y_jac, rtol);
+    REQUIRE(rel_err_spherical_y_jac <= rtol);
+}

--- a/tests/xsf_tests/test_sph_bessel.cpp
+++ b/tests/xsf_tests/test_sph_bessel.cpp
@@ -89,8 +89,7 @@ TEST_CASE("spherical_y reflection complex", "[bessel][xsf_tests]") {
         test_case{10, {5., 0}, {-26.656114405718699, 0}, 1e-14},
         test_case{10, {-5., 0}, {26.656114405718699, 0}, 1e-14},
         // Odd n => y_n(-z) = y_n(z)   https://dlmf.nist.gov/10.47#E14
-        test_case{7, {5., 0}, {-1.0273946388125984, 0}, 1e-14},
-        test_case{7, {-5., 0}, {-1.0273946388125984, 0}, 1e-14}
+        test_case{7, {5., 0}, {-1.0273946388125984, 0}, 1e-14}, test_case{7, {-5., 0}, {-1.0273946388125984, 0}, 1e-14}
     );
 
     std::complex<double> result_spherical_y = xsf::sph_bessel_y(n, z);
@@ -106,11 +105,9 @@ TEST_CASE("spherical_y_jac reflection derivative complex", "[bessel][xsf_tests]"
     // Reference values computed with mpmath.
     auto [n, z, ref_spherical_y_jac, rtol] = GENERATE(
         // Even n => y_n'(-z) = y_n'(z)   from DLMF 10.47.14 by taking the derivative with respect to z
-        test_case{10, {5., 0}, {50.954006758163679, 0}, 1e-14},
-        test_case{10, {-5., 0}, {50.954006758163679, 0}, 1e-14},
+        test_case{10, {5., 0}, {50.954006758163679, 0}, 1e-14}, test_case{10, {-5., 0}, {50.954006758163679, 0}, 1e-14},
         // Odd n => y_n'(-z) = -y_n'(z)   from DLMF 10.47.14 by taking the derivative with respect to z
-        test_case{7, {5., 0}, {1.1254238507300277, 0}, 1e-14},
-        test_case{7, {-5., 0}, {-1.1254238507300277, 0}, 1e-14}
+        test_case{7, {5., 0}, {1.1254238507300277, 0}, 1e-14}, test_case{7, {-5., 0}, {-1.1254238507300277, 0}, 1e-14}
     );
 
     std::complex<double> result_spherical_y_jac = xsf::sph_bessel_y_jac(n, z);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
gh-222

#### What does this implement/fix?
This PR adds tests for the reflection property of the spherical Bessel functions of the second kind as was done before in #221 for the spherical Bessel functions of the first kind.

#### Additional information
In #221, the reflection in case of negative arguments `z` was added for the spherical Bessel functions of the first kind. For the Bessel functions of the second kind, the required code was already present, so that there is no immediate need to apply changes to `xsf/sph_bessel.h`.

However, in the variant for real argument `z`, the reflection is implemented with a code differing from the variant for complex argument and differing from the code used in `sph_bessel_j`.

The variant for real argument uses
https://github.com/scipy/xsf/blob/db2fdd0277b9cea80bf66781235400f51a6b5dd3/include/xsf/sph_bessel.h#L174-L176
while for complex arguments
https://github.com/scipy/xsf/blob/db2fdd0277b9cea80bf66781235400f51a6b5dd3/include/xsf/sph_bessel.h#L237-L240
is used. The corresponding variant for `sph_bessel_j` with real argument reads
https://github.com/scipy/xsf/blob/db2fdd0277b9cea80bf66781235400f51a6b5dd3/include/xsf/sph_bessel.h#L51-L54

I propose to use the latter code (with the function call adapted accordingly) in `sph_bessel_y` for real argument as well. Any thoughts on this? I will amend the PR accordingly, if the change shall be made.

Since the reflection property is already ensured for `sph_bessel_y`, the corresponding decorator in `scipy/special/_spherical_bessel.py` can be removed. This will be done in a separate PR once the present PR has been handled.

The changes for the modified spherical Bessel functions mentioned in gh-222 will be the subject of separate PRs.

#### AI Generation Disclosure
No AI tools used