### PR TITLE
Fix missing header

### DIFF
--- a/include/xsf/sph_bessel.h
+++ b/include/xsf/sph_bessel.h
@@ -29,6 +29,7 @@ Translated to C++ by SciPy developers in 2024.
 #pragma once
 
 #include "amos.h"
+#include "bessel.h"
 #include "error.h"
 
 namespace xsf {

--- a/tests/xsf_tests/test_sph_bessel.cpp
+++ b/tests/xsf_tests/test_sph_bessel.cpp
@@ -1,7 +1,6 @@
 #include "../testing_utils.h"
 #include <complex>
 #include <tuple>
-#include <xsf/bessel.h>
 #include <xsf/sph_bessel.h>
 
 TEST_CASE("spherical_j reflection complex", "[spherical_bessel][xsf_tests]") {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
Previous `tests/xsf_tests/test_sph_bessel.cpp` included `#include <xsf/bessel.h>` however this masked the fact that this header should have been in `sph_bessel.h` itself.
#### Additional information
<!--Any additional information you think is important.-->
cc @lucascolley @gertingold 
#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
Copilot found the issue