### PR TITLE
BUG: fix y1 for large inputs

### DIFF
--- a/include/xsf/cephes/j1.h
+++ b/include/xsf/cephes/j1.h
@@ -199,9 +199,13 @@ namespace cephes {
         z = w * w;
         p = polevl(z, detail::j1_PP, 6) / polevl(z, detail::j1_PQ, 6);
         q = polevl(z, detail::j1_QP, 7) / p1evl(z, detail::j1_QQ, 7);
-        xn = x - detail::THPIO4;
-        p = p * std::sin(xn) + w * q * std::cos(xn);
-        return (p * detail::SQRT2OPI / std::sqrt(x));
+        if (x < 10.0) {
+            xn = x - detail::THPIO4;
+            p = p * std::sin(xn) + w * q * std::cos(xn);
+            return (p * detail::SQRT2OPI / std::sqrt(x));
+        }
+        p = (w * q - p) * std::sin(x) - (p + w * q) * std::cos(x);
+        return (p * detail::SQRT1OPI / std::sqrt(x));
     }
 } // namespace cephes
 } // namespace xsf

--- a/tests/xsf_tests/test_bessel_functions_large_inputs.cpp
+++ b/tests/xsf_tests/test_bessel_functions_large_inputs.cpp
@@ -102,3 +102,30 @@ TEST_CASE("j1 right tail gh-large-input", "[j1][xsf_tests]") {
     CAPTURE(x, w, ref, rtol, rel_error);
     REQUIRE(rel_error <= rtol);
 }
+
+TEST_CASE("y1 right tail gh-large-input", "[y1][xsf_tests]") {
+    using test_case = std::tuple<double, double, double>;
+    // Reference values computed with mpmath with 1000 digits of precision:
+    //
+    // import math
+    // import mpmath as mp
+    // mp.mp.dps = 1000
+    // xs = [
+    //     math.nextafter(10.0, 0.0), 10.0, math.nextafter(10.0, math.inf),
+    //     100.0, 1e4, 1e8, 1e12, 1e13, 1e15, 1e20,
+    // ]
+    // for x in xs:
+    //     print(x, mp.nstr(mp.bessely(1, x), 18))
+    auto [x, ref, rtol] = GENERATE(
+        test_case{9.999999999999998, 0.24901542420695383, 5e-15}, test_case{10.0, 0.24901542420695388, 5e-15},
+        test_case{10.000000000000002, 0.24901542420695394, 5e-15}, test_case{100.0, -0.020372312002759792, 5e-15},
+        test_case{1e4, 0.007096342752536495, 5e-15}, test_case{1e8, -3.2060294975092524e-05, 5e-15},
+        test_case{1e12, -1.016712505008025e-07, 5e-15}, test_case{1e13, -1.1926484739666765e-07, 5e-15},
+        test_case{1e15, -6.15663864688501e-09, 5e-15}, test_case{1e20, -6.698009040703424e-12, 5e-15}
+    );
+    const double w = xsf::cephes::y1(x);
+    const double rel_error = xsf::extended_relative_error(w, ref);
+
+    CAPTURE(x, w, ref, rtol, rel_error);
+    REQUIRE(rel_error <= rtol);
+}


### PR DESCRIPTION
#### Reference issue

Follow-up to j0 (scipy#131), y0 (scipy#140) and j1 (scipy#143). `y1` is the last one in that group still forming the phase as `x - 3pi/4`.

#### What does this implement/fix?

`xn = x - THPIO4` rounds to the nearest double, so it costs about `ulp(x)/2` of
absolute phase, which `sin`/`cos` turn into relative error.

I implemented the same rewrite as y0 (scipy#140), so the trig is evaluated on the unmodified `x`. I also adds the
missing `y1` case to `test_bessel_functions_large_inputs.cpp`.

#### Additional information

Relative error vs mpmath at 1000 dps:

| x | before | after |
|---|---|---|
| 1e4 | 1.1e-13 | 9.0e-18 |
| 1e8 | 1.4e-08 | 1.1e-16 |
| 1e20 | 6.7 | 1.2e-16 |

`j0`, `y0` and `j1` are at ~1e-16 on the same points, so this is `y1` only.
Additionally, `yv`/`yn` inherit it through the recurrence. For example, `yv(200, 1e7)` is off by 4.1e-10 before this change.

`pixi run tests` passes and the new test fails on main.

#### AI Generation Disclosure

I used Claude Code to draft the fix and test.
