### PR TITLE
MAINT: improved polynomial evaluation interface

### DIFF
--- a/include/xsf/evalpoly.h
+++ b/include/xsf/evalpoly.h
@@ -19,11 +19,12 @@
 
 #pragma once
 
+#include "cephes/polevl.h"
 #include "config.h"
 
 namespace xsf {
 
-XSF_HOST_DEVICE inline std::complex<double> cevalpoly(const double *coeffs, int degree, std::complex<double> z) {
+XSF_HOST_DEVICE inline std::complex<double> evalpoly(const double *coeffs, int degree, std::complex<double> z) {
     /* Evaluate a polynomial with real coefficients at a complex point.
      *
      * Uses equation (3) in section 4.6.4 of [1]. Note that it is more
@@ -42,6 +43,10 @@ XSF_HOST_DEVICE inline std::complex<double> cevalpoly(const double *coeffs, int 
     }
 
     return z * a + b;
+}
+
+XSF_HOST_DEVICE inline double evalpoly(const double *coeffs, int degree, double x) {
+    return cephes::polevl(x, coeffs, degree);
 }
 
 } // namespace xsf

--- a/include/xsf/evalpoly.h
+++ b/include/xsf/evalpoly.h
@@ -30,6 +30,9 @@ XSF_HOST_DEVICE inline std::complex<double> evalpoly(const double *coeffs, int d
      * Uses equation (3) in section 4.6.4 of [1]. Note that it is more
      * efficient than Horner's method.
      */
+    if (degree == 0) {
+        return coeffs[0];
+    }
     double a = coeffs[0];
     double b = coeffs[1];
     double r = 2 * z.real();
@@ -46,6 +49,9 @@ XSF_HOST_DEVICE inline std::complex<double> evalpoly(const double *coeffs, int d
 }
 
 XSF_HOST_DEVICE inline double evalpoly(const double *coeffs, int degree, double x) {
+    if (degree == 0) {
+        return coeffs[0];
+    }
     return cephes::polevl(x, coeffs, degree);
 }
 

--- a/include/xsf/lambertw.h
+++ b/include/xsf/lambertw.h
@@ -51,7 +51,7 @@ namespace detail {
         double coeffs[] = {-1.0 / 3.0, 1.0, -1.0};
         std::complex<double> p = std::sqrt(2.0 * (M_E * z + 1.0));
 
-        return cevalpoly(coeffs, 2, p);
+        return evalpoly(coeffs, 2, p);
     }
 
     XSF_HOST_DEVICE inline std::complex<double> lambertw_pade0(std::complex<double> z) {
@@ -62,7 +62,7 @@ namespace detail {
         /* This only gets evaluated close to 0, so we don't need a more
          * careful algorithm that avoids overflow in the numerator for
          * large z. */
-        return z * cevalpoly(num, 2, z) / cevalpoly(denom, 2, z);
+        return z * evalpoly(num, 2, z) / evalpoly(denom, 2, z);
     }
 
     XSF_HOST_DEVICE inline std::complex<double> lambertw_asy(std::complex<double> z, long k) {

--- a/include/xsf/loggamma.h
+++ b/include/xsf/loggamma.h
@@ -50,7 +50,7 @@ namespace detail {
         std::complex<double> rz = 1.0 / z;
         std::complex<double> rzz = rz / z;
 
-        return (z - 0.5) * std::log(z) - z + loggamma_HLOG2PI + rz * cevalpoly(coeffs, 7, rzz);
+        return (z - 0.5) * std::log(z) - z + loggamma_HLOG2PI + rz * evalpoly(coeffs, 7, rzz);
     }
 
     XSF_HOST_DEVICE std::complex<double> loggamma_recurrence(std::complex<double> z) {
@@ -95,7 +95,7 @@ namespace detail {
                            8.2246703342411321824E-1,  -5.7721566490153286061E-1};
 
         z -= 1.0;
-        return z * cevalpoly(coeffs, 22, z);
+        return z * evalpoly(coeffs, 22, z);
     }
 } // namespace detail
 

--- a/tests/xsf_tests/test_orthogonal_eval.cpp
+++ b/tests/xsf_tests/test_orthogonal_eval.cpp
@@ -1,7 +1,6 @@
 #include "../../include/xsf/config.h"
 #include "../testing_utils.h"
 
-#include <xsf/cephes/polevl.h>
 #include <xsf/evalpoly.h>
 #include <xsf/orthogonal_eval.h>
 
@@ -36,22 +35,14 @@ std::vector<double> multiply(const std::vector<double> &a, const std::vector<dou
     return out;
 }
 
-double polyval(const std::vector<double> &coeffs, double x) {
+template <typename T>
+T polyval(const std::vector<double> &coeffs, T x) {
     if (coeffs.size() == 1) {
         return coeffs[0];
     }
 
     const std::vector<double> reversed(coeffs.rbegin(), coeffs.rend());
-    return xsf::cephes::polevl(x, reversed.data(), reversed.size() - 1);
-}
-
-std::complex<double> polyval(const std::vector<double> &coeffs, std::complex<double> x) {
-    if (coeffs.size() == 1) {
-        return coeffs[0];
-    }
-
-    const std::vector<double> reversed(coeffs.rbegin(), coeffs.rend());
-    return xsf::cevalpoly(reversed.data(), reversed.size() - 1, x);
+    return xsf::evalpoly(reversed.data(), reversed.size() - 1, x);
 }
 
 double sample(double a, double b, int i) {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
While working on #239 it became quite annoying that there are two completely different functions for evaluating a polynomial with either a real or complex input. This PR introduces a unified `xsf::evalpoly` which has a `double` and `std::complex<double>` overload.
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No ai 