### PR TITLE
CI: move GPU job caches to Cloudflare R2

### DIFF
--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -40,6 +40,7 @@ jobs:
           s3-access-key-id: ${{ secrets.S3_ACCESS_KEY_ID }}
           s3-secret-access-key: ${{ secrets.S3_SECRET_ACCESS_KEY }}
           s3-prefix: xsf
+          s3-ttl-days: 0  # expiry is a lifecycle rule on the bucket itself
 
       # Replaces setup-pixi's built-in cache (which is hardwired to the GitHub
       # cache backend). setup-pixi caches the `.pixi` directory next to
@@ -58,6 +59,7 @@ jobs:
           s3-access-key-id: ${{ secrets.S3_ACCESS_KEY_ID }}
           s3-secret-access-key: ${{ secrets.S3_SECRET_ACCESS_KEY }}
           s3-prefix: xsf
+          s3-ttl-days: 0  # expiry is a lifecycle rule on the bucket itself
 
       - name: run nvidia-smi
         run: nvidia-smi

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -24,12 +24,40 @@ jobs:
           # We don't want to change the directory, and $HOME isn't available for `env:`
           echo "CUPY_CACHE_DIR=$HOME/.cupy/kernel_cache" >> $GITHUB_ENV
 
+      # The on-prem GPU runner has no fast path to the GitHub-hosted cache
+      # backend (restores ran at ~14 MB/s), so caches live in a Cloudflare R2
+      # bucket instead. Same interface as actions/cache; see
+      # https://docs.cirun.io/caching/s3-compatible
       - name: Cache CuPy kernels
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        uses: cirunlabs/cache/s3@0d5005be5be8cb3f20e624125e3fca0dc68eb384 # v5.0.5-cirun.1
         with:
           path: ${{ env.CUPY_CACHE_DIR }}
           key: cupy-v0-${{ github.run_id }}
           restore-keys: cupy-v0
+          s3-bucket: scipy-cirun-github-actions-cache
+          s3-endpoint: ${{ secrets.S3_ENDPOINT }}
+          s3-region: auto
+          s3-access-key-id: ${{ secrets.S3_ACCESS_KEY_ID }}
+          s3-secret-access-key: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          s3-prefix: xsf
+
+      # Replaces setup-pixi's built-in cache (which is hardwired to the GitHub
+      # cache backend). setup-pixi caches the `.pixi` directory next to
+      # pixi.lock; the key hashes the lockfile plus this workflow file, since
+      # the pixi version and environment selection live here and change what
+      # ends up in `.pixi`.
+      - name: Cache pixi environment
+        uses: cirunlabs/cache/s3@0d5005be5be8cb3f20e624125e3fca0dc68eb384 # v5.0.5-cirun.1
+        with:
+          path: .pixi
+          key: gpu-pixi-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pixi.lock', '.github/workflows/gpu_tests.yml') }}
+          restore-keys: gpu-pixi-${{ runner.os }}-${{ runner.arch }}-
+          s3-bucket: scipy-cirun-github-actions-cache
+          s3-endpoint: ${{ secrets.S3_ENDPOINT }}
+          s3-region: auto
+          s3-access-key-id: ${{ secrets.S3_ACCESS_KEY_ID }}
+          s3-secret-access-key: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          s3-prefix: xsf
 
       - name: run nvidia-smi
         run: nvidia-smi
@@ -41,8 +69,7 @@ jobs:
         with:
           pixi-version: v0.75.0
           manifest-path: pixi.toml
-          cache: true
-          cache-key: gpu-pixi-
+          cache: false
 
       - name: Run CuPy tests
         run: pixi run test-cupy

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -13,6 +13,14 @@ jobs:
   cupy_tests:
     name: CuPy GPU
     runs-on: "cirun-scipy-onprem-gpu--${{ github.run_id }}"
+    env:
+      # The on-prem GPU runner has no fast path to the GitHub-hosted cache
+      # backend (restores ran at ~14 MB/s), so caches live in a Cloudflare R2
+      # bucket instead, via cirunlabs/cache/s3 (same interface as actions/cache,
+      # see https://docs.cirun.io/caching/s3-compatible). Repository secrets are
+      # not available to pull requests from forks, so those runs fall back to
+      # the GitHub cache below.
+      S3_CACHE: ${{ secrets.S3_ACCESS_KEY_ID != '' }}
     steps:
       - name: Checkout xsf repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -24,11 +32,8 @@ jobs:
           # We don't want to change the directory, and $HOME isn't available for `env:`
           echo "CUPY_CACHE_DIR=$HOME/.cupy/kernel_cache" >> $GITHUB_ENV
 
-      # The on-prem GPU runner has no fast path to the GitHub-hosted cache
-      # backend (restores ran at ~14 MB/s), so caches live in a Cloudflare R2
-      # bucket instead. Same interface as actions/cache; see
-      # https://docs.cirun.io/caching/s3-compatible
-      - name: Cache CuPy kernels
+      - name: Cache CuPy kernels (R2)
+        if: env.S3_CACHE == 'true'
         uses: cirunlabs/cache/s3@0d5005be5be8cb3f20e624125e3fca0dc68eb384 # v5.0.5-cirun.1
         with:
           path: ${{ env.CUPY_CACHE_DIR }}
@@ -42,12 +47,21 @@ jobs:
           s3-prefix: xsf
           s3-ttl-days: 0  # expiry is a lifecycle rule on the bucket itself
 
+      - name: Cache CuPy kernels (GitHub)
+        if: env.S3_CACHE != 'true'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.CUPY_CACHE_DIR }}
+          key: cupy-v0-${{ github.run_id }}
+          restore-keys: cupy-v0
+
       # Replaces setup-pixi's built-in cache (which is hardwired to the GitHub
       # cache backend). setup-pixi caches the `.pixi` directory next to
       # pixi.lock; the key hashes the lockfile plus this workflow file, since
       # the pixi version and environment selection live here and change what
       # ends up in `.pixi`.
-      - name: Cache pixi environment
+      - name: Cache pixi environment (R2)
+        if: env.S3_CACHE == 'true'
         uses: cirunlabs/cache/s3@0d5005be5be8cb3f20e624125e3fca0dc68eb384 # v5.0.5-cirun.1
         with:
           path: .pixi
@@ -71,7 +85,9 @@ jobs:
         with:
           pixi-version: v0.75.0
           manifest-path: pixi.toml
-          cache: false
+          # Built-in (GitHub-backed) cache only when the R2 cache is unavailable.
+          cache: ${{ env.S3_CACHE != 'true' }}
+          cache-key: gpu-pixi-
 
       - name: Run CuPy tests
         run: pixi run test-cupy

--- a/.github/workflows/gpu_tests.yml
+++ b/.github/workflows/gpu_tests.yml
@@ -87,7 +87,7 @@ jobs:
           manifest-path: pixi.toml
           # Built-in (GitHub-backed) cache only when the R2 cache is unavailable.
           cache: ${{ env.S3_CACHE != 'true' }}
-          cache-key: gpu-pixi-
+          cache-key: ${{ env.S3_CACHE != 'true' && 'gpu-pixi-' || '' }}
 
       - name: Run CuPy tests
         run: pixi run test-cupy


### PR DESCRIPTION
#### Reference issue
Follow up from gh-242 (https://github.com/scipy/xsf/pull/242#issuecomment-5411609987).

#### What does this implement/fix?
The on-prem GPU runner reaches the GitHub-hosted cache backend at ~14 MB/s, so restoring the 2.2 GB pixi environment took ~2.5 min of a ~4 min job. This moves both caches (pixi environment and CuPy kernels) to a Cloudflare R2 bucket via `cirunlabs/cache/s3`, and turns off setup-pixi's built-in cache so the environment is not fetched twice.

#### Additional information
Uses the `S3_ENDPOINT` / `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` repository secrets. Bucket: `scipy-cirun-github-actions-cache`. Docs: https://docs.cirun.io/caching/s3-compatible

#### AI Generation Disclosure
Claude Code (Opus) was used to draft the workflow changes. I take full responsibility of the changes.
