### PR TITLE
ENH: add tetragamma function, implemented using Horner approach in Julia's trigamma

### DIFF
--- a/include/xsf/tetragamma.h
+++ b/include/xsf/tetragamma.h
@@ -1,0 +1,109 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2026 Steven T. Smith
+ *
+ * https://github.com/scipy/scipy/pull/17933#issuecomment-5235227979
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include "cephes/polevl.h"
+#include "config.h"
+#include "evalpoly.h"
+#include "trig.h"
+
+#include <complex>
+#include <type_traits>
+
+namespace xsf {
+
+// Asymptotic coefficients d_k = B_{2k}*(2k+1), k=1..10 (A&S 6.4.11, m=2)
+template <typename T>
+XSF_HOST_DEVICE inline T tetragamma(T z) {
+    using base_t = std::remove_cv_t<T>;
+    constexpr bool is_complex_t =
+        std::is_same_v<base_t, std::complex<double>> || std::is_same_v<base_t, std::complex<float>>;
+
+    if constexpr (is_complex_t) {
+        if (std::imag(z) == 0) {
+            # also catches 0.+0.j → -Inf because M_PI / 0. is Inf in IEEE 754,
+            # but M_PI+0j / 0+0j is Nan+Nan*1j in complex
+            using real_t = typename base_t::value_type;
+            return T(tetragamma(static_cast<real_t>(std::real(z))), 0);
+        }
+    }
+
+    double x = std::real(z);
+    if (x <= 0) {
+        // omit numerically 0 term and avoid overflow at large imag(z)
+        bool use_trig_term = true;
+        if constexpr (is_complex_t) {
+            using real_t = typename base_t::value_type;
+            use_trig_term = std::abs(std::imag(z)) < std::log(std::numeric_limits<real_t>::max());
+        }
+        if (use_trig_term) {
+            T s = sinpi(z);
+            T c = M_PI / s;
+            return tetragamma(T(1) - z) - T(2) * cospi(z) * c * c * c;
+        } else {
+            return tetragamma(T(1) - z);
+        }
+    }
+
+    T psi = 0;
+    int N = 10;
+    int n;
+    if (x < N) {
+        n = N - std::floor(x);
+        psi -= 2.0 / (z * z * z);
+        for (int v = 1; v < n; v++) {
+            T w = z + static_cast<T>(v);
+            psi -= 2.0 / (w * w * w);
+        }
+        z += n;
+    }
+    T t = 1.0 / z;
+    T w = t * t;
+    psi += -w * (1.0 + t);
+    double coeffs[] = {-11111.609090909091, 1044.452380952381, -120.56666666666666,
+                        17.5, -3.2904761904761903, 0.83333333333333337,
+                        -0.29999999999999999, 0.16666666666666666,
+                        -0.16666666666666666, 0.5};
+    if constexpr (is_complex_t) {
+        psi -= w * w * cevalpoly(coeffs, 9, w);
+    } else {
+        psi -= w * w * cephes::polevl(w, coeffs, 9);
+    }
+    return psi;
+}
+
+template <>
+XSF_HOST_DEVICE inline float tetragamma(float z) {
+    return static_cast<float>(tetragamma(static_cast<double>(z)));
+}
+
+template <>
+XSF_HOST_DEVICE inline std::complex<float> tetragamma(std::complex<float> z) {
+    return static_cast<std::complex<float>>(tetragamma(static_cast<std::complex<double>>(z)));
+}
+
+} // namespace xsf

--- a/tests/xsf_tests/test_tetragamma.cpp
+++ b/tests/xsf_tests/test_tetragamma.cpp
@@ -1,0 +1,85 @@
+#include "../testing_utils.h"
+#include <complex>
+#include <tuple>
+#include <xsf/tetragamma.h>
+
+// Apery's constant zeta(3), used throughout via the A&S 6.4.4 closed form
+// psi''(1) = -2*zeta(3) and the A&S 6.4.6 recurrence psi''(z+1) = psi''(z) + 2/z^3.
+static constexpr double ZETA3 = 1.2020569031595942854;
+
+TEST_CASE("tetragamma real", "[tetragamma][xsf_tests]") {
+    double rtol = 1e-14;
+    using test_case = std::tuple<double, double>;
+
+    auto [z, ref_tetragamma] = GENERATE(
+        // Closed-form reference values, A&S 6.4.4 (psi''(1) = -2*zeta(3)) and
+        // A&S 6.4.6 (psi''(1/2) = -14*zeta(3)), extended by the integer recurrence
+        // psi''(n+1) = psi''(n) + 2/n^3.
+        test_case{0.5, -14.0 * ZETA3},
+        test_case{1.0, -2.0 * ZETA3},
+        test_case{2.0, -2.0 * ZETA3 + 2.0},
+        test_case{3.0, -2.0 * ZETA3 + 9.0 / 4.0},
+        test_case{4.0, -2.0 * ZETA3 + 251.0 / 108.0},
+        test_case{5.0, -2.0 * ZETA3 + 2035.0 / 864.0},
+        test_case{10.0, -2.0 * ZETA3 + 2.0 * (19148110939.0 / 16003008000.0)},
+        // Reference values from test_trigamma computed using mpmath
+        test_case{-7.5, -0.015564511795903923324}, test_case{-3.2, 246.9761555554604978}
+    );
+
+    double result_tetragamma = xsf::tetragamma(z);
+    double rel_err_tetragamma = xsf::extended_relative_error(result_tetragamma, ref_tetragamma);
+
+    CAPTURE(z, result_tetragamma, ref_tetragamma, rel_err_tetragamma, rtol);
+    REQUIRE(rel_err_tetragamma <= rtol);
+}
+
+TEST_CASE("tetragamma real poles", "[tetragamma][xsf_tests]") {
+    auto z = GENERATE(-1.0, 0.0);
+    double result_tetragamma = xsf::tetragamma(z);
+    CAPTURE(z, result_tetragamma);
+    REQUIRE(std::isinf(result_tetragamma));
+}
+
+TEST_CASE("tetragamma complex", "[tetragamma][xsf_tests]") {
+    double rtol = 1e-14;
+    using test_case = std::tuple<std::complex<double>, std::complex<double>>;
+
+    auto [z, ref_tetragamma] = GENERATE(
+        // Test points used in test_trigamma, taken from
+        // https://github.com/JuliaMath/SpecialFunctions.jl/blob/c9ff36085c9008b9bdaa457e745f459a1827e52e/test/gamma.jl#L261-L294
+        // computed using mpmath (mp.dps=60).
+        test_case{
+            {8.0, 0.0},
+            {-0.0176995691957677739092916777362138785173389598024749258780319, 0.0}
+        },
+        test_case{
+            {0.0, 8.0},
+            {0.0155022836781734350054183962027714397271268582016030387460863,
+             -0.00195312500000000001834374260890084586707709090054569497956919}
+        },
+        test_case{
+            {-3.2, 0.1},
+            {29.285628461389160743289806565288260993728667020276678436109,
+             177.776489607267829881651358046772576380967686212268333777227}
+        },
+        test_case{
+            {-10.0, 1.0e100},
+            {1.0e-200, -2.0999999999999998e-299}
+        }
+    );
+
+    std::complex<double> result_tetragamma = xsf::tetragamma(z);
+    double rel_err_tetragamma = xsf::extended_relative_error(result_tetragamma, ref_tetragamma);
+
+    CAPTURE(z, result_tetragamma, ref_tetragamma, rel_err_tetragamma, rtol);
+    REQUIRE(rel_err_tetragamma <= rtol);
+}
+
+TEST_CASE("tetragamma complex poles", "[tetragamma][xsf_tests]") {
+    auto z = GENERATE(std::complex<double>{0.0, 0.0}, std::complex<double>{-1.0, 0.0},
+                       std::complex<double>{-2.0, 0.0});
+    std::complex<double> result_tetragamma = xsf::tetragamma(z);
+    CAPTURE(z, result_tetragamma);
+    REQUIRE(std::isinf(result_tetragamma.real()));
+    REQUIRE(result_tetragamma.imag() == 0.0);
+}


### PR DESCRIPTION
`tetragamma` function, implemented using the Horner approach in Julia's [trigamma function](https://github.com/JuliaMath/SpecialFunctions.jl/blob/c9ff36085c9008b9bdaa457e745f459a1827e52e/src/gamma.jl#L58-L62).

Polynomial order to achieve `complex128` accuracy determined using [Lentz's method](https://github.com/scipy/scipy/issues/7410) near $|z| = 10$.

Asymptotic coefficients computed using $B_{2k}(2k+1)$, $k=1…10$ (A&S 6.4.11, $m=2$). Closed-form tests use Apéry's constant $\zeta(3)$, and numerical tests use the same test points as @j-bowhay's trigamma tests in #239.

#### Reference issue
* https://github.com/scipy/scipy/issues/7410
* https://github.com/scipy/scipy/pull/17933
* https://github.com/scipy/xsf/pull/239

#### What does this implement/fix?
I have implemented the `tetragamma` function using @j-bowhay's `trigamma` implementation in #239, itself an implementation of Julia's [trigamma function](https://github.com/JuliaMath/SpecialFunctions.jl/blob/c9ff36085c9008b9bdaa457e745f459a1827e52e/src/gamma.jl#L58-L62). The Horner coefficients are computed from Bernoulli numbers and closed-form tests use Apéry's constant.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
I used Claude to copy the xsf function and test templates used in #239, and to test the numerical accuracy of the code logic with `mpmath`.