### PR TITLE
ENH(kolmogorov): template `kolmogorov` for `float` and `double`

### DIFF
--- a/include/xsf/config.h
+++ b/include/xsf/config.h
@@ -339,3 +339,10 @@ using complex = complex_type_t<T>;
 } // namespace xsf
 
 #endif
+
+namespace xsf {
+
+template <typename T>
+inline constexpr bool is_float_or_double_v = std::is_same_v<T, float> || std::is_same_v<T, double>;
+
+} // namespace xsf

--- a/include/xsf/cpu/stats.h
+++ b/include/xsf/cpu/stats.h
@@ -6,9 +6,10 @@
 namespace xsf {
 namespace cpu {
 
-    inline double kolmogorov(double x) { return cephes::kolmogorov(x); }
-
-    inline float kolmogorov(float x) { return static_cast<float>(kolmogorov(static_cast<double>(x))); }
+    template <typename T>
+    inline typename std::enable_if<is_float_or_double_v<T>, T>::type kolmogorov(T x) {
+        return static_cast<T>(cephes::kolmogorov(static_cast<double>(x)));
+    }
 
     inline double kolmogc(double x) { return cephes::kolmogc(x); }
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
Replace the separate float and double overloads with a constrained template for kolmogorov. This PR tries to replicate was is  done in https://github.com/scipy/xsf/blob/main/include/xsf/tools.h#L45. 

Note that https://github.com/scipy/xsf/blob/main/include/xsf/gamma.h#L11 appears to have no constraints.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Asked Codex for feedback.