### PR TITLE
fix sign of sph_bessel_k and sph_bessel_k_jac on arm

### DIFF
--- a/include/xsf/sph_bessel.h
+++ b/include/xsf/sph_bessel.h
@@ -411,6 +411,10 @@ std::complex<T> sph_bessel_k(long n, std::complex<T> z) {
         return std::numeric_limits<T>::quiet_NaN();
     }
 
+    if (std::imag(z)) {
+        return {sph_bessel_k(n, std::real(z)), 0};
+    }
+
     return std::sqrt(static_cast<T>(M_PI_2) / z) * cyl_bessel_k(n + 1 / static_cast<T>(2), z);
 }
 

--- a/include/xsf/sph_bessel.h
+++ b/include/xsf/sph_bessel.h
@@ -411,7 +411,7 @@ std::complex<T> sph_bessel_k(long n, std::complex<T> z) {
         return std::numeric_limits<T>::quiet_NaN();
     }
 
-    if (std::imag(z)) {
+    if (std::imag(z) == 0) {
         return {sph_bessel_k(n, std::real(z)), 0};
     }
 

--- a/tests/xsf_tests/test_sph_bessel.cpp
+++ b/tests/xsf_tests/test_sph_bessel.cpp
@@ -276,3 +276,38 @@ TEST_CASE("spherical_k_jac reflection derivative", "[spherical_bessel][xsf_tests
     CAPTURE(n, z, result_spherical_k_jac, ref_spherical_k_jac, rel_err_spherical_k_jac, rtol);
     REQUIRE(rel_err_spherical_k_jac <= rtol);
 }
+
+TEST_CASE("spherical_k reflection complex", "[spherical_bessel][xsf_tests]") {
+    using test_case = std::tuple<long, std::complex<double>, std::complex<double>, double>;
+
+    // Reference values computed with mpmath.
+    auto [n, z, ref_spherical_k, rtol] = GENERATE(
+        test_case{10, {5., 0}, {11.162178171949055, 0}, 1e-14},
+        test_case{10, {-5., 0}, {-11.165977657150502, 0}, 1e-14},
+        test_case{7, {5., 0}, {0.22221361309239493, 0}, 1e-14},
+        test_case{7, {-5., 0}, {-0.023872188945034639, 0}, 1e-14}
+    );
+
+    std::complex<double> result_spherical_k = xsf::sph_bessel_k(n, z);
+    double rel_err_spherical_k = xsf::extended_relative_error(result_spherical_k, ref_spherical_k);
+
+    CAPTURE(n, z, result_spherical_k, ref_spherical_k, rel_err_spherical_k, rtol);
+    REQUIRE(rel_err_spherical_k <= rtol);
+}
+
+TEST_CASE("spherical_k_jac reflection derivative complex", "[spherical_bessel][xsf_tests]") {
+    using test_case = std::tuple<long, std::complex<double>, std::complex<double>, double>;
+
+    // Reference values computed with mpmath.
+    auto [n, z, ref_spherical_k_jac, rtol] = GENERATE(
+        test_case{10, {5., 0}, {-27.299149693641313, 0}, 1e-14},
+        test_case{10, {-5., 0}, {-27.290758018530437, 0}, 1e-14},
+        test_case{7, {5., 0}, {-0.43011979527682201, 0}, 1e-14}, test_case{7, {-5., 0}, {0.84209146503609691, 0}, 1e-14}
+    );
+
+    std::complex<double> result_spherical_k_jac = xsf::sph_bessel_k_jac(n, z);
+    double rel_err_spherical_k_jac = xsf::extended_relative_error(result_spherical_k_jac, ref_spherical_k_jac);
+
+    CAPTURE(n, z, result_spherical_k_jac, ref_spherical_k_jac, rel_err_spherical_k_jac, rtol);
+    REQUIRE(rel_err_spherical_k_jac <= rtol);
+}

--- a/tests/xsf_tests/test_sph_bessel.cpp
+++ b/tests/xsf_tests/test_sph_bessel.cpp
@@ -285,7 +285,7 @@ TEST_CASE("spherical_k reflection complex", "[spherical_bessel][xsf_tests]") {
         test_case{10, {5., 0}, {11.162178171949055, 0}, 1e-14},
         test_case{10, {-5., 0}, {-11.165977657150502, 0}, 1e-14},
         test_case{7, {5., 0}, {0.22221361309239493, 0}, 1e-14},
-        test_case{7, {-5., 0}, {-0.023872188945034639, 0}, 1e-14}
+        test_case{7, {-5., 0}, {-0.023872188945034639, 0}, 1.5e-14}
     );
 
     std::complex<double> result_spherical_k = xsf::sph_bessel_k(n, z);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->
closes #237
#### What does this implement/fix?
<!--Please explain your changes.-->
Hopefully fixes arm result by use real implementation when `z` has zero imaginary part
#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
no ai