### PR TITLE
DOC: fix typos for Legendre polynomials

### DIFF
--- a/include/xsf/legendre.h
+++ b/include/xsf/legendre.h
@@ -386,14 +386,14 @@ void assoc_legendre_p_pm1(NormPolicy norm, int n, int m, dual<T, Order> z, int b
 /**
  * Compute the associated Legendre polynomial of degree n and order m.
  *
+ * @param norm normalization policy
  * @param n degree of the polynomial
  * @param m order of the polynomial
- * @param type specifies the branch cut of the polynomial, either 1, 2, or 3
  * @param z argument of the polynomial, either real or complex
- * @param callback a function to be called as callback(j, m, type, z, p, p_prev, args...) for 0 <= j <= n
- * @param args arguments to forward to the callback
- *
- * @return value of the polynomial
+ * @param branch_cut specifies the branch cut of the polynomial, either 1, 2, or 3
+ * @param res_m_abs_m polynomial value at degree abs(m) and order m
+ * @param res recurrence buffer
+ * @param f a function to be called as f(j, res) for 0 <= j <= n
  */
 template <typename NormPolicy, typename T, typename Func>
 void assoc_legendre_p_for_each_n(
@@ -463,10 +463,11 @@ void assoc_legendre_p_for_each_n_m(NormPolicy norm, int n, int m, T z, int branc
 /**
  * Compute the associated Legendre polynomial of degree n and order m.
  *
+ * @param norm normalization policy
  * @param n degree of the polynomial
  * @param m order of the polynomial
- * @param type specifies the branch cut of the polynomial, either 1, 2, or 3
  * @param z argument of the polynomial, either real or complex
+ * @param branch_cut specifies the branch cut of the polynomial, either 1, 2, or 3
  *
  * @return value of the polynomial
  */
@@ -481,11 +482,10 @@ T assoc_legendre_p(NormPolicy norm, int n, int m, T z, int branch_cut) {
 /**
  * Compute all associated Legendre polynomials of degree j and order i, where 0 <= j <= n and -m <= i <= m.
  *
- * @param type specifies the branch cut of the polynomial, either 1, 2, or 3
+ * @param norm normalization policy
  * @param z argument of the polynomial, either real or complex
- * @param res a view into the output with element type T and extents (2 * m + 1, n + 1)
- *
- * @return value of the polynomial
+ * @param branch_cut specifies the branch cut of the polynomial, either 1, 2, or 3
+ * @param res a view into the output with element type T and extents (n + 1, 2 * m + 1)
  */
 template <typename NormPolicy, typename T, typename OutputMat>
 void assoc_legendre_p_all(NormPolicy norm, T z, int branch_cut, OutputMat res) {
@@ -601,11 +601,10 @@ struct sph_legendre_p_recurrence_n {
  *
  * @param n degree of the polynomial
  * @param m order of the polynomial
- * @param theta z = cos(theta) argument of the polynomial, either real or complex
- * @param callback a function to be called as callback(j, m, type, z, p, p_prev, args...) for 0 <= j <= n
- * @param args arguments to forward to the callback
- *
- * @return value of the polynomial
+ * @param theta polar angle, either real or complex
+ * @param res_m_abs_m polynomial value at degree abs(m) and order m
+ * @param res recurrence buffer
+ * @param f a function to be called as f(j, res) for 0 <= j <= n
  */
 template <typename T, typename Func>
 void sph_legendre_p_for_each_n(int n, int m, T theta, const T &res_m_abs_m, T (&res)[2], Func f) {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
As I was working on https://github.com/scipy/xsf/issues/165, I noticed that some doxygen docs for the Legendre polynomials appear to be wrong (notably the arguments). This PR tries to fix them.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I worked with Codex on this.