### PR TITLE
CI: run GPU job on cirun on-prem runner

### DIFF
--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -5,9 +5,6 @@ on: [ push, pull_request ]
 permissions:
    contents: read  # to fetch code (actions/checkout)
 
-env:
-  CCACHE_DIR: "${{ github.workspace }}/.ccache"
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -21,16 +18,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
-
-      - name: Setup compiler cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ${{ env.CCACHE_DIR }}
-          # Make primary key unique by using `run_id`, this ensures the cache
-          # is always saved at the end.
-          key: ${{ runner.os }}-gpu-ccache-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-gpu-ccache
 
       - name: run nvidia-smi
         run: nvidia-smi

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   cupy_tests:
     name: CuPy GPU
-    runs-on: ghcr.io/cirruslabs/ubuntu-runner-amd64-gpu:24.04
+    runs-on: "cirun-scipy-onprem-gpu--${{ github.run_id }}"
     steps:
       - name: Checkout xsf repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -23,7 +23,7 @@ jobs:
           submodules: recursive
 
       - name: Setup compiler cache
-        uses: cirruslabs/cache@v4  #caa3ad0624c6c2acd8ba50ad452d1f44bba078bb # v4
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.CCACHE_DIR }}
           # Make primary key unique by using `run_id`, this ensures the cache
@@ -42,7 +42,8 @@ jobs:
         with:
           pixi-version: v0.75.0
           manifest-path: pixi.toml
-          cache: false
+          cache: true
+          cache-key: gpu-pixi-
 
       - name: Run CuPy tests
         run: pixi run test-cupy


### PR DESCRIPTION
Switch the CuPy GPU job from the Cirrus GPU runner to a cirun on-prem runner. Replace cirruslabs/cache with actions/cache and enable setup-pixi's built-in cache.

<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
Follow up from #25664

#### What does this implement/fix?
Switch the CuPy GPU job from the Cirrus GPU runner to a cirun on-prem runner. Replace cirruslabs/cache with actions/cache and enable setup-pixi's built-in cache.

#### Additional information
Runner is provisioned via the `cirun-scipy-onprem-gpu--<run_id>` label; actions/cache is pinned to the v6.1.0 commit and keeps the existing run_id key + restore-keys scheme.

#### AI Generation Disclosure
Claude Code (Fable 5) was used to draft the workflow changes. I take full responsibility of the changes.
