### PR TITLE
BUG(bessel): cyl_bessel_{i, j}: fix at complex zero for large orders

### DIFF
--- a/include/xsf/bessel.h
+++ b/include/xsf/bessel.h
@@ -66,6 +66,17 @@ namespace detail {
         return i + s * k;
     }
 
+    // Handle exact z = 0 values before the AMOS range checks.
+    // Negative noninteger orders are left to AMOS.
+    inline bool zero_argument_ji(std::complex<double> *cy, double v, std::complex<double> z) {
+        if (z.real() != 0 || z.imag() != 0 || !std::isfinite(v) || (v < 0 && v != std::floor(v))) {
+            return false;
+        }
+
+        *cy = v == 0 ? std::complex<double>{1, 0} : std::complex<double>{0, 0};
+        return true;
+    }
+
     template <typename T>
     void itika(T x, T *ti, T *tk) {
 
@@ -608,6 +619,12 @@ inline std::complex<double> cyl_bessel_je(double v, std::complex<double> z) {
     if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
         return cy_j;
     }
+    if (detail::zero_argument_ji(&cy_j, v, z)) {
+        if (v < 0) {
+            detail::reflect_jy(&cy_j, -v);
+        }
+        return cy_j;
+    }
     if (v < 0) {
         v = -v;
         sign = -1;
@@ -714,6 +731,9 @@ inline std::complex<double> cyl_bessel_ie(double v, std::complex<double> z) {
     cy_k.imag(NAN);
 
     if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
+        return cy;
+    }
+    if (detail::zero_argument_ji(&cy, v, z)) {
         return cy;
     }
     if (v < 0) {
@@ -886,6 +906,12 @@ inline std::complex<double> cyl_bessel_j(double v, std::complex<double> z) {
     if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
         return cy_j;
     }
+    if (detail::zero_argument_ji(&cy_j, v, z)) {
+        if (v < 0) {
+            detail::reflect_jy(&cy_j, -v);
+        }
+        return cy_j;
+    }
     if (v < 0) {
         v = -v;
         sign = -1;
@@ -1029,6 +1055,9 @@ inline std::complex<double> cyl_bessel_i(double v, std::complex<double> z) {
     cy_k.imag(NAN);
 
     if (std::isnan(v) || std::isnan(z.real()) || std::isnan(z.imag())) {
+        return cy;
+    }
+    if (detail::zero_argument_ji(&cy, v, z)) {
         return cy;
     }
     if (v < 0) {

--- a/tests/xsf_tests/test_bessel.cpp
+++ b/tests/xsf_tests/test_bessel.cpp
@@ -19,3 +19,14 @@ TEST_CASE("iv tiny inputs", "[bessel][xsf_tests]") {
     CAPTURE(n, z, result, ref, rel_err, rtol);
     REQUIRE(rel_err <= rtol);
 }
+
+using large_order_case = std::tuple<std::complex<double> (*)(double, std::complex<double>), double>;
+
+TEST_CASE("cyl_bessel_j and cyl_bessel_i at complex zero beyond the AMOS order range", "[bessel][xsf_tests]") {
+    auto [kernel, v] = GENERATE(
+        large_order_case{xsf::cyl_bessel_j, 0x1p52}, large_order_case{xsf::cyl_bessel_je, 0x1p52},
+        large_order_case{xsf::cyl_bessel_i, 0x1p30}, large_order_case{xsf::cyl_bessel_ie, 0x1p30}
+    );
+
+    REQUIRE(kernel(v, {0.0, 0.0}) == std::complex<double>(0.0, 0.0));
+}


### PR DESCRIPTION
#### Reference issue

None. 

#### What does this implement/fix?

`cyl_bessel_j`, `cyl_bessel_je`, `cyl_bessel_i` and `cyl_bessel_ie` return NaN
at `z = 0` for large orders, where the value is exactly 0 and no argument
reduction is needed:

| call | main | value |
|---|---|---|
| `cyl_bessel_i(0x1p30, {0, 0})` | `(nan, nan)` | 0 |
| `cyl_bessel_ie(0x1p30, {0, 0})` | `(nan, nan)` | 0 |
| `cyl_bessel_j(0x1p52, {0, 0})` | `(nan, nan)` | 0 |
| `cyl_bessel_je(0x1p52, {0, 0})` | `(nan, nan)` | 0 |

AMOS rejects these before evaluating anything. `besj` and `besi` apply the same
generic range check to `fn` and `az`, but with different limits: `besi` uses
`min(0.5/RTOL_MIN, INT_MAX*0.5)`, which is `1073741823.5`, and `besj` uses
`min(0.5/RTOL_MIN, DBL_MAX*0.5)`, which is `2**51`. Either way `ierr = 4` maps
to `SF_ERROR_NO_RESULT`, and `set_error_and_nan` writes NaN into both
components.

This returns the exact value before calling AMOS, for `v = 0`, for every
`v > 0`, and for negative integer orders. 

#### Additional information

Negative noninteger orders are singular and still go to AMOS.

#### AI Generation Disclosure

I used Codex to draft the fix and test.