### PR TITLE
ENH: add relection formula to sph_bessel_k

### DIFF
--- a/include/xsf/sph_bessel.h
+++ b/include/xsf/sph_bessel.h
@@ -362,6 +362,14 @@ T sph_bessel_k(long n, T z) {
         return std::numeric_limits<T>::infinity();
     }
 
+    if (z < 0) {
+        // https://dlmf.nist.gov/10.47#E17
+        // and
+        // https://dlmf.nist.gov/10.47.E11
+        int sign = (std::abs(n) % 2 == 0) ? 1 : -1;
+        return -(M_PI * sph_bessel_i(n, -z) + sign * sph_bessel_k(n, -z));
+    }
+
     if (std::isinf(z)) {
         // https://dlmf.nist.gov/10.52.E6
         if (z == std::numeric_limits<T>::infinity()) {

--- a/tests/xsf_tests/test_sph_bessel.cpp
+++ b/tests/xsf_tests/test_sph_bessel.cpp
@@ -246,41 +246,6 @@ TEST_CASE("spherical_i tiny inputs", "[spherical_bessel][xsf_tests]") {
     REQUIRE(rel_err <= rtol);
 }
 
-TEST_CASE("spherical_k reflection complex", "[spherical_bessel][xsf_tests]") {
-    using test_case = std::tuple<long, std::complex<double>, std::complex<double>, double>;
-
-    // Reference values computed with mpmath.
-    auto [n, z, ref_spherical_k, rtol] = GENERATE(
-        test_case{10, {5., 0}, {11.162178171949055, 0}, 1e-14},
-        test_case{10, {-5., 0}, {-11.165977657150502, 0}, 1e-14},
-        test_case{7, {5., 0}, {0.22221361309239493, 0}, 1e-14},
-        test_case{7, {-5., 0}, {-0.023872188945034639, 0}, 1e-14}
-    );
-
-    std::complex<double> result_spherical_k = xsf::sph_bessel_k(n, z);
-    double rel_err_spherical_k = xsf::extended_relative_error(result_spherical_k, ref_spherical_k);
-
-    CAPTURE(n, z, result_spherical_k, ref_spherical_k, rel_err_spherical_k, rtol);
-    REQUIRE(rel_err_spherical_k <= rtol);
-}
-
-TEST_CASE("spherical_k_jac reflection derivative complex", "[spherical_bessel][xsf_tests]") {
-    using test_case = std::tuple<long, std::complex<double>, std::complex<double>, double>;
-
-    // Reference values computed with mpmath.
-    auto [n, z, ref_spherical_k_jac, rtol] = GENERATE(
-        test_case{10, {5., 0}, {-27.299149693641313, 0}, 1e-14},
-        test_case{10, {-5., 0}, {-27.290758018530437, 0}, 1e-14},
-        test_case{7, {5., 0}, {-0.43011979527682201, 0}, 1e-14}, test_case{7, {-5., 0}, {0.84209146503609691, 0}, 1e-14}
-    );
-
-    std::complex<double> result_spherical_k_jac = xsf::sph_bessel_k_jac(n, z);
-    double rel_err_spherical_k_jac = xsf::extended_relative_error(result_spherical_k_jac, ref_spherical_k_jac);
-
-    CAPTURE(n, z, result_spherical_k_jac, ref_spherical_k_jac, rel_err_spherical_k_jac, rtol);
-    REQUIRE(rel_err_spherical_k_jac <= rtol);
-}
-
 TEST_CASE("spherical_k real reflection", "[spherical_bessel][xsf_tests]") {
     using test_case = std::tuple<long, double, double, double>;
 

--- a/tests/xsf_tests/test_sph_bessel.cpp
+++ b/tests/xsf_tests/test_sph_bessel.cpp
@@ -245,3 +245,17 @@ TEST_CASE("spherical_i tiny inputs", "[spherical_bessel][xsf_tests]") {
     CAPTURE(n, z, result, ref, rel_err, rtol);
     REQUIRE(rel_err <= rtol);
 }
+
+TEST_CASE("spherical_k real reflection", "[spherical_bessel][xsf_tests]") {
+    using test_case = std::tuple<long, double, double, double>;
+
+    // Reference values computed with mpmath.
+    auto [n, z, ref_spherical_k, rtol] =
+        GENERATE(test_case{10, -5., -11.165977657150503, 1e-14}, test_case{7, -5., -0.02387218894503464, 1e-14});
+
+    double result_spherical_k = xsf::sph_bessel_k(n, z);
+    double rel_err_spherical_k = xsf::extended_relative_error(result_spherical_k, ref_spherical_k);
+
+    CAPTURE(n, z, result_spherical_k, ref_spherical_k, rel_err_spherical_k, rtol);
+    REQUIRE(rel_err_spherical_k <= rtol);
+}

--- a/tests/xsf_tests/test_sph_bessel.cpp
+++ b/tests/xsf_tests/test_sph_bessel.cpp
@@ -246,16 +246,69 @@ TEST_CASE("spherical_i tiny inputs", "[spherical_bessel][xsf_tests]") {
     REQUIRE(rel_err <= rtol);
 }
 
+TEST_CASE("spherical_k reflection complex", "[spherical_bessel][xsf_tests]") {
+    using test_case = std::tuple<long, std::complex<double>, std::complex<double>, double>;
+
+    // Reference values computed with mpmath.
+    auto [n, z, ref_spherical_k, rtol] = GENERATE(
+        test_case{10, {5., 0}, {11.162178171949055, 0}, 1e-14},
+        test_case{10, {-5., 0}, {-11.165977657150502, 0}, 1e-14},
+        test_case{7, {5., 0}, {0.22221361309239493, 0}, 1e-14},
+        test_case{7, {-5., 0}, {-0.023872188945034639, 0}, 1e-14}
+    );
+
+    std::complex<double> result_spherical_k = xsf::sph_bessel_k(n, z);
+    double rel_err_spherical_k = xsf::extended_relative_error(result_spherical_k, ref_spherical_k);
+
+    CAPTURE(n, z, result_spherical_k, ref_spherical_k, rel_err_spherical_k, rtol);
+    REQUIRE(rel_err_spherical_k <= rtol);
+}
+
+TEST_CASE("spherical_k_jac reflection derivative complex", "[spherical_bessel][xsf_tests]") {
+    using test_case = std::tuple<long, std::complex<double>, std::complex<double>, double>;
+
+    // Reference values computed with mpmath.
+    auto [n, z, ref_spherical_k_jac, rtol] = GENERATE(
+        test_case{10, {5., 0}, {-27.299149693641313, 0}, 1e-14},
+        test_case{10, {-5., 0}, {-27.290758018530437, 0}, 1e-14},
+        test_case{7, {5., 0}, {-0.43011979527682201, 0}, 1e-14}, test_case{7, {-5., 0}, {0.84209146503609691, 0}, 1e-14}
+    );
+
+    std::complex<double> result_spherical_k_jac = xsf::sph_bessel_k_jac(n, z);
+    double rel_err_spherical_k_jac = xsf::extended_relative_error(result_spherical_k_jac, ref_spherical_k_jac);
+
+    CAPTURE(n, z, result_spherical_k_jac, ref_spherical_k_jac, rel_err_spherical_k_jac, rtol);
+    REQUIRE(rel_err_spherical_k_jac <= rtol);
+}
+
 TEST_CASE("spherical_k real reflection", "[spherical_bessel][xsf_tests]") {
     using test_case = std::tuple<long, double, double, double>;
 
     // Reference values computed with mpmath.
-    auto [n, z, ref_spherical_k, rtol] =
-        GENERATE(test_case{10, -5., -11.165977657150503, 1e-14}, test_case{7, -5., -0.02387218894503464, 1e-14});
+    auto [n, z, ref_spherical_k, rtol] = GENERATE(
+        test_case{10, 5., 11.162178171949055, 1e-14}, test_case{10, -5., -11.165977657150502, 1e-14},
+        test_case{7, 5., 0.22221361309239493, 1e-14}, test_case{7, -5., -0.023872188945034639, 1e-14}
+    );
 
     double result_spherical_k = xsf::sph_bessel_k(n, z);
     double rel_err_spherical_k = xsf::extended_relative_error(result_spherical_k, ref_spherical_k);
 
     CAPTURE(n, z, result_spherical_k, ref_spherical_k, rel_err_spherical_k, rtol);
     REQUIRE(rel_err_spherical_k <= rtol);
+}
+
+TEST_CASE("spherical_k_jac reflection derivative", "[spherical_bessel][xsf_tests]") {
+    using test_case = std::tuple<long, double, double, double>;
+
+    // Reference values computed with mpmath.
+    auto [n, z, ref_spherical_k_jac, rtol] = GENERATE(
+        test_case{10, 5., -27.299149693641313, 1e-14}, test_case{10, -5., -27.290758018530437, 1e-14},
+        test_case{7, 5., -0.43011979527682201, 1e-14}, test_case{7, -5., 0.84209146503609691, 1e-14}
+    );
+
+    double result_spherical_k_jac = xsf::sph_bessel_k_jac(n, z);
+    double rel_err_spherical_k_jac = xsf::extended_relative_error(result_spherical_k_jac, ref_spherical_k_jac);
+
+    CAPTURE(n, z, result_spherical_k_jac, ref_spherical_k_jac, rel_err_spherical_k_jac, rtol);
+    REQUIRE(rel_err_spherical_k_jac <= rtol);
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #222 (I think, let me know if there is more to do)
#### What does this implement/fix?
<!--Please explain your changes.-->
Adds relection formula to `sph_bessel_k` which is given by

$$k_n(-z)= -\frac{\pi}{2}\left(i_n^{(n)}(z) + i_n^{(2)}(z)\right)$$

except that we don't have an $i_n^{(2)}$ so I use the property that

$$k_n(z) = (-1)^n\frac{\pi}{2}\left(i_n^{(1)}(z) - i_n^{(2)}(z)\right)$$

which gives

$$k_n(-z)= -\frac{\pi}{2}\left(2i_n^{(1)}(z) + (-1)^n\frac{2}{\pi}k_n(z)\right)$$
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I used Claude to double check the derivation.