### PR TITLE
BUG(kelvin): ker/kei: fix across the whole subnormal range

### DIFF
--- a/include/xsf/kelvin.h
+++ b/include/xsf/kelvin.h
@@ -25,7 +25,7 @@ namespace detail {
 
         int k, km, m;
         T gs, r, x2, x4, pp1, pn1, qp1, qn1, r1, pp0, pn0, qp0, qn0, r0, fac, xt, cs, ss, xd, xe1, xe2, xc1, xc2, cp0,
-            cn0, sp0, sn0, rc, rs;
+            cn0, sp0, sn0, rc, rs, xlog;
         const T pi = 3.141592653589793;
         const T el = 0.5772156649015329;
         const T eps = 1.0e-15;
@@ -46,6 +46,14 @@ namespace detail {
         x4 = x2 * x2;
 
         if (fabs(x) < 10.0) {
+            // x / 2 is exact for every argument except the smallest subnormal,
+            // where it underflows to zero and makes log(x / 2) -inf. The series
+            // terms it multiplies below have underflowed to zero by then, so
+            // that -inf becomes inf * 0 = NaN and kei(5e-324) is returned as
+            // NaN while kei(1e-320) is correct. log(x) - log(2) stays finite
+            // there and agrees with log(x / 2) elsewhere.
+            xlog = (x / 2.0 == 0.0) ? log(x) - log(2.0) : log(x / 2.0);
+
             *ber = 1.0;
             r = 1.0;
             for (m = 1; m <= 60; m++) {
@@ -66,7 +74,7 @@ namespace detail {
                 }
             }
 
-            *ger = -(log(x / 2.0) + el) * (*ber) + 0.25 * pi * (*bei);
+            *ger = -(xlog + el) * (*ber) + 0.25 * pi * (*bei);
 
             r = 1.0;
             gs = 0.0;
@@ -79,7 +87,7 @@ namespace detail {
                 }
             }
 
-            *gei = x2 - (log(x / 2.0) + el) * (*bei) - 0.25 * pi * (*ber);
+            *gei = x2 - (xlog + el) * (*bei) - 0.25 * pi * (*ber);
 
             r = x2;
             gs = 1.0;
@@ -114,7 +122,7 @@ namespace detail {
 
             r = -0.25 * x * x2;
             gs = 1.5;
-            *her = 1.5 * r - (*ber) / x - (log(x / 2.0) + el) * (*der) + 0.25 * pi * (*dei);
+            *her = 1.5 * r - (*ber) / x - (xlog + el) * (*der) + 0.25 * pi * (*dei);
             for (m = 1; m <= 60; m++) {
                 r = -0.25 * r / m / (m + 1.0) / pow((2.0 * m + 1.0), 2) * x4;
                 gs = gs + 1.0 / (2.0 * m + 1.0) + 1.0 / (2 * m + 2.0);
@@ -126,7 +134,7 @@ namespace detail {
 
             r = 0.5 * x;
             gs = 1.0;
-            *hei = 0.5 * x - (*bei) / x - (log(x / 2.0) + el) * (*dei) - 0.25 * pi * (*der);
+            *hei = 0.5 * x - (*bei) / x - (xlog + el) * (*dei) - 0.25 * pi * (*der);
             for (m = 1; m <= 60; m++) {
                 r = -0.25 * r / (m * m) / (2 * m - 1.0) / (2 * m + 1.0) * x4;
                 gs = gs + 1.0 / (2.0 * m) + 1.0 / (2 * m + 1.0);

--- a/include/xsf/kelvin.h
+++ b/include/xsf/kelvin.h
@@ -46,13 +46,18 @@ namespace detail {
         x4 = x2 * x2;
 
         if (fabs(x) < 10.0) {
-            // x / 2 is exact for every argument except the smallest subnormal,
-            // where it underflows to zero and makes log(x / 2) -inf. The series
-            // terms it multiplies below have underflowed to zero by then, so
-            // that -inf becomes inf * 0 = NaN and kei(5e-324) is returned as
-            // NaN while kei(1e-320) is correct. log(x) - log(2) stays finite
-            // there and agrees with log(x / 2) elsewhere.
-            xlog = (x / 2.0 == 0.0) ? log(x) - log(2.0) : log(x / 2.0);
+            // x / 2 is exact while x is normal. Once x is subnormal it is not:
+            // halving shifts the mantissa into a field that has already lost bits,
+            // so an odd multiple of 2^-1074 rounds onto the neighbouring even one,
+            // and at 2^-1074 itself the quotient underflows to zero and makes
+            // log(x / 2) equal -inf. The series terms it multiplies have
+            // underflowed to zero by then, so that -inf becomes inf * 0 = NaN.
+            //
+            // log(x) - log(2) is the same quantity and never forms x / 2. It is
+            // used only below DBL_MIN, because ker and kei are built by cancelling
+            // exponentially large terms and a one-ulp change here is amplified by
+            // |ber|/|ker|, which is 1.07e6 at x = 10.
+            xlog = (fabs(x) >= std::numeric_limits<T>::min()) ? log(x / 2.0) : log(x) - log(2.0);
 
             *ber = 1.0;
             r = 1.0;

--- a/tests/xsf_tests/test_kelvin.cpp
+++ b/tests/xsf_tests/test_kelvin.cpp
@@ -3,11 +3,12 @@
 #include <xsf/kelvin.h>
 
 TEST_CASE("kei is continuous down to the smallest subnormal", "[kelvin][kei][xsf_tests]") {
-    // klvna computes log(x / 2) for the series branch. x / 2 is exact for every
-    // argument except the smallest subnormal, where it underflows to zero and
-    // the logarithm becomes -inf. It multiplies a series term that has itself
-    // underflowed to zero, so the product is inf * 0 = NaN -- while both
-    // neighbours, x == 0.0 and the next representable value up, are correct.
+    // klvna computes log(x / 2) for the series branch. That halving is exact while
+    // x is normal, but not once x is subnormal: at the smallest subnormal the
+    // quotient underflows to zero and the logarithm becomes -inf. It multiplies a
+    // series term that has itself underflowed to zero, so the product is
+    // inf * 0 = NaN -- while both neighbours, x == 0.0 and the next representable
+    // value up, are correct.
     const double rtol = 1e-15;
     // The same literal klvna uses, so this checks the value the implementation
     // targets rather than a constant from somewhere else.
@@ -33,4 +34,61 @@ TEST_CASE("kelvin functions agree either side of the subnormal boundary", "[kelv
     REQUIRE(std::isfinite(xsf::kei(denorm_min)));
     // ker diverges as x -> 0, so only its sign and finiteness are meaningful.
     REQUIRE(xsf::ker(denorm_min) > 0.0);
+}
+
+TEST_CASE("ker is strictly decreasing across the subnormal range", "[kelvin][ker][xsf_tests]") {
+    // The inexact halving reaches further than the underflow does. An odd multiple
+    // of 2^-1074 rounds onto the neighbouring even one, so before the fix ker
+    // returned the same value for three consecutive representable inputs -- worst
+    // relative error 3.87e-04 over the first 25 multiples, against 2.17e-16 after.
+    //
+    // ker is strictly decreasing, so equal outputs for distinct inputs are a defect
+    // on their own terms and this needs no reference table.
+    //
+    // The range matters and the bound is deliberate. Here the inputs differ by a
+    // ratio, so ker moves by log(1 + 1/k) >= 0.039 between neighbours -- ker(3u) and
+    // ker(4u) are 2.5e12 ulps apart, and equal outputs cannot be right. Higher up
+    // that stops holding: adjacent doubles near DBL_MIN differ by a relative 2.2e-16,
+    // so the true ker values are 2.2e-16 apart on a result of 708.5, which is 512x
+    // below one ulp there. They round to the same double, and equal outputs are then
+    // correct rather than a defect. So this invariant is asserted only over small
+    // multiples of denorm_min, where the spacing is coarse enough to resolve.
+    const double u = std::numeric_limits<double>::denorm_min();
+    double previous = std::numeric_limits<double>::infinity();
+    for (int k = 1; k <= 25; k++) {
+        const double x = k * u;
+        const double out = xsf::ker(x);
+        CAPTURE(k, x, out, previous);
+        REQUIRE(std::isfinite(out));
+        REQUIRE(out < previous);
+        previous = out;
+    }
+}
+
+TEST_CASE("ker subnormal-input", "[kelvin][ker][xsf_tests]") {
+    using test_case = std::tuple<double, double>;
+    // Reference values computed with mpmath with 60 digits of precision:
+    //
+    // import mpmath as mp
+    // mp.mp.dps = 60
+    // u = 4.9406564584124654e-324
+    // for k in [1, 2, 3, 4, 5, 7, 9, 17, 25]:
+    //     print(k * u, mp.nstr(mp.ker(0, mp.mpf(k * u)), 18))
+    auto [x, ref] = GENERATE(
+        test_case{4.9406564584124654e-324, 744.556003437039675},
+        test_case{9.8813129168249309e-324, 743.862856256479729},
+        test_case{1.4821969375237396e-323, 743.457391148371565},
+        test_case{1.9762625833649862e-323, 743.169709075919784},
+        test_case{2.4703282292062327e-323, 742.946565524605574},
+        test_case{3.4584595208887258e-323, 742.610093287984361},
+        test_case{4.4465908125712189e-323, 742.358778859703455},
+        test_case{8.3991159793011913e-323, 741.722790092983459},
+        test_case{1.2351641146031164e-322, 741.337127612171474},
+        test_case{9.9998886718268301e-321, 736.943172406632319}, test_case{2.2250738585072014e-308, 708.512350047922519}
+    );
+    const double w = xsf::ker(x);
+    const double rel_error = xsf::extended_relative_error(w, ref);
+
+    CAPTURE(x, w, ref, rel_error);
+    REQUIRE(rel_error <= 5e-16);
 }

--- a/tests/xsf_tests/test_kelvin.cpp
+++ b/tests/xsf_tests/test_kelvin.cpp
@@ -1,0 +1,36 @@
+#include "../testing_utils.h"
+
+#include <xsf/kelvin.h>
+
+TEST_CASE("kei is continuous down to the smallest subnormal", "[kelvin][kei][xsf_tests]") {
+    // klvna computes log(x / 2) for the series branch. x / 2 is exact for every
+    // argument except the smallest subnormal, where it underflows to zero and
+    // the logarithm becomes -inf. It multiplies a series term that has itself
+    // underflowed to zero, so the product is inf * 0 = NaN -- while both
+    // neighbours, x == 0.0 and the next representable value up, are correct.
+    const double rtol = 1e-15;
+    // The same literal klvna uses, so this checks the value the implementation
+    // targets rather than a constant from somewhere else.
+    const double expected = -0.25 * 3.141592653589793;
+
+    const auto x = GENERATE(std::numeric_limits<double>::denorm_min(), 1e-323, 1e-320, 1e-300, 1e-200, 1e-100);
+
+    const auto out = xsf::kei(x);
+    const auto rel_error = xsf::extended_relative_error(out, expected);
+    CAPTURE(x, out, expected, rtol, rel_error);
+    REQUIRE(std::isfinite(out));
+    REQUIRE(rel_error <= rtol);
+}
+
+TEST_CASE("kelvin functions agree either side of the subnormal boundary", "[kelvin][xsf_tests]") {
+    // The four outputs the series produces for a vanishing argument. Pinned
+    // together so a future change to the small-x path cannot fix one and leave
+    // the rest to drift.
+    const double denorm_min = std::numeric_limits<double>::denorm_min();
+
+    REQUIRE(xsf::ber(denorm_min) == 1.0);
+    REQUIRE(xsf::bei(denorm_min) == 0.0);
+    REQUIRE(std::isfinite(xsf::kei(denorm_min)));
+    // ker diverges as x -> 0, so only its sign and finiteness are meaningful.
+    REQUIRE(xsf::ker(denorm_min) > 0.0);
+}


### PR DESCRIPTION
#### Reference issue

gh-232, the third of the three items in it. Opened separately from the branch-point work
because it is independent of it.

#### What does this implement/fix?

`ker` and `kei` are wrong across the whole subnormal range. `kei` returns NaN at exactly
one argument; `ker` returns the same value for several distinct arguments.

```python
>>> sp.kei(0.0)
-0.7853981633974483        # the explicit x == 0.0 branch
>>> sp.kei(1e-320)
-0.7853981633974483        # the series
>>> sp.kei(5e-324)
nan
```

```
k   x = k * 2**-1074           ker(x) before      true
3   1.4821969375237396e-323    743.16970907591974 743.457391148371565
4   1.9762625833649862e-323    743.16970907591974 743.169709075919784
5   2.4703282292062327e-323    743.16970907591974 742.946565524605574
```

Three different arguments, one result. Worst relative error 3.87e-04.

#### Cause

`klvna` computes `log(x / 2)` in the series branch. Dividing by two is exact while `x` is
normal. Once `x` is subnormal it is not: halving shifts the mantissa into a field that has
already lost bits, so an odd multiple of `2**-1074` rounds onto the neighbouring even one.
That is the `ker` collapse above. At `2**-1074` itself the quotient underflows to zero, so
`log(x / 2)` is `-inf`, and it multiplies series terms that have themselves underflowed to
zero — `inf * 0 = NaN`, which is the `kei` case.

`ber` and `bei` are unaffected: their expressions do not contain the logarithm.

#### Fix

Compute the logarithm as `log(x) - log(2)` below `DBL_MIN`. That is the same quantity and
never forms `x / 2`.

The guard is deliberately `fabs(x) >= std::numeric_limits<T>::min()` rather than something
looser. `log(x) - log(2)` rounds twice where `log(x / 2)` rounds once, and `ker`/`kei` are
built by cancelling exponentially large terms, so a one-ulp change is amplified by
`|ber| / |ker|` — 1.07e6 at `x = 10`. Normal arguments keep the exact single-rounding form;
only the subnormal range, where `x / 2` is not exact anyway, uses the alternative.

The four call sites now share one hoisted `xlog` rather than recomputing the logarithm.

#### Verification

Compiled with gcc 14 and compared against scipy 1.17.1 — which is this file without the
change — over 408 arguments: the subnormal range, a 400-point sweep of the whole series
branch, and the arguments immediately below the branch point.

```
1632 comparisons
1 NaN fixed: kei(4.9406564584124654e-324): NaN -> -0.78539816339744828
1 difference above 1e-15: kei(4.3109147869674196), rel 1.14e-13
```

That remaining difference is present identically when the **unmodified** header is built
with the same compiler, so it is a gcc/libm difference against scipy's build rather than a
consequence of this patch. `kei` passes close to a zero near `x = 4.31`, which is why the
relative error there is visible at all.

In the subnormal range the six values above are now distinct and strictly decreasing, and
match mpmath to 2.17e-16.

#### Tests

`tests/xsf_tests/test_kelvin.cpp` is new:

- `kei` across the subnormal range down to `denorm_min()`.
- `ker` strictly decreasing over consecutive multiples of `denorm_min()` — this needs no
  reference table, since two distinct inputs cannot legitimately produce one output.
- `ker` pinned against mpmath at 11 points in that range.
- The four values the series produces for a vanishing argument, pinned together so a later
  change cannot fix one and let the others drift.

The strictly-decreasing test fails on the first commit of this PR and passes on the second,
which is how the `ker` half was found.

I could not run `pixi run tests` — the harness pulls Arrow for the parquet fixtures and I
did not get that building here — so the tests are verified by direct compilation and
execution rather than through the suite. `clang-format --dry-run --Werror` passes.

#### On the other two items in gh-232

`ker(inf)` is a judgement call I did not want to make unilaterally: `ker` and `kei` decay to
zero so returning 0.0 is clear, but `ber` and `bei` oscillate unboundedly and NaN may be the
answer you want there. Happy to send it if you tell me which you prefer.

The branch-point split is the substantial one and needs the benchmark you said would be
acceptable. I would rather land this first and do that properly on its own.

---

<sub>Written with AI assistance (Claude Opus 5 via Claude Code). I reproduced both failures
in scipy 1.17.1, built and ran the comparisons above myself, and I am responsible for the
change as submitted.</sub>
