### PR TITLE
CI: improve Pixi caching

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,7 +22,7 @@ jobs:
         environment: [lint]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: v0.75.0
           cache: true

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: prefix-dev/setup-pixi@92815284c57faa15cd896c4d5cfb2d59f32dc43d # v0.8.3
         with:
-          pixi-version: v0.70.1
+          pixi-version: v0.75.0
           cache: true
           environments: ${{ matrix.environment }}
       - name: Check for formatting violations

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -22,7 +22,7 @@ jobs:
         environment: [lint]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prefix-dev/setup-pixi@92815284c57faa15cd896c4d5cfb2d59f32dc43d # v0.8.3
+      - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: v0.75.0
           cache: true

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: run nvidia-smi --query
         run: nvidia-smi --query
 
-      - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: v0.75.0
           manifest-path: pixi.toml

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -40,7 +40,7 @@ jobs:
       - name: run nvidia-smi --query
         run: nvidia-smi --query
 
-      - uses: prefix-dev/setup-pixi@ba3bb36eb2066252b2363392b7739741bb777659 # v0.8.1
+      - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: v0.75.0
           manifest-path: pixi.toml

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: prefix-dev/setup-pixi@ba3bb36eb2066252b2363392b7739741bb777659 # v0.8.1
         with:
-          pixi-version: v0.70.1
+          pixi-version: v0.75.0
           manifest-path: pixi.toml
           cache: false
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: prefix-dev/setup-pixi@92815284c57faa15cd896c4d5cfb2d59f32dc43d # v0.8.3
         with:
-          pixi-version: v0.73.0
+          pixi-version: v0.75.0
           cache: true
           cache-key: ${{ matrix.runs-on }}
           environments: coverage
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: prefix-dev/setup-pixi@92815284c57faa15cd896c4d5cfb2d59f32dc43d # v0.8.3
         with:
-          pixi-version: v0.73.0
+          pixi-version: v0.75.0
           cache: true
           cache-key: ${{ matrix.runs-on }}
           environments: default
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: prefix-dev/setup-pixi@92815284c57faa15cd896c4d5cfb2d59f32dc43d # v0.8.3
         with:
-          pixi-version: v0.70.1
+          pixi-version: v0.75.0
           cache: true
           cache-key: ${{ matrix.runs-on }}
           environments: default

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         runs-on: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prefix-dev/setup-pixi@92815284c57faa15cd896c4d5cfb2d59f32dc43d # v0.8.3
+      - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: v0.75.0
           cache: true
@@ -81,7 +81,7 @@ jobs:
         runs-on: [windows-latest]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prefix-dev/setup-pixi@92815284c57faa15cd896c4d5cfb2d59f32dc43d # v0.8.3
+      - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: v0.75.0
           cache: true
@@ -128,7 +128,7 @@ jobs:
         runs-on: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prefix-dev/setup-pixi@92815284c57faa15cd896c4d5cfb2d59f32dc43d # v0.8.3
+      - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: v0.75.0
           cache: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           pixi-version: v0.75.0
           cache: true
-          cache-key: ${{ matrix.runs-on }}
           environments: coverage
       - name:  Prepare compiler cache
         id:    prep-ccache
@@ -86,7 +85,6 @@ jobs:
         with:
           pixi-version: v0.75.0
           cache: true
-          cache-key: ${{ matrix.runs-on }}
           environments: default
       - name:  Prepare compiler cache
         id:    prep-ccache
@@ -134,7 +132,6 @@ jobs:
         with:
           pixi-version: v0.75.0
           cache: true
-          cache-key: ${{ matrix.runs-on }}
           environments: default
       - name:  Prepare compiler cache
         id:    prep-ccache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
         runs-on: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: v0.75.0
           cache: true
@@ -81,7 +81,7 @@ jobs:
         runs-on: [windows-latest]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: v0.75.0
           cache: true
@@ -128,7 +128,7 @@ jobs:
         runs-on: [ubuntu-latest, ubuntu-24.04-arm]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
+      - uses: prefix-dev/setup-pixi@v0.10.0
         with:
           pixi-version: v0.75.0
           cache: true


### PR DESCRIPTION
on the osx job I see [35](https://github.com/scipy/xsf/actions/runs/30566772457/job/90953209619?pr=229#step:3:9240)
  Warning: Failed to save: Unable to reserve cache with key pixi-osx-arm64-a5ffeab4454cb9691ff9a53bd21832b648fbfcef24ebb3e96b394082b990f507, another job may be creating this cache.