### PR TITLE
FIX:amos: Pick the correct branch in complex sqrt

### DIFF
--- a/include/xsf/amos/amos.h
+++ b/include/xsf/amos/amos.h
@@ -781,6 +781,9 @@ namespace amos {
         }
         if (*ierr != 0)
             return 0.;
+        if (std::imag(z) == 0.0) {
+            z = std::complex<double>(std::real(z), 0.0);
+        }
         az = std::abs(z);
         tol = std::numeric_limits<double>::epsilon();
         fid = id;
@@ -2915,6 +2918,9 @@ namespace amos {
         }
         if (*ierr != 0) {
             return 0.0;
+        }
+        if (std::imag(z) == 0.0) {
+            z = std::complex<double>(std::real(z), 0.0);
         }
         az = std::abs(z);
         tol = RTOL_MIN;


### PR DESCRIPTION
AMOS had its own `AZSQRT` function in `zsqrt.f` that did not respect the signed zeros. Also `airye` was additionally wrong at every negative x including `|x| < 1`.

`airy(z)` and `biry(z)` return a different value for `z = x - 0.0j` than for `z = x + 0.0j` when `x < 0`. Ai and Bi are entire, so the two must agree. However it gives

```
Ai(-2 + 0j) =  0.22740742820168577
Ai(-2 - 0j) = -0.11370371410084285 + 0.20615129397819931j
```

#### Reference issue
https://github.com/scipy/scipy/issues/26034
