### PR TITLE
TST(kelvin): kelvin: add a Wronskian identity test

### DIFF
--- a/tests/xsf_tests/test_kelvin_wronskian.cpp
+++ b/tests/xsf_tests/test_kelvin_wronskian.cpp
@@ -1,0 +1,40 @@
+#include "../testing_utils.h"
+
+#include <xsf/kelvin.h>
+
+// Wronskian of the Kelvin equation, in the complex form the functions come in:
+//
+//     x * (Be*Kep - Bep*Ke) == -1
+//
+// with Be = ber + i*bei, Ke = ker + i*kei, and Bep, Kep their derivatives --
+// exactly what xsf::kelvin() returns. Its real part is
+// (ber*kerp - berp*ker) - (bei*keip - beip*kei) and its imaginary part is
+// (ber*keip - berp*kei) + (bei*kerp - beip*ker), so one check covers all eight
+// functions at once.
+//
+// Verified against mpmath at 50 digits for x in [0.05, 25]: the largest deviation
+// is 1.4e-51, i.e. mpmath's own rounding.
+//
+// This needs no reference table -- the eight functions are checked against each
+// other -- so it stays valid whatever is decided about the |x| < 10 branch point
+// discussed in gh-232.
+
+TEST_CASE("kelvin wronskian", "[ber][bei][ker][kei][kelvin][xsf_tests]") {
+    // Loose enough to pass today. The worst residual measured on the current
+    // implementation is 8.2e-11, at x = 9.9 -- just below the |x| < 10 branch
+    // point, and about 111x worse than the first point above it.
+    const double atol = 1e-9;
+
+    const auto x = GENERATE(
+        0.001, 0.01, 0.1, 0.5, 1.0, 2.0, 3.0, 5.0, 7.0, 9.0, 9.5, 9.9,
+        10.0, 10.1, 10.5, 11.0, 15.0, 20.0, 30.0, 50.0
+    );
+
+    std::complex<double> Be, Ke, Bep, Kep;
+    xsf::kelvin(x, Be, Ke, Bep, Kep);
+
+    const auto wronskian = x * (Be * Kep - Bep * Ke);
+    const auto residual = std::abs(wronskian + 1.0);
+    CAPTURE(x, Be, Ke, Bep, Kep, residual, atol);
+    REQUIRE(residual <= atol);
+}

--- a/tests/xsf_tests/test_kelvin_wronskian.cpp
+++ b/tests/xsf_tests/test_kelvin_wronskian.cpp
@@ -26,8 +26,7 @@ TEST_CASE("kelvin wronskian", "[ber][bei][ker][kei][kelvin][xsf_tests]") {
     const double atol = 1e-9;
 
     const auto x = GENERATE(
-        0.001, 0.01, 0.1, 0.5, 1.0, 2.0, 3.0, 5.0, 7.0, 9.0, 9.5, 9.9,
-        10.0, 10.1, 10.5, 11.0, 15.0, 20.0, 30.0, 50.0
+        0.001, 0.01, 0.1, 0.5, 1.0, 2.0, 3.0, 5.0, 7.0, 9.0, 9.5, 9.9, 10.0, 10.1, 10.5, 11.0, 15.0, 20.0, 30.0, 50.0
     );
 
     std::complex<double> Be, Ke, Bep, Kep;

--- a/tests/xsf_tests/test_kelvin_wronskian.cpp
+++ b/tests/xsf_tests/test_kelvin_wronskian.cpp
@@ -11,13 +11,6 @@
 // (ber*kerp - berp*ker) - (bei*keip - beip*kei) and its imaginary part is
 // (ber*keip - berp*kei) + (bei*kerp - beip*ker), so one check covers all eight
 // functions at once.
-//
-// Verified against mpmath at 50 digits for x in [0.05, 25]: the largest deviation
-// is 1.4e-51, i.e. mpmath's own rounding.
-//
-// This needs no reference table -- the eight functions are checked against each
-// other -- so it stays valid whatever is decided about the |x| < 10 branch point
-// discussed in gh-232.
 
 TEST_CASE("kelvin wronskian", "[ber][bei][ker][kei][kelvin][xsf_tests]") {
     // Loose enough to pass today. The worst residual measured on the current


### PR DESCRIPTION
Follows up on the Wronskian test offered in gh-232, which @steppi said he'd be happy to see.

## What it checks

The Kelvin functions satisfy

```
x * (Be*Kep - Bep*Ke) == -1
```

with `Be = ber + i*bei`, `Ke = ker + i*kei`, and `Bep`, `Kep` their derivatives — exactly the four values `xsf::kelvin()` returns. Its real part is `(ber*kerp - berp*ker) - (bei*keip - beip*kei)` and its imaginary part is `(ber*keip - berp*kei) + (bei*kerp - beip*ker)`, so a single check exercises all eight functions.

I derived it by searching bilinear combinations against `mpmath` rather than quoting it: over `x` in `[0.05, 25]` at 50 digits the largest deviation is **1.4e-51**, which is mpmath's own rounding.

**It needs no reference table** — the functions are checked against each other. That is why it does not depend on how the `|x| < 10` branch point question in gh-232 is resolved.

## What it measures on the current implementation

Sweeping 52 points against `scipy` 1.17.1:

| x | \|residual\| |
|---|---|
| 0.001 | 0 |
| 0.5 | 0 |
| 5.0 | 7.1e-14 |
| **9.9** | **8.2e-11** |
| 10.0 | 7.4e-13 |
| 20.0 | 2.2e-16 |
| 50.0 | 0 |

The worst point in the whole sweep sits **just below the `|x| < 10` branch point**, and crossing it improves by ~111x. That is the claim gh-232 makes, arrived at without mpmath and without any reference values of mine — it is the library disagreeing with itself.

## On the tolerance

`atol = 1e-9` passes today with about two orders of margin, so this lands as a non-regression test rather than a failing assertion. At `1e-12` it fails at `x = 9.9` on current `main`. I chose the looser bound deliberately so the test is mergeable independently of the branch-point work; if you would rather it fail loudly and block until that is fixed, say so and I will tighten it.

## What I have not done

**I have not compiled this.** Catch2 3, Arrow and Parquet are not available on the machine I measured from, so the numbers above are verified but the build is not. It goes in `tests/xsf_tests/` rather than `tests/scipy_special_tests/` because it needs no parquet tables, and `CMakeLists.txt` picks it up through the existing `file(GLOB TEST_SOURCES "*/test_*.cpp")` — no build-system change. If CI finds a compile error I will fix it promptly; the one thing I would guess at is whether `CAPTURE()` prints `std::complex<double>`, which is diagnostic only.

---

AI disclosure: prepared with AI assistance (Claude Opus 5 via Claude Code). The identity and every figure above were measured, and I am responsible for the change as submitted.
