### PR TITLE
TST: clean up CuPy test definitions

### DIFF
--- a/python_tests/test_cupy.py
+++ b/python_tests/test_cupy.py
@@ -10,8 +10,6 @@ import os
 import numpy as np
 import polars as pl
 import pytest
-import shutil
-import tempfile
 
 from packaging.version import Version
 from pathlib import Path
@@ -228,13 +226,13 @@ class TestCuPy:
         input_path, output_path, tol_path = tables_paths
         expn = cupy._core.create_ufunc(
             'cupyx_scipy_special_expn',
-            ('ff->f', 'dd->d'),
+            ('ld->d', 'ff->f', 'dd->d'),
             'out0 = xsf::cephes::expn(in0, in1)',
             preamble=get_preamble("xsf/cephes/expn.h"),
         )
 
-        x, n = get_cols_as_cupy(input_path)
-        out = cupy.asnumpy(expn(x, n))
+        n, x = get_cols_as_cupy(input_path)
+        out = cupy.asnumpy(expn(n, x))
 
         desired = get_cols_as_numpy(output_path)
         rtol = get_cols_as_numpy(tol_path)
@@ -297,7 +295,7 @@ class TestCuPy:
         input_path, output_path, tol_path = tables_paths
         _lambertw_scalar = cupy._core.create_ufunc(
             "cupyx_scipy_lambertw_scalar",
-            ("Dld->D", "Fif->f"),
+            ("Dld->D", "Flf->F"),
             "out0 = xsf::lambertw(in0, in1, in2)",
             preamble=get_preamble("xsf/lambertw.h"),
         )
@@ -356,7 +354,7 @@ class TestCuPy:
             ),
             preamble=get_preamble("xsf/sici.h"),
         )
-            
+
         x = get_cols_as_cupy(input_path)
         if cupy.iscomplexobj(x):
             pytest.xfail("Known bug, returning nan instead of a complex infinity.")
@@ -364,8 +362,6 @@ class TestCuPy:
 
         desired0, desired1 = get_cols_as_numpy(output_path)
         rtol0, rtol1 = get_cols_as_numpy(tol_path)
-        error = extended_relative_error(out0, desired0)
-        tol = self._adjust_tol(rtol0)
         assert np.all(
             extended_relative_error(out0, desired0) <= self._adjust_tol(rtol0)
         )
@@ -416,7 +412,7 @@ class TestCuPy:
             ),
             preamble=get_preamble("xsf/sici.h"),
         )
-            
+
         x = get_cols_as_cupy(input_path)
         if cupy.iscomplexobj(x):
             pytest.xfail("Known bug, returning nan instead of a complex infinity.")
@@ -475,7 +471,6 @@ class TestCuPy:
         skip = x.get() == (-21092.63667768141-7.794025022440267e+201j)
         out, desired, rtol = out[~skip], desired[~skip], rtol[~skip]
 
-        r = extended_relative_error(out, desired)
         assert np.all(
             extended_relative_error(out, desired) <= self._adjust_tol(rtol)
         )
@@ -550,7 +545,7 @@ class TestCuPy:
         input_path, output_path, tol_path = tables_paths
         wofz = cupy._core.create_ufunc(
             'cupyx_scipy_special_wofz',
-            ('f->f', 'd->d', 'F->F', 'D->D'),
+            ('F->F', 'D->D'),
             'out0 = xsf::wofz(in0)',
             preamble=get_preamble("xsf/erf.h"),
         )

--- a/python_tests/test_cupy.py
+++ b/python_tests/test_cupy.py
@@ -226,7 +226,7 @@ class TestCuPy:
         input_path, output_path, tol_path = tables_paths
         expn = cupy._core.create_ufunc(
             'cupyx_scipy_special_expn',
-            ('ld->d', 'ff->f', 'dd->d'),
+            ('ff->f', 'dd->d'),
             'out0 = xsf::cephes::expn(in0, in1)',
             preamble=get_preamble("xsf/cephes/expn.h"),
         )
@@ -295,7 +295,7 @@ class TestCuPy:
         input_path, output_path, tol_path = tables_paths
         _lambertw_scalar = cupy._core.create_ufunc(
             "cupyx_scipy_lambertw_scalar",
-            ("Dld->D", "Flf->F"),
+            ("Dld->D", "Fif->f"),
             "out0 = xsf::lambertw(in0, in1, in2)",
             preamble=get_preamble("xsf/lambertw.h"),
         )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
- Fix the mismatch for `expn` https://github.com/scipy/xsf/blob/main/include/xsf/cephes/expn.h#L147 for CuPy tests (changing to `n,x`)

- `wofz` only accepts complex arguments https://github.com/scipy/xsf/blob/main/include/xsf/erf.h#L78 so this PR removes the signature `'f->f', 'd->d'`

- Some cleaning (unused imports and whitepace)

#### Additional information


#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Worked with Codex on this.