### PR TITLE
BUG: fix premature overflow in i0 and i1

### DIFF
--- a/include/xsf/cephes/i0.h
+++ b/include/xsf/cephes/i0.h
@@ -79,6 +79,7 @@
 
 #include "../config.h"
 #include "chbevl.h"
+#include "const.h"
 
 namespace xsf {
 namespace cephes {
@@ -129,6 +130,13 @@ namespace cephes {
         if (x <= 8.0) {
             y = (x / 2.0) - 2.0;
             return (std::exp(x) * chbevl(y, detail::i0_A, 30));
+        }
+
+        if (x > detail::MAXLOG) {
+            /* exp(x) overflows here even though i0(x) is still finite up to x ~ 713.99,
+             * so evaluate the exponential in two halves. */
+            double e = std::exp(x / 2.0);
+            return (e * chbevl(32.0 / x - 2.0, detail::i0_B, 25) / sqrt(x) * e);
         }
 
         return (std::exp(x) * chbevl(32.0 / x - 2.0, detail::i0_B, 25) / sqrt(x));

--- a/include/xsf/cephes/i1.h
+++ b/include/xsf/cephes/i1.h
@@ -80,6 +80,7 @@
 
 #include "../config.h"
 #include "chbevl.h"
+#include "const.h"
 
 namespace xsf {
 namespace cephes {
@@ -131,6 +132,11 @@ namespace cephes {
         if (z <= 8.0) {
             y = (z / 2.0) - 2.0;
             z = chbevl(y, detail::i1_A, 29) * z * std::exp(z);
+        } else if (z > detail::MAXLOG) {
+            /* exp(z) overflows here even though i1(z) is still finite up to z ~ 713.99,
+             * so evaluate the exponential in two halves. */
+            double e = std::exp(z / 2.0);
+            z = e * chbevl(32.0 / z - 2.0, detail::i1_B, 25) / std::sqrt(z) * e;
         } else {
             z = std::exp(z) * chbevl(32.0 / z - 2.0, detail::i1_B, 25) / std::sqrt(z);
         }

--- a/tests/xsf_tests/test_bessel_functions_large_inputs.cpp
+++ b/tests/xsf_tests/test_bessel_functions_large_inputs.cpp
@@ -1,4 +1,6 @@
 #include "../testing_utils.h"
+#include <xsf/cephes/i0.h>
+#include <xsf/cephes/i1.h>
 #include <xsf/cephes/j0.h>
 #include <xsf/cephes/j1.h>
 
@@ -128,4 +130,69 @@ TEST_CASE("y1 right tail gh-large-input", "[y1][xsf_tests]") {
 
     CAPTURE(x, w, ref, rtol, rel_error);
     REQUIRE(rel_error <= rtol);
+}
+
+/* i0 and i1 used to compute exp(x) before dividing by sqrt(x), so they returned inf for
+ * every x above log(DBL_MAX) ~ 709.78 even though the result stays representable up to
+ * x ~ 713.99. Reported as scipy/scipy#25823 and scipy/scipy#25824. */
+
+TEST_CASE("i0 near the overflow threshold scipy-gh-25823", "[i0][xsf_tests]") {
+    using test_case = std::tuple<double, double, double>;
+    // Reference values computed with mpmath with 1000 digits of precision:
+    //
+    // import mpmath as mp
+    // mp.mp.dps = 1000
+    // xs = [
+    //     709.0, 709.7827128933839, 709.7827128933841, 710.0, 711.0,
+    //     712.0, 713.0, 713.5, 713.9, 713.98,
+    // ]
+    // for x in xs:
+    //     print(x, mp.nstr(mp.besseli(0, x), 18))
+    auto [x, ref, rtol] = GENERATE(
+        test_case{709.0, 1.231547706701654e+306, 5e-15}, test_case{709.7827128933839, 2.6923992106264072e+306, 5e-15},
+        test_case{709.7827128933841, 2.692399210627019e+306, 5e-15}, test_case{710.0, 3.345334558619656e+306, 5e-15},
+        test_case{711.0, 9.087162727263793e+306, 5e-15}, test_case{712.0, 2.4684110577627523e+307, 5e-15},
+        test_case{713.0, 6.705128263670996e+307, 5e-15}, test_case{713.5, 1.1051012081178279e+308, 5e-15},
+        test_case{713.9, 1.6481551866951379e+308, 5e-15}, test_case{713.98, 1.785325134768229e+308, 5e-15}
+    );
+    const double w = xsf::cephes::i0(x);
+    const double rel_error = xsf::extended_relative_error(w, ref);
+
+    CAPTURE(x, w, ref, rtol, rel_error);
+    REQUIRE(rel_error <= rtol);
+}
+
+TEST_CASE("i1 near the overflow threshold scipy-gh-25824", "[i1][xsf_tests]") {
+    using test_case = std::tuple<double, double, double>;
+    // Reference values computed with mpmath with 1000 digits of precision:
+    //
+    // import mpmath as mp
+    // mp.mp.dps = 1000
+    // xs = [
+    //     709.0, 709.7827128933839, 709.7827128933841, 710.0, 711.0,
+    //     712.0, 713.0, 713.5, 713.9, 713.98,
+    // ]
+    // for x in xs:
+    //     print(x, mp.nstr(mp.besseli(1, x), 18))
+    auto [x, ref, rtol] = GENERATE(
+        test_case{709.0, 1.2306788896524786e+306, 5e-15}, test_case{709.7827128933839, 2.690501905423821e+306, 5e-15},
+        test_case{709.7827128933841, 2.6905019054244322e+306, 5e-15}, test_case{710.0, 3.3429778585097626e+306, 5e-15},
+        test_case{711.0, 9.080770067322847e+306, 5e-15}, test_case{712.0, 2.4666770135246153e+307, 5e-15},
+        test_case{713.0, 6.700424559186402e+307, 5e-15}, test_case{713.5, 1.1043265136795952e+308, 5e-15},
+        test_case{713.9, 1.6470004499232343e+308, 5e-15}, test_case{713.98, 1.7840744336676367e+308, 5e-15}
+    );
+    const double w = xsf::cephes::i1(x);
+    const double rel_error = xsf::extended_relative_error(w, ref);
+
+    CAPTURE(x, w, ref, rtol, rel_error);
+    REQUIRE(rel_error <= rtol);
+}
+
+// i0(x) exceeds DBL_MAX just above 713.9869, so these must still overflow.
+TEST_CASE("i0 and i1 still overflow beyond the representable range", "[i0][i1][xsf_tests]") {
+    const double x = GENERATE(714.0, 715.0, 1e5, 1e300);
+    CAPTURE(x);
+    REQUIRE(std::isinf(xsf::cephes::i0(x)));
+    REQUIRE(std::isinf(xsf::cephes::i1(x)));
+    REQUIRE(std::isinf(xsf::cephes::i1(-x)));
 }

--- a/tests/xsf_tests/test_bessel_functions_large_inputs.cpp
+++ b/tests/xsf_tests/test_bessel_functions_large_inputs.cpp
@@ -1,6 +1,5 @@
 #include "../testing_utils.h"
-#include <xsf/cephes/i0.h>
-#include <xsf/cephes/i1.h>
+#include <xsf/bessel.h>
 #include <xsf/cephes/j0.h>
 #include <xsf/cephes/j1.h>
 
@@ -155,7 +154,7 @@ TEST_CASE("i0 near the overflow threshold scipy-gh-25823", "[i0][xsf_tests]") {
         test_case{713.0, 6.705128263670996e+307, 5e-15}, test_case{713.5, 1.1051012081178279e+308, 5e-15},
         test_case{713.9, 1.6481551866951379e+308, 5e-15}, test_case{713.98, 1.785325134768229e+308, 5e-15}
     );
-    const double w = xsf::cephes::i0(x);
+    const double w = xsf::cyl_bessel_i0(x);
     const double rel_error = xsf::extended_relative_error(w, ref);
 
     CAPTURE(x, w, ref, rtol, rel_error);
@@ -181,7 +180,7 @@ TEST_CASE("i1 near the overflow threshold scipy-gh-25824", "[i1][xsf_tests]") {
         test_case{713.0, 6.700424559186402e+307, 5e-15}, test_case{713.5, 1.1043265136795952e+308, 5e-15},
         test_case{713.9, 1.6470004499232343e+308, 5e-15}, test_case{713.98, 1.7840744336676367e+308, 5e-15}
     );
-    const double w = xsf::cephes::i1(x);
+    const double w = xsf::cyl_bessel_i1(x);
     const double rel_error = xsf::extended_relative_error(w, ref);
 
     CAPTURE(x, w, ref, rtol, rel_error);
@@ -192,7 +191,7 @@ TEST_CASE("i1 near the overflow threshold scipy-gh-25824", "[i1][xsf_tests]") {
 TEST_CASE("i0 and i1 still overflow beyond the representable range", "[i0][i1][xsf_tests]") {
     const double x = GENERATE(714.0, 715.0, 1e5, 1e300);
     CAPTURE(x);
-    REQUIRE(std::isinf(xsf::cephes::i0(x)));
-    REQUIRE(std::isinf(xsf::cephes::i1(x)));
-    REQUIRE(std::isinf(xsf::cephes::i1(-x)));
+    REQUIRE(std::isinf(xsf::cyl_bessel_i0(x)));
+    REQUIRE(std::isinf(xsf::cyl_bessel_i1(x)));
+    REQUIRE(std::isinf(xsf::cyl_bessel_i1(-x)));
 }


### PR DESCRIPTION
#### Reference issue

Reported in scipy/scipy#25823 (i0) and scipy/scipy#25824 (i1). Closing keywords do not
work across repositories, so those issues will need to be closed manually.

#### What does this implement/fix?

- The large-argument branch of both functions has the form `exp(x) * chbevl(...) / sqrt(x)`,
  so `exp(x)` is evaluated before the division.
- `exp(x)` overflows above `log(DBL_MAX)` ≈ 709.7827, but the result itself stays
  representable up to x ≈ 713.9869.
- Both functions therefore return `inf` for every x above `log(DBL_MAX)` and up to
  x ≈ 713.9869. For example `scipy.special.i0(713)` returns `inf`, where the correct value
  is 6.705e307 — less than half of `DBL_MAX`.
- The fix guards the branch with `detail::MAXLOG`, as `expn.h:161` and `kn.h:210` already
  do, and evaluates the exponential in two halves above the threshold: `e = exp(x / 2)`,
  then `e * chbevl(...) / sqrt(x) * e`.
- At or below `MAXLOG` the original expression is untouched.
- `i0e` and `i1e` are unaffected; they never multiply by `exp(x)`.

#### Additional information

- Why the guard rather than splitting `exp(x)` unconditionally: the unconditional form
  raised the relative error at x = 100 from 2.2e-17 to 1.66e-16. The table tests compare
  against per-platform recorded error values, so a change of that size is a real risk.
- 1,212,346 sample points between 8 and `MAXLOG`: bit-for-bit identical to `main`, zero
  differences for either `i0` or `i1`.
- 1636 points above `MAXLOG` went from `inf` to finite. Checked against mpmath: 0 wrongly
  infinite and 0 wrongly finite results — the overflow boundary now lands exactly at
  x ≈ 713.98691, where `i0(x)` crosses `DBL_MAX`.
- Worst relative error in the newly working region: 4.5e-16 for `i0` and 4.1e-16 for `i1`
  (~4 ulp).
- Three `TEST_CASE`s were added to `test_bessel_functions_large_inputs.cpp`, following the
  pattern used for `y1` in gh-231. 16 of their assertions fail on unpatched `main`.
- `pixi run tests`: 407/407 passing. `pixi run -e lint format-dry-error`: clean.

| x | i0 before | i0 after | i1 before | i1 after |
|---|---|---|---|---|
| 709 | 1.2315477067e+306 | unchanged | 1.2306788897e+306 | unchanged |
| 710 | inf | 3.3453345586e+306 | inf | 3.3429778585e+306 |
| 712 | inf | 2.4684110578e+307 | inf | 2.4666770135e+307 |
| 713 | inf | 6.7051282637e+307 | inf | 6.7004245592e+307 |
| 713.98 | inf | 1.7853251348e+308 | inf | 1.7840744337e+308 |
| 714 | inf | inf | inf | inf |

Every "after" value agrees with mpmath at 1000 dps to within 3 ulp (worst case 2.46 ulp,
`i1` at 713.98). `i0(714)` exceeds `DBL_MAX`, so `inf` is correct there.

#### AI Generation Disclosure

Claude Code (Opus) was used on this pull request. It located the root cause, wrote the
patch and the tests, produced the mpmath reference values, and ran the verification sweeps
reported above. I reviewed the change, I understand it and can explain it, and I take
responsibility for it. I drafted this description myself; the tool corrected its English
and terminology.
