### PR TITLE
MAINT: make correct sign of coefficients responsibility of caller of mathieu sum_fourier_series

### DIFF
--- a/include/xsf/mathieu.h
+++ b/include/xsf/mathieu.h
@@ -190,7 +190,7 @@ namespace mathieu {
      * AngleUnits = AngleUnitPolicy::Radians or AngleUnitPolicy::Degrees.
      *
      * Inputs:
-     * X = A 1d mdspan view of the Fourier coefficients.
+     * X = A 1d mdspan view of an array of Fourier coefficients with signs correctly determined.
      * v = Angular argument, in either radians or degrees depending on the
      * value of the AngleUnits template argument.
      *
@@ -240,29 +240,8 @@ namespace mathieu {
             }
         } // for (k=(N-1) ...
 
-        /* This makes sure the fcn has the right overall sign.
-         * The eigenvector solver that found the coefficients may have
-         * given the correct vector of coefficients, but with the sign
-         * flipped.
-         * These functions satisfy cem(m, q, 0) > 0 and sem'(m, q, 0) > 0
-         * (follows from https://dlmf.nist.gov/28.2#E29).
-         * Use these to fix the sign if needed.
-         * Someday combine this with the above sums into the same for loop. */
-        double x = 0.0;
-        for (decltype(N) l = 0; l < N; l++) {
-            if constexpr (FuncParity == Parity::Even) {
-                // sum of coefficients A_k equals cem(m, q, 0)
-                x += X(l);
-            } else {
-                // sum of k * B_k equals sem'(m, q, 0)
-                double r = sqrt_di<Parity::Odd, OrderParity>(l);
-                x += r * X(l);
-            }
-        }
-
-        auto sgn = std::copysign(1.0, x);
-        out = sgn * (xep + xem);
-        out_diff = sgn * (xedp + xedm);
+        out = xep + xem;
+        out_diff = xedp + xedm;
     }
 
 } // namespace mathieu


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
This PR moves the sign correction logic out of `xsf::mathieu::sum_fourier_series`. As revealed here, https://github.com/scipy/scipy/pull/25128#pullrequestreview-4874095191, proper sign correction needs to be aware of `m` and `q`, since the easy to understand correction that is currently employed is not always well conditioned. I am instead adding the sign correction on the SciPy side in https://github.com/scipy/scipy/pull/25128.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
No AI
