### PR TITLE
BUG(par_cyl): pbdv: fix for large arguments

### DIFF
--- a/include/xsf/par_cyl.h
+++ b/include/xsf/par_cyl.h
@@ -1,7 +1,9 @@
 #pragma once
 
+#include "cephes/gamma.h"
 #include "error.h"
 #include "specfun/specfun.h"
+#include "trig.h"
 
 namespace xsf {
 namespace detail {
@@ -97,8 +99,8 @@ namespace detail {
         if (x < 0.0) {
             x1 = -x;
             vl = vvla(x1, va);
-            gl = specfun::gamma2(-va);
-            pd = pi * vl / gl + cos(pi * va) * pd;
+            gl = cephes::Gamma(-va);
+            pd = pi * vl / gl + cospi(va) * pd;
         }
         return pd;
     }
@@ -220,7 +222,7 @@ namespace detail {
         // ====================================================
 
         int ja, k, l, m, nk, nv, na;
-        T xa, vh, ep, f, f0, f1, v0, v1, v2, pd, pd0, pd1, s0;
+        T xa, vh, ep, f, f0, f1, v0, v1, v2, pd, pd0, pd1;
 
         xa = fabs(x);
         vh = v;
@@ -313,9 +315,8 @@ namespace detail {
                     f1 = f0;
                     f0 = f;
                 }
-                s0 = pd0 / f;
                 for (k = 0; k <= na; k++) {
-                    dv[k] *= s0;
+                    dv[k] = pd0 * (dv[k] / f);
                 }
             }
         }
@@ -635,6 +636,18 @@ void pbdv(T v, T x, T &pdf, T &pdd) {
         } else {
             dp = dv + num;
             detail::pbdv(x, v, dv, dp, &pdf, &pdd);
+            T nearest = nearbyint(v);
+            T distance = fabs(v - nearest);
+            if ((x < -5.8) && (v > 0.0) && (distance > 0.0) &&
+                (distance <= 8.0 * std::numeric_limits<T>::epsilon() * fabs(v))) {
+                T pvf, pvd;
+                T positive_pdf, positive_pdd;
+                detail::pbdv(-x, v, dv, dp, &positive_pdf, &positive_pdd);
+                detail::pbvv(-x, v, dv, dp, &pvf, &pvd);
+                T coefficient = M_PI / cephes::Gamma(-v);
+                pdf = coefficient * pvf + cospi(v) * positive_pdf;
+                pdd = -coefficient * pvd - cospi(v) * positive_pdd;
+            }
             free(dv);
         }
     }

--- a/include/xsf/par_cyl.h
+++ b/include/xsf/par_cyl.h
@@ -638,6 +638,7 @@ void pbdv(T v, T x, T &pdf, T &pdd) {
             detail::pbdv(x, v, dv, dp, &pdf, &pdd);
             T nearest = nearbyint(v);
             T distance = fabs(v - nearest);
+            // The forward recurrence is unstable within a few ulps of positive integer orders.
             if ((x < -5.8) && (v > 0.0) && (distance > 0.0) &&
                 (distance <= 8.0 * std::numeric_limits<T>::epsilon() * fabs(v))) {
                 T pvf, pvd;

--- a/tests/scipy_special_tests/test_pbdv.cpp
+++ b/tests/scipy_special_tests/test_pbdv.cpp
@@ -34,3 +34,26 @@ TEST_CASE("pbdv dd->dd scipy_special_tests", "[pbdv][dd->dd][scipy_special_tests
     CAPTURE(v, x, out1, desired1, error1, tol1, fallback);
     REQUIRE(error1 <= tol1);
 }
+
+TEST_CASE("pbdv remains stable for large arguments", "[pbdv][regression]") {
+    struct Case {
+        double v;
+        double x;
+        double desired0;
+        double desired1;
+    };
+    const Case cases[] = {
+        {std::nextafter(50.0, 0.0), -std::sqrt(500.0), 3.1429284557854132e37, -2.7008764338749622e38},
+        {std::nextafter(50.0, 0.0), -std::nextafter(50.0, 0.0), 5.6977287669133012e235, -1.3650529001419031e237},
+        {-1.0, 50.0, 7.3587705514938545e-274, -1.8411632169283370e-272},
+    };
+
+    for (const auto &test_case : cases) {
+        double out0;
+        double out1;
+        xsf::pbdv(test_case.v, test_case.x, out0, out1);
+        CAPTURE(test_case.v, test_case.x, out0, out1);
+        REQUIRE(xsf::extended_relative_error(out0, test_case.desired0) <= 5e-13);
+        REQUIRE(xsf::extended_relative_error(out1, test_case.desired1) <= 5e-13);
+    }
+}


### PR DESCRIPTION
## Summary

- use the accurate gamma and trigonometric helpers near integer orders
- use the connection formula where the forward recurrence loses accuracy
- avoid premature underflow when normalizing the backward recurrence
- add regression coverage for the reported large-argument failures

Addresses scipy/scipy#25814.

## Tests

- `pixi run tests`
- `pixi run format-dry-error`

## AI disclosure

I used AI assistance to understand the repository structure and generate an initial draft of the potential fix and regression tests.
The initial drafts of v small parts of `include/xsf/par_cyl.h` and `tests/scipy_special_tests/test_pbdv.cpp` were AI-assisted.
I reproduced the reported failures, traced the two numerical root causes, revised the implementation based on my own understanding, verified the reference values against mpmath, and ran the full test and formatting checks.
I reviewed the final code and take responsibility for it.