### PR TITLE
DOC: add permalinks for scipy/special/_precompute/ scripts

### DIFF
--- a/include/xsf/hyp2f1.h
+++ b/include/xsf/hyp2f1.h
@@ -56,7 +56,8 @@ namespace detail {
     /* The original implementation in SciPy from Zhang and Jin used 1500 for the
      * maximum number of series iterations in some cases and 500 in others.
      * Through the empirical results on the test cases in
-     * scipy/special/_precompute/hyp2f1_data.py, it was determined that these values
+     * https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/_precompute/hyp2f1_data.py,
+     * it was determined that these values
      * can lead to early termination of series which would have eventually converged
      * at a reasonable level of accuracy. We've bumped the iteration limit to 3000,
      * and may adjust it again based on further analysis. */
@@ -205,7 +206,7 @@ namespace detail {
         }
         /* Direct ratio tends to be more accurate for arguments in this range. Range
          * chosen empirically based on the relevant benchmarks in
-         * scipy/special/_precompute/hyp2f1_data.py */
+         * https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/_precompute/hyp2f1_data.py */
         if (std::abs(u) <= 100 && std::abs(v) <= 100 && std::abs(w) <= 100 && std::abs(x) <= 100) {
             result = cephes::Gamma(u) * cephes::Gamma(v) * (cephes::rgamma(w) * cephes::rgamma(x));
             if (std::isfinite(result) && result != 0.0) {

--- a/include/xsf/wright_bessel.h
+++ b/include/xsf/wright_bessel.h
@@ -118,11 +118,13 @@ namespace detail {
          * the fewer polygamma functions have to be computed.
          *
          * Call: python _precompute/wright_bessel.py 1
+         * Source: https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/_precompute/wright_bessel.py
          *
          * For small b, i.e. b <= 1e-3, cancellation of poles of digamma(b)/Gamma(b)
          * and polygamma needs to be carried out => series expansion in a=0 to order 5
          * and in b=0 to order 4.
          * Call: python _precompute/wright_bessel.py 2
+         * Source: https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/_precompute/wright_bessel.py
          */
         double A[6]; // coefficients of a^k  (1, -x * Psi(b), ...)
         double B[6]; // powers of b^k/k! or terms in polygamma functions
@@ -233,6 +235,7 @@ namespace detail {
          *
          * with Z = (a*x)^(1/(1+a)).
          * Call: python _precompute/wright_bessel.py 3
+         * Source: https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/_precompute/wright_bessel.py
          */
         double A[15];  // powers of a
         double B[17];  // powers of b
@@ -547,7 +550,8 @@ namespace detail {
         0.01811556071348939,  0.01438082276148557,  0.01059054838365097, 0.006759799195745401, 0.002908622553155141
     };
     /* Fitted parameters for optimal choice of eps
-     * Call: python _precompute/wright_bessel.py 4 */
+     * Call: python _precompute/wright_bessel.py 4
+     * Source: https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/_precompute/wright_bessel.py */
     constexpr double wb_A[] = {0.41037, 0.30833, 6.9952, 18.382, -2.8566, 2.1122};
 
     template <bool log_wb>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
As I was working on removing some old scripts in scipy/special/_precompute, I thought it would be good to add permalinks to those scripts in XSF.

The same thing exists for cosine.h https://github.com/scipy/xsf/blob/main/include/xsf/cosine.h#L42

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Asked Codex to check what I did and if I missed any.