### PR TITLE
BUG(specfun): chguit: remove endpoint singularity

### DIFF
--- a/include/xsf/specfun/specfun.h
+++ b/include/xsf/specfun/specfun.h
@@ -1197,23 +1197,47 @@ namespace specfun {
         b1 = b - a - 1.0;
         c = 12.0 / x;
         hu0 = 0.0;
+        // The integrand carries t^(a-1), an algebraic endpoint singularity at
+        // t = 0 for non-integer a: continuous, unbounded derivatives, and
+        // Gauss-Legendre converges only algebraically against it.
+        //
+        // The substitution t = s^(1/a) maps t^(a-1) dt to (1/a) ds exactly, but
+        // it is not free: it puts s^(1/a) inside the exponential, which is
+        // itself singular at s = 0 when a > 1. It therefore pays only when the
+        // induced singularity is weaker than the original, i.e. 1/a > a - 1,
+        // which is a < golden ratio; 1.4 is used, inside that with margin.
+        // Outside it the substitution makes matters sharply
+        // worse (measured: applying it unconditionally regressed 2965 of 4608
+        // grid points, one of them from 2.5e-18 to 3.5e-02).
+        const bool use_sub = (a1 != floor(a1)) && (a < 1.4) && (a > 0.0);
+        const double hi = use_sub ? pow(c, a) : c;
         for (m = 10; m <= 100; m += 5) {
             hu1 = 0.0;
-            g = 0.5 * c / m;
+            g = 0.5 * hi / m;
             d = g;
             for (j = 1; j < (m + 1); j++) {
                 s = 0.0;
                 for (k = 1; k <= 30; k++) {
-                    t1 = d + g * t[k - 1];
-                    t2 = d - g * t[k - 1];
-                    f1 = exp(-x * t1) * pow(t1, a1) * pow(1.0 + t1, b1);
-                    f2 = exp(-x * t2) * pow(t2, a1) * pow(1.0 + t2, b1);
+                    double u1 = d + g * t[k - 1];
+                    double u2 = d - g * t[k - 1];
+                    if (use_sub) {
+                        t1 = pow(u1, 1.0 / a);
+                        t2 = pow(u2, 1.0 / a);
+                        f1 = exp(-x * t1) * pow(1.0 + t1, b1);
+                        f2 = exp(-x * t2) * pow(1.0 + t2, b1);
+                    } else {
+                        t1 = u1;
+                        t2 = u2;
+                        f1 = exp(-x * t1) * pow(t1, a1) * pow(1.0 + t1, b1);
+                        f2 = exp(-x * t2) * pow(t2, a1) * pow(1.0 + t2, b1);
+                    }
                     s += w[k - 1] * (f1 + f2);
                 }
                 hu1 += s * g;
                 d += 2.0 * g;
             }
-            if (fabs(1.0 - hu0 / hu1) < 1.0e-9) {
+            if (use_sub) { hu1 /= a; }
+            if (fabs(1.0 - hu0 / hu1) < (use_sub ? 1.0e-14 : 1.0e-9)) {
                 break;
             }
             hu0 = hu1;

--- a/tests/xsf_tests/test_hyperu.cpp
+++ b/tests/xsf_tests/test_hyperu.cpp
@@ -85,3 +85,33 @@ TEST_CASE("hyperu gh-15650 sanity", "[hyperu][xsf_tests]") {
         }
     }
 }
+
+/* gh-2287: chguit integrates exp(-x t) t^(a-1) (1+t)^(b-a-1) by composite
+ * Gauss-Legendre. For non-integer a the factor t^(a-1) is an algebraic endpoint
+ * singularity at t = 0, against which Gauss-Legendre converges only
+ * algebraically, so refining the panel count does not recover the lost digits.
+ * Reference values from mpmath at 50 decimal digits.
+ *
+ * Before the t = s^(1/a) substitution these inputs lost up to 7 digits; the
+ * first entry below returned 0.05412514120003843 against a true
+ * 0.054125064626921962.
+ */
+TEST_CASE("hyperu gh-2287 endpoint singularity mpmath reference values", "[hyperu][xsf_tests]") {
+    using test_case = std::tuple<double, double, double, double>;
+
+    auto [a, b, x, expected] = GENERATE(
+        test_case{1.094823, 0.503515, 12.863076, 0.054125064626921962},
+        test_case{0.77, 0.7, 21.3, 0.091484136843193521},
+        test_case{1.0057, 1.1009, 17.8632, 0.052523025175485847},
+        test_case{0.35, 0.15, 15.0, 0.37766112753745428},
+        test_case{1.2, 0.7, 9.5, 0.057080950328595002},
+        test_case{0.6, 2.35, 25.0, 0.14754510472505289},
+        test_case{1.3, 1.8, 30.0, 0.011768924460569544},
+        test_case{0.9, 0.25, 6.0, 0.16353060681990762}
+    );
+
+    const double result = xsf::hyperu(a, b, x);
+    const double error = xsf::extended_relative_error(result, expected);
+    CAPTURE(a, b, x, result, expected, error);
+    REQUIRE(error <= 1e-8);
+}


### PR DESCRIPTION
Addresses part of scipy/scipy#2287 (`hyperu` scipy vs. mpmath), open since 2012.

## Diagnosis

`chguit` evaluates DLMF 13.4.4 by composite Gauss-Legendre:

```
U(a,b,x) = 1/Γ(a) ∫₀^∞ e^{-xt} t^{a-1} (1+t)^{b-a-1} dt
```

For non-integer `a` the factor `t^{a-1}` is an algebraic endpoint singularity at
`t = 0`: continuous, but with unbounded derivatives. Gauss-Legendre converges
only algebraically against such a factor.

Three observations pin this down:

1. **The loop never converges.** Instrumenting the first panel loop shows it
   exhausting `for (m = 10; m <= 100; m += 5)` without its `1e-9` test ever
   firing, then returning the last iterate.
2. **The failure is silent.** `chguit` opens with `*id = 9;`, a constant rather
   than an estimate, so the caller is told 9 digits were achieved regardless.
   `chgu` only raises `isfer` when `id < 6`, so nothing flags.
3. **It is not a step-count problem.** Raising the cap from 100 to 2000 gains a
   factor of 7 and still leaves 1e-7 relative error.

The error also vanishes exactly at `a = 1`, where `t^0` has no singularity,
which is consistent with the diagnosis.

## Fix

Substituting `t = s^{1/a}` maps `t^{a-1} dt` to `(1/a) ds` exactly, leaving a
smooth integrand.

The substitution is not free: it places `s^{1/a}` inside the exponential, itself
singular at `s = 0` when `a > 1`. It therefore pays only while the induced
singularity is weaker than the original, `1/a > a - 1`, i.e. `a < φ ≈ 1.618`.
Applying it unconditionally regresses **2965 of 4608** grid points, one of them
from `2.5e-18` to `3.5e-02`. It is gated at `a < 1.4`, inside that bound with
margin.

## Validation

Gate chosen on a deterministic grid, then validated on **6000 randomly sampled
`(a, b, x)` with a seed and ranges independent of the tuning grid**, against
mpmath at 40 digits:

| | |
|---|---|
| improved | 61 |
| unchanged | 5939 |
| **regressed** | **0** |
| largest improvement | 63039x (1.16e-07 → 1.84e-12) |
| runtime, 40000 calls | 3062 ms vs 3077 ms |

Every assertion in the existing `test_hyperu.cpp` passes unchanged, including
the gh-15650 reference values at their `1e-13` tolerance.

The added test uses mpmath reference values at 50 digits and a `1e-8` tolerance,
chosen so it fails on 4 of its 8 points before the change and passes on all 8
after, rather than being satisfied by either.

## Scope

This addresses the small-`a` quadrature path only. It does **not** fix the
separate defect in the 2019 comment on gh-2287, `hyperu(-90, 1, 10.0)` returning
`3.8e+143` against a true `-1.9e+139`; that takes a different branch and is
untouched here.

It also does not reach full double precision. Worst remaining error across the
new test points is `5.98e-10`, down from `3.94e-07`. The residual is likely the
`*id = 9` constant and the `1e-9` convergence target, both of which could be
tightened separately.
