### PR TITLE
ENH: add float overload for `hyp1f1`

### DIFF
--- a/include/xsf/specfun.h
+++ b/include/xsf/specfun.h
@@ -65,6 +65,12 @@ inline std::complex<double> hyp1f1(double a, double b, std::complex<double> z) {
     return outz;
 }
 
+inline std::complex<float> hyp1f1(float a, float b, std::complex<float> z) {
+    return static_cast<std::complex<float>>(
+        hyp1f1(static_cast<double>(a), static_cast<double>(b), static_cast<std::complex<double>>(z))
+    );
+}
+
 inline double hypu(double a, double b, double x) {
     double out;
     int md; /* method code --- not returned */


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Follow-up of https://github.com/scipy/xsf/pull/249. It looks like we will also need the following float overload for hyp1f1 (ffF->f)

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

No AI