### PR TITLE
Let poisson_binom distribution function kernels take generic integers

### DIFF
--- a/include/xsf/config.h
+++ b/include/xsf/config.h
@@ -222,6 +222,24 @@ XSF_HOST_DEVICE complex<T> pow(const complex<T> &x, const T &y) {
 template <typename T>
 using is_floating_point = cuda::std::is_floating_point<T>;
 
+template <typename T>
+using is_integral = cuda::std::is_integral<T>;
+
+template <typename T>
+inline constexpr bool is_integral_v = cuda::std::is_integral_v<T>;
+
+template <typename T>
+using is_signed = cuda::std::is_signed<T>;
+
+template <typename T>
+inline constexpr bool is_signed_v = cuda::std::is_signed_v<T>;
+
+template <typename T>
+using make_unsigned = cuda::std::make_unsigned<T>;
+
+template <typename T>
+using make_unsigned_t = cuda::std::make_unsigned_t<T>;
+
 template <bool Cond, typename T = void>
 using enable_if = cuda::std::enable_if<Cond, T>;
 

--- a/include/xsf/stats.h
+++ b/include/xsf/stats.h
@@ -17,6 +17,7 @@
 #include "config.h"
 #include "erf.h"
 #include "gamma.h"
+#include "tools.h"
 
 namespace xsf {
 
@@ -336,24 +337,24 @@ XSF_HOST_DEVICE inline void poisson_binom_cdf_all(InputMat p, OutputMat res) {
     res(n) = T(1);
 }
 
-template <typename InputMat>
-XSF_HOST_DEVICE inline typename InputMat::value_type take_from_pmf(InputMat pmf, long long int k) {
+template <typename InputMat, typename Int>
+XSF_HOST_DEVICE inline typename InputMat::value_type take_from_pmf(InputMat pmf, Int k) {
     using T = typename InputMat::value_type;
     auto size = pmf.extent(0);
-    if ((k < 0) || (k >= static_cast<long long int>(size))) {
+    if (detail::cmp_less(k, 0) || !detail::cmp_less(k, size)) {
         return T(0);
     }
     return pmf(k);
 }
 
-template <typename InputMat>
-XSF_HOST_DEVICE inline typename InputMat::value_type take_from_discrete_cdf(InputMat cdf, long long int k) {
+template <typename InputMat, typename Int>
+XSF_HOST_DEVICE inline typename InputMat::value_type take_from_discrete_cdf(InputMat cdf, Int k) {
     using T = typename InputMat::value_type;
     auto size = cdf.extent(0);
-    if (k < 0) {
+    if (detail::cmp_less(k, 0)) {
         return T(0);
     }
-    if (k >= static_cast<long long int>(size) - 1) {
+    if (!detail::cmp_less(k, size - 1)) {
         return T(1);
     }
     return cdf(k);

--- a/include/xsf/tools.h
+++ b/include/xsf/tools.h
@@ -474,5 +474,18 @@ namespace detail {
         return {x, NewtonRootFinderStatus::MAX_ITERATIONS_EXCEEDED};
     }
 
+    template <typename T, typename U>
+    XSF_HOST_DEVICE constexpr bool cmp_less(T t, U u) {
+        static_assert(std::is_integral_v<T> && std::is_integral_v<U>);
+
+        if constexpr (std::is_signed_v<T> == std::is_signed_v<U>) {
+            return t < u;
+        } else if constexpr (std::is_signed_v<T>) {
+            return t < 0 || static_cast<std::make_unsigned_t<T>>(t) < u;
+        } else {
+            return u >= 0 && t < static_cast<std::make_unsigned_t<U>>(u);
+        }
+    }
+
 } // namespace detail
 } // namespace xsf


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
<!--Please explain your changes.-->
In preparation for making `poisson_binom_cdf` public in SciPy as I proposed here, https://github.com/scipy/scipy/issues/25921#issuecomment-5287134536, this updates the `take_from_discrete_cdf` and `take_from_pmf` functions to take template args for the integer type so that they will work for generic integers. To do this in a streamlined way I added in implementation of the [`std::cmp_less`](https://en.cppreference.com/cpp/utility/intcmp) template function for comparing integers of arbitrary types. Although this cannot be used in CuPy until github.com/cupy/cupy/pull/9959 lands, I've gone ahead and added the relevant helper templates to `config.h`, along with some related helpers which aren't needed here but seem like they could be desirable in the future when we move to supporting generic integer type across more functions.
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->
I've used GPT 5.6 Sol to help review my diffs locally
