### PR TITLE
ENH: add Carlson elliptic integrals

### DIFF
--- a/include/xsf/cpu/ellint_carlson.h
+++ b/include/xsf/cpu/ellint_carlson.h
@@ -1,0 +1,144 @@
+#pragma once
+
+#include "../config.h"
+#include "../ellint_carlson/ellint_carlson.hh"
+#include "../error.h"
+
+namespace xsf {
+namespace cpu {
+    namespace detail {
+
+        constexpr double ellint_carlson_rerr = 5e-16;
+
+        template <typename T>
+        inline T elliprc(T x, T y) {
+            T result;
+            const auto status = ellint_carlson::rc(x, y, ellint_carlson_rerr, result);
+            set_error("elliprc", static_cast<sf_error_t>(status), nullptr);
+            return result;
+        }
+
+        template <typename T>
+        inline T elliprd(T x, T y, T z) {
+            T result;
+            const auto status = ellint_carlson::rd(x, y, z, ellint_carlson_rerr, result);
+            set_error("elliprd", static_cast<sf_error_t>(status), nullptr);
+            return result;
+        }
+
+        template <typename T>
+        inline T elliprf(T x, T y, T z) {
+            T result;
+            const auto status = ellint_carlson::rf(x, y, z, ellint_carlson_rerr, result);
+            set_error("elliprf", static_cast<sf_error_t>(status), nullptr);
+            return result;
+        }
+
+        template <typename T>
+        inline T elliprg(T x, T y, T z) {
+            T result;
+            const auto status = ellint_carlson::rg(x, y, z, ellint_carlson_rerr, result);
+            set_error("elliprg", static_cast<sf_error_t>(status), nullptr);
+            return result;
+        }
+
+        template <typename T>
+        inline T elliprj(T x, T y, T z, T p) {
+            T result;
+            const auto status = ellint_carlson::rj(x, y, z, p, ellint_carlson_rerr, result);
+            set_error("elliprj", static_cast<sf_error_t>(status), nullptr);
+            return result;
+        }
+
+    } // namespace detail
+
+    inline double elliprc(double x, double y) { return detail::elliprc(x, y); }
+
+    inline float elliprc(float x, float y) {
+        return static_cast<float>(elliprc(static_cast<double>(x), static_cast<double>(y)));
+    }
+
+    inline std::complex<double> elliprc(std::complex<double> x, std::complex<double> y) {
+        return detail::elliprc(x, y);
+    }
+
+    inline std::complex<float> elliprc(std::complex<float> x, std::complex<float> y) {
+        return static_cast<std::complex<float>>(
+            elliprc(static_cast<std::complex<double>>(x), static_cast<std::complex<double>>(y))
+        );
+    }
+
+    inline double elliprd(double x, double y, double z) { return detail::elliprd(x, y, z); }
+
+    inline float elliprd(float x, float y, float z) {
+        return static_cast<float>(elliprd(static_cast<double>(x), static_cast<double>(y), static_cast<double>(z)));
+    }
+
+    inline std::complex<double> elliprd(std::complex<double> x, std::complex<double> y, std::complex<double> z) {
+        return detail::elliprd(x, y, z);
+    }
+
+    inline std::complex<float> elliprd(std::complex<float> x, std::complex<float> y, std::complex<float> z) {
+        return static_cast<std::complex<float>>(elliprd(
+            static_cast<std::complex<double>>(x), static_cast<std::complex<double>>(y),
+            static_cast<std::complex<double>>(z)
+        ));
+    }
+
+    inline double elliprf(double x, double y, double z) { return detail::elliprf(x, y, z); }
+
+    inline float elliprf(float x, float y, float z) {
+        return static_cast<float>(elliprf(static_cast<double>(x), static_cast<double>(y), static_cast<double>(z)));
+    }
+
+    inline std::complex<double> elliprf(std::complex<double> x, std::complex<double> y, std::complex<double> z) {
+        return detail::elliprf(x, y, z);
+    }
+
+    inline std::complex<float> elliprf(std::complex<float> x, std::complex<float> y, std::complex<float> z) {
+        return static_cast<std::complex<float>>(elliprf(
+            static_cast<std::complex<double>>(x), static_cast<std::complex<double>>(y),
+            static_cast<std::complex<double>>(z)
+        ));
+    }
+
+    inline double elliprg(double x, double y, double z) { return detail::elliprg(x, y, z); }
+
+    inline float elliprg(float x, float y, float z) {
+        return static_cast<float>(elliprg(static_cast<double>(x), static_cast<double>(y), static_cast<double>(z)));
+    }
+
+    inline std::complex<double> elliprg(std::complex<double> x, std::complex<double> y, std::complex<double> z) {
+        return detail::elliprg(x, y, z);
+    }
+
+    inline std::complex<float> elliprg(std::complex<float> x, std::complex<float> y, std::complex<float> z) {
+        return static_cast<std::complex<float>>(elliprg(
+            static_cast<std::complex<double>>(x), static_cast<std::complex<double>>(y),
+            static_cast<std::complex<double>>(z)
+        ));
+    }
+
+    inline double elliprj(double x, double y, double z, double p) { return detail::elliprj(x, y, z, p); }
+
+    inline float elliprj(float x, float y, float z, float p) {
+        return static_cast<float>(
+            elliprj(static_cast<double>(x), static_cast<double>(y), static_cast<double>(z), static_cast<double>(p))
+        );
+    }
+
+    inline std::complex<double>
+    elliprj(std::complex<double> x, std::complex<double> y, std::complex<double> z, std::complex<double> p) {
+        return detail::elliprj(x, y, z, p);
+    }
+
+    inline std::complex<float>
+    elliprj(std::complex<float> x, std::complex<float> y, std::complex<float> z, std::complex<float> p) {
+        return static_cast<std::complex<float>>(elliprj(
+            static_cast<std::complex<double>>(x), static_cast<std::complex<double>>(y),
+            static_cast<std::complex<double>>(z), static_cast<std::complex<double>>(p)
+        ));
+    }
+
+} // namespace cpu
+} // namespace xsf

--- a/include/xsf/ellint_carlson/_rc.hh
+++ b/include/xsf/ellint_carlson/_rc.hh
@@ -1,0 +1,98 @@
+#ifndef ELLINT_RC_GENERIC_GUARD
+#define ELLINT_RC_GENERIC_GUARD
+
+
+#include <algorithm>
+#include <complex>
+#include "ellint_typing.hh"
+#include "ellint_argcheck.hh"
+#include "ellint_common.hh"
+#include "ellint_carlson.hh"
+
+
+/* References:
+ * [1] B. C. Carlson, ed., Chapter 19 in "Digital Library of Mathematical
+ *     Functions," NIST, US Dept. of Commerce.
+ *     https://dlmf.nist.gov/19.16.E6
+ * [2] B. C. Carlson, "Numerical computation of real or complex elliptic
+ *     integrals," Numer. Algorithm, vol. 10, no. 1, pp. 13-26, 1995.
+ *     https://arxiv.org/abs/math/9409227
+ *     https://doi.org/10.1007/BF02198293
+ */
+
+
+namespace ellint_carlson {
+
+template<typename T>
+ExitStatus
+rc(const T& x, const T& y, const double& rerr, T& res)
+{
+    typedef typing::decplx_t<T> RT;
+
+    ExitStatus status = ExitStatus::success;
+#ifndef ELLINT_NO_VALIDATE_RELATIVE_ERROR_BOUND
+    if ( argcheck::invalid_rerr(rerr, 2.0e-4) )
+    {
+	res = typing::nan<T>();
+	return ExitStatus::bad_rerr;
+    }
+#endif
+
+    /* Cauchy principal value with real negative y */
+    if ( argcheck::too_small(std::imag(y)) &&
+        ( std::real(y) < 0.0 ) )
+    {
+	T tmpres;
+	/* Ref[2], Eq. 2.14 or Eq. (21) in the arXiv preprint */
+	status = ellint_carlson::rc(x - y, -y, rerr, tmpres);
+	if ( is_horrible(status) )
+	{
+	    res = typing::nan<T>();
+	} else {
+	    res = tmpres * std::sqrt(x / (x - y));
+	}
+	return status;
+    } else if ( argcheck::too_small(y) || !argcheck::ph_good(x) ) {
+	res = typing::nan<T>();
+	return ExitStatus::bad_args;
+    } else if ( argcheck::isinf(x) || argcheck::isinf(y) ) {
+	res = T(0.0);
+	return ExitStatus::success;
+    }
+
+    T Am = (x + (RT)2.0 * y) / (RT)3.0;
+    RT fterm = std::abs(Am - x) / arithmetic::ocrt(3.0 * rerr);
+
+    T xm = x;
+    T ym = y;
+    T sm = y - Am;
+
+    unsigned int m = 0;  /* loop variable */
+    while ( std::max(std::abs(xm - ym), fterm) >= std::abs(Am) )
+    {
+	if ( m > config::max_iter )
+	{
+	    status = ExitStatus::n_iter;
+	    break;
+	}
+
+	T lam = (RT)2.0 * std::sqrt(xm) * std::sqrt(ym) + ym;
+        Am = (Am + lam) * (RT)0.25;
+        xm = (xm + lam) * (RT)0.25;
+        ym = (ym + lam) * (RT)0.25;
+	sm *= (RT)0.25;
+	fterm *= (RT)0.25;
+
+	++m;
+    }
+    Am = (xm + ym + ym) / (RT)3.0;
+    sm /= Am;
+    /* Eq. (20) of Ref[2] */
+    res = arithmetic::comp_horner(sm, constants::RC_C) /
+          (std::sqrt(Am) * (RT)(constants::RC_C[0]));
+    return status;
+}
+
+
+}  /* namespace ellint_carlson */
+#endif /* ELLINT_RC_GENERIC_GUARD */

--- a/include/xsf/ellint_carlson/_rd.hh
+++ b/include/xsf/ellint_carlson/_rd.hh
@@ -1,0 +1,169 @@
+#ifndef ELLINT_RD_GENERIC_GUARD
+#define ELLINT_RD_GENERIC_GUARD
+
+
+#include <algorithm>
+#include <cmath>
+#include <complex>
+#include "ellint_typing.hh"
+#include "ellint_argcheck.hh"
+#include "ellint_common.hh"
+#include "ellint_carlson.hh"
+
+
+/* References
+ * [1] B. C. Carlson, ed., Chapter 19 in "Digital Library of Mathematical
+ *     Functions," NIST, US Dept. of Commerce.
+ *     https://dlmf.nist.gov/19.16.E5
+ * [2] B. C. Carlson, "Numerical computation of real or complex elliptic
+ *     integrals," Numer. Algorithm, vol. 10, no. 1, pp. 13-26, 1995.
+ *     https://arxiv.org/abs/math/9409227
+ *     https://doi.org/10.1007/BF02198293
+ */
+
+
+namespace ellint_carlson {
+
+template<typename T>
+ExitStatus
+rd(const T& x, const T& y, const T& z, const double& rerr, T& res)
+{
+    typedef typing::decplx_t<T> RT;
+
+    T cct1[6];
+    T cct2[6];
+
+    ExitStatus status = ExitStatus::success;
+#ifndef ELLINT_NO_VALIDATE_RELATIVE_ERROR_BOUND
+    if ( argcheck::invalid_rerr(rerr, 1.0e-4) )
+    {
+	res = typing::nan<T>();
+	return ExitStatus::bad_rerr;
+    }
+#endif
+
+    if ( !( argcheck::ph_good(x) && argcheck::ph_good(y) &&
+            argcheck::ph_good(z) ) )
+    {
+	res = typing::nan<T>();
+	return ExitStatus::bad_args;
+    }
+
+    if ( argcheck::too_small(z) )
+    {
+	res = typing::huge<T>();
+	return ExitStatus::singular;
+    }
+
+    if ( argcheck::isinf(x) || argcheck::isinf(y) || argcheck::isinf(z) )
+    {
+	res = T(0.0);
+	return status;
+    }
+
+    if ( argcheck::too_small(x) && argcheck::too_small(y) )
+    {
+	res = typing::huge<T>();
+	return ExitStatus::singular;
+    }
+
+    cct1[0] = x;
+    cct1[1] = y;
+    cct1[2] = z;
+    cct1[3] = z;
+    cct1[4] = z;
+    T Am = arithmetic::nsum2(cct1, 5) / (RT)5.0;
+    T xm = x;
+    T ym = y;
+    T zm = z;
+    T xxm = Am - xm;
+    T yym = Am - ym;
+    RT fterm = std::max({std::abs(xxm), std::abs(yym), std::abs(Am - z)}) /
+               arithmetic::ocrt(rerr / 5.0);
+    RT d4m(1.0);
+    T adt(0.0), ade(0.0);
+
+    unsigned int m = 0;
+    RT aAm;
+    T tmp;
+    while ( (aAm = std::abs(Am)) <= fterm ||
+	    aAm <= std::max({std::abs(xxm), std::abs(yym), std::abs(Am - zm)}) )
+    {
+	if ( m > config::max_iter )
+	{
+	    status = ExitStatus::n_iter;
+	    break;
+	}
+	cct1[0] = cct2[2] = std::sqrt(xm);
+	cct1[1] = cct2[0] = std::sqrt(ym);
+	cct1[2] = cct2[1] = std::sqrt(zm);
+	T lam = arithmetic::ndot2(cct1, cct2, 3);
+
+	/* The cumulative sum term in Ref. [2], Eq. (41), implemented by
+	 * accumulating the summation term into adt with compensation
+	 * term ade */
+	tmp = d4m / (cct1[2] * (zm + lam));
+	arithmetic::sum2_acc(tmp, adt, ade);
+
+        Am = (Am + lam) * (RT)0.25;
+        xm = (xm + lam) * (RT)0.25;
+        ym = (ym + lam) * (RT)0.25;
+        zm = (zm + lam) * (RT)0.25;
+        xxm *= (RT)0.25;
+        yym *= (RT)0.25;
+        fterm *= (RT)0.25;
+        d4m *= (RT)0.25;
+
+        ++m;
+    }
+    /* Burn some extra cycles re-balancing Am as the "true" centroid */
+    cct1[0] = xm;
+    cct1[1] = ym;
+    cct1[2] = zm;
+    cct1[3] = zm;
+    cct1[4] = zm;
+    Am = arithmetic::nsum2(cct1, 5) / (RT)5.0;
+    xxm /= Am;
+    yym /= Am;
+    T zzm = (xxm + yym) / (RT)(-3.0);
+    /* Prepare the "elementary" terms E_n as in Eqs. (39-40) in Ref. [2] */
+    T xy = xxm * yym;
+    T zz2 = zzm * zzm;
+    T e2 = xy - zz2 * (RT)6.0;
+    T e3 = (xy * (RT)3.0 - zz2 * (RT)8.0) * zzm;
+    T e4 = (xy - zz2) * zz2 * (RT)3.0;
+    T e5 = xy * zz2 * zzm;
+    T t = std::sqrt(Am);
+    tmp = d4m / (t * t * t);
+    /* Evaluate the 7th-degree expansion using the E_n terms, following
+     * Eq. 19.36.2 of [1], https://dlmf.nist.gov/19.36#E2
+     * The order of expansion is higher than that in Eq. (41) of Ref. [2]. */
+    cct1[0] = arithmetic::comp_horner(e2, constants::RDJ_C1);
+    cct1[1] = arithmetic::comp_horner(e3, constants::RDJ_C2);
+    cct1[2] = arithmetic::comp_horner(e2, constants::RDJ_C3);
+    cct1[3] = arithmetic::comp_horner(e2, constants::RDJ_C4);
+    cct1[4] = arithmetic::comp_horner(e2, constants::RDJ_C5);
+    cct1[5] = e3 * (RT)(constants::RDJ_C5[1]);
+
+    cct2[0] = (T)1.0;
+    cct2[1] = (T)1.0;
+    cct2[2] = e3;
+    cct2[3] = e4;
+    cct2[4] = e5;
+    cct2[5] = e4;
+    t = arithmetic::dot2(cct1, cct2) / (RT)(constants::RDJ_DENOM) + (T)1.0;
+
+    /* Combine in to final result using compensated dot. See Eq. (41) of Ref.
+     * [2]. */
+    cct1[0] = tmp;
+    cct1[1] = (T)3.0;
+    cct1[2] = (T)3.0;
+    cct2[0] = t;
+    cct2[1] = adt;
+    cct2[2] = ade;
+    res = arithmetic::ndot2(cct1, cct2, 3);
+    return status;
+}
+
+}  /* namespace ellint_carlson */
+#endif /* ELLINT_RD_GENERIC_GUARD */

--- a/include/xsf/ellint_carlson/_rf.hh
+++ b/include/xsf/ellint_carlson/_rf.hh
@@ -1,0 +1,180 @@
+#ifndef ELLINT_RF_GENERIC_GUARD
+#define ELLINT_RF_GENERIC_GUARD
+
+
+#include <algorithm>
+#include <iterator>
+#include <cmath>
+#include <complex>
+#include "ellint_typing.hh"
+#include "ellint_argcheck.hh"
+#include "ellint_common.hh"
+#include "ellint_carlson.hh"
+
+
+/* References
+ * [1] B. C. Carlson, ed., Chapter 19 in "Digital Library of Mathematical
+ *     Functions," NIST, US Dept. of Commerce.
+ *     https://dlmf.nist.gov/19.16.E1
+ * [2] B. C. Carlson, "Numerical computation of real or complex elliptic
+ *     integrals," Numer. Algorithm, vol. 10, no. 1, pp. 13-26, 1995.
+ *     https://arxiv.org/abs/math/9409227
+ *     https://doi.org/10.1007/BF02198293
+ */
+
+
+namespace ellint_carlson {
+
+template<typename T>
+inline void agm_update(T& x, T& y)
+{
+    typedef typing::decplx_t<T> RT;
+
+    T xnext = (x + y) * (RT)0.5;
+    T ynext = std::sqrt(x * y);
+
+    x = xnext;
+    y = ynext;
+}
+
+template<typename T>
+ExitStatus
+rf0(const T& x, const T& y, const double& rerr, T& res)
+{
+    typedef typing::decplx_t<T> RT;
+    ExitStatus status = ExitStatus::success;
+    double rsq = 2.0 * std::sqrt(rerr);
+
+    T xm = std::sqrt(x);
+    T ym = std::sqrt(y);
+    unsigned int m = 0;
+    while ( std::abs(xm - ym) >= rsq * std::fmin(std::abs(xm), std::abs(ym)) )
+    {
+	if ( m > config::max_iter )
+	{
+	    status = ExitStatus::n_iter;
+	    break;
+	}
+
+	agm_update(xm, ym);
+
+	++m;
+    }
+
+    res = (RT)(constants::pi) / (xm + ym);
+    return status;
+}
+
+
+template<typename T>
+ExitStatus
+rf(const T& x, const T& y, const T& z, const double& rerr, T& res)
+{
+    typedef typing::decplx_t<T> RT;
+
+    T cct1[3];
+    T cct2[3];
+
+    ExitStatus status = ExitStatus::success;
+#ifndef ELLINT_NO_VALIDATE_RELATIVE_ERROR_BOUND
+    if ( argcheck::invalid_rerr(rerr, 3.0e-4) )
+    {
+	res = typing::nan<T>();
+	return ExitStatus::bad_rerr;
+    }
+#endif
+
+    if ( argcheck::ph_good(x) && argcheck::ph_good(y) && argcheck::ph_good(z) )
+    {
+	if ( argcheck::isinf(x) || argcheck::isinf(y) || argcheck::isinf(z) )
+	{
+	    res = T(0.0);
+	    return ExitStatus::success;
+	}
+    } else {
+	res = typing::nan<T>();
+	return ExitStatus::bad_args;
+    }
+
+    cct1[0] = T(x);
+    cct1[1] = T(y);
+    cct1[2] = T(z);
+    std::sort(std::begin(cct1), std::end(cct1), util::abscmp<T>);
+    T xm = cct1[0];
+    T ym = cct1[1];
+    T zm = cct1[2];
+    if ( argcheck::too_small(xm) )
+    {
+	if ( argcheck::too_small(ym) )
+	{
+	    status = ExitStatus::singular;
+	    res = typing::huge<T>();
+	    return status;
+	} else {
+	    T tmpres;
+	    status = rf0(ym, zm, rerr * (RT)0.5, tmpres);
+	    /* Correction for non-zero x, see Eq. 19.27.3 in
+	     * https://dlmf.nist.gov/19.27.E3 */
+	    res = tmpres - std::sqrt(xm / (ym * zm));
+	    return status;
+	}
+    }
+
+    T Am = arithmetic::sum2(cct1) / (RT)3.0;
+    T xxm = Am - xm;
+    T yym = Am - ym;
+    RT fterm = std::abs(std::max({xxm, yym, Am - zm}, util::abscmp<T>)) /
+               arithmetic::ocrt(3.0 * rerr);
+    unsigned int m = 0;
+    RT aAm;
+    while ( (aAm = std::abs(Am)) <= fterm ||
+	    aAm <= std::abs(std::max({xxm, yym, Am - zm}, util::abscmp<T>)) )
+    {
+	if ( m > config::max_iter )
+	{
+	    status = ExitStatus::n_iter;
+	    break;
+	}
+	cct1[0] = cct2[2] = std::sqrt(xm);
+	cct1[1] = cct2[0] = std::sqrt(ym);
+	cct1[2] = cct2[1] = std::sqrt(zm);
+	T lam = arithmetic::dot2(cct1, cct2);
+        Am = (Am + lam) * (RT)0.25;
+        xm = (xm + lam) * (RT)0.25;
+        ym = (ym + lam) * (RT)0.25;
+        zm = (zm + lam) * (RT)0.25;
+        xxm *= (RT)0.25;
+        yym *= (RT)0.25;
+        fterm *= (RT)0.25;
+
+        ++m;
+    }
+    /* Burn some extra cycles re-balancing Am as the "true" centroid. */
+    cct1[0] = xm;
+    cct1[1] = ym;
+    cct1[2] = zm;
+    Am = arithmetic::sum2(cct1) / (RT)3.0;
+    xxm /= Am;
+    yym /= Am;
+    /* Prepare the E_2 and E_3 terms used in the expansion */
+    T zzm = -(xxm + yym);
+    T e2 = xxm * yym - zzm * zzm;
+    T e3 = xxm * (yym * zzm);
+    /* Evaluate the 7th-degree expansion using the E_2 and E3 terms, following
+     * Eq. 19.36.1 of [1], https://dlmf.nist.gov/19.36.E1
+     * The order of expansion is higher than that in Eq. (14) of Ref. [2]. */
+    T s = arithmetic::comp_horner(e2, constants::RF_C1);
+    s += e3 * (arithmetic::comp_horner(e2, constants::RF_C2) +
+               e3 * (RT)(constants::RF_c33));
+    s /= (RT)(constants::RF_DENOM);
+    s += (RT)1.0;
+
+    res = s / std::sqrt(Am);
+    return status;
+}
+
+
+}  /* namespace ellint_carlson */
+
+
+#endif /* ELLINT_RF_GENERIC_GUARD */

--- a/include/xsf/ellint_carlson/_rg.hh
+++ b/include/xsf/ellint_carlson/_rg.hh
@@ -1,0 +1,196 @@
+#ifndef ELLINT_RG_GENERIC_GUARD
+#define ELLINT_RG_GENERIC_GUARD
+
+
+#include <algorithm>
+#include <iterator>
+#include <complex>
+#include "ellint_typing.hh"
+#include "ellint_argcheck.hh"
+#include "ellint_common.hh"
+#include "ellint_carlson.hh"
+
+
+#define CHECK_STATUS_OR_FAIL()	\
+do {	\
+    if ( status_tmp != ExitStatus::success )	\
+    {	\
+	status = status_tmp;	\
+    }	\
+    if ( is_horrible(status) )	\
+    {	\
+	res = typing::nan<T>();	\
+	return status;	\
+    }	\
+} while ( 0 )
+
+
+/* References
+ * [1] B. C. Carlson, "Numerical computation of real or complex elliptic
+ *     integrals," Numer. Algorithm, vol. 10, no. 1, pp. 13-26, 1995.
+ *     https://arxiv.org/abs/math/9409227
+ *     https://doi.org/10.1007/BF02198293
+ * [2] B. C. Carlson, ed., Chapter 19 in "Digital Library of Mathematical
+ *     Functions," NIST, US Dept. of Commerce.
+ *     https://dlmf.nist.gov/19.16.E1
+ *     https://dlmf.nist.gov/19.20.ii
+ */
+
+
+/* Forward declaration */
+/* See the file _rf.hh for the definition of agm_update */
+namespace ellint_carlson {
+    template<typename T>
+    inline void agm_update(T& x, T& y);
+}
+
+
+namespace ellint_carlson {
+
+namespace arithmetic { namespace aux {
+
+template<typename T>
+inline typing::real_only<T, void>
+rg_dot2_acc(const T& fac, const T& term, T& acc, T& cor)
+{
+    fdot2_acc(fac, term, acc, cor);
+}
+
+template<typename CT>
+inline typing::cplx_only<CT, void>
+rg_dot2_acc(const typing::decplx_t<CT>& fac, const CT& term, CT& acc, CT& cor)
+{
+    typedef typing::decplx_t<CT> RT;
+    RT ar, cr, ai, ci;
+    CT p, q;
+    eft_prod(fac, term.real(), ar, cr);
+    eft_prod(fac, term.imag(), ai, ci);
+    eft_sum(acc, CT{ar, ai}, p, q);
+    acc = p;
+    cor += q + CT{cr, ci};
+}
+
+}}  /* namespace ellint_carlson::arithmetic::aux */
+
+
+template<typename T>
+ExitStatus
+rg0(const T& x, const T& y, const double& rerr, T& res)
+{
+    typedef typing::decplx_t<T> RT;
+    ExitStatus status = ExitStatus::success;
+    double rsq = 2.0 * std::sqrt(rerr);
+    RT fac(0.25);
+
+    T xm = std::sqrt(x);
+    T ym = std::sqrt(y);
+    T dm = (xm + ym) * (RT)0.5;
+    T sum = -dm * dm;
+    T cor(0.0);
+    dm = xm - ym;
+    unsigned int m = 0;
+    while ( std::abs(dm) >= rsq * std::fmin(std::abs(xm), std::abs(ym)) )
+    {
+
+	if ( m > config::max_iter )
+	{
+	    status = ExitStatus::n_iter;
+	    break;
+	}
+
+	agm_update(xm, ym);
+	/* Ref[1], Eq. 2.39 or Eq. (46) in the arXiv preprint */
+	fac *= (RT)2.0;
+	dm = xm - ym;
+	arithmetic::aux::rg_dot2_acc(fac, dm * dm, sum, cor);
+
+	++m;
+    }
+
+    res = (RT)(constants::pi) / (xm + ym);
+    res *= -(RT)0.5 * (sum + cor);
+    return status;
+}
+
+
+template<typename T>
+ExitStatus
+rg(const T& x, const T& y, const T& z, const double& rerr, T& res)
+{
+    typedef typing::decplx_t<T> RT;
+
+    ExitStatus status = ExitStatus::success;
+#ifndef ELLINT_NO_VALIDATE_RELATIVE_ERROR_BOUND
+    if ( argcheck::invalid_rerr(rerr, 1.0e-4) )
+    {
+	res = typing::nan<T>();
+	return ExitStatus::bad_rerr;
+    }
+#endif
+
+    T cct[3] = {x, y, z};
+    std::sort(std::begin(cct), std::end(cct), util::abscmp<T>);
+
+    if ( (argcheck::isinf(cct[0]) || argcheck::isinf(cct[1]) ||
+          argcheck::isinf(cct[2])) &&
+	 argcheck::ph_good(cct[0]) && argcheck::ph_good(cct[1]) &&
+	 argcheck::ph_good(cct[2]) )
+    {
+	res = typing::huge<T>();
+	return ExitStatus::singular;
+    }
+
+    if ( argcheck::too_small(cct[0]) )
+    {
+	if ( argcheck::too_small(cct[1]) )
+	{
+	    /* Special case -- also covers the case of z ~ zero. */
+	    res = std::sqrt(cct[2]) * (RT)0.5;
+	    return status;
+	} else {
+	    /* Special case -- use the AGM algorithm. */
+	    status = rg0(cct[1], cct[2], rerr, res);
+	    return status;
+	}
+    }
+
+    /* Ref[2], Eq. 19.21.11 (second identity) <https://dlmf.nist.gov/19.21.E11>
+     * i.e. 6R_G() = sum of [ x * (y + z) * R_D() ] over cyclic permutations of
+     * (x, y, z).
+     * This cyclic form is manifestly symmetric and is preferred over
+     * Eq. 19.21.10 ibid.
+     * Here we put the three R_D terms in the buffer cct2, and the
+     * x * (y + z) = dot({x, x}, {y, z}) terms in cct1. */
+    T cct1[3];
+    T cct2[3];
+
+    ExitStatus status_tmp;
+
+    status_tmp = rd(y, z, x, rerr, cct2[0]);
+    CHECK_STATUS_OR_FAIL();
+    status_tmp = rd(z, x, y, rerr, cct2[1]);
+    CHECK_STATUS_OR_FAIL();
+    status_tmp = rd(x, y, z, rerr, cct2[2]);
+    CHECK_STATUS_OR_FAIL();
+
+    /* Fill the cct1 buffer via the intermediate buffers tm1, tm2
+     * that are dotted together (using the compensation algorithm). */
+    T tm1[2] = {x, x};
+    T tm2[2] = {y, z};
+    cct1[0] = arithmetic::dot2(tm1, tm2);
+    tm1[0] = tm1[1] = y;
+    tm2[0] = x;
+    cct1[1] = arithmetic::dot2(tm1, tm2);
+    tm1[0] = tm1[1] = z;
+    tm2[1] = y;
+    cct1[2] = arithmetic::dot2(tm1, tm2);
+
+    res = arithmetic::dot2(cct1, cct2) / (RT)6.0;
+    return status;
+}
+
+
+}  /* namespace ellint_carlson */
+
+
+#endif  /* ELLINT_RG_GENERIC_GUARD */

--- a/include/xsf/ellint_carlson/_rj.hh
+++ b/include/xsf/ellint_carlson/_rj.hh
@@ -1,0 +1,703 @@
+#ifndef ELLINT_RJ_GENERIC_GUARD
+#define ELLINT_RJ_GENERIC_GUARD
+
+
+#include <algorithm>
+#include <iterator>
+#include <complex>
+#include <cmath>
+#include <cstring>
+#include "ellint_typing.hh"
+#include "ellint_argcheck.hh"
+#include "ellint_common.hh"
+#include "ellint_carlson.hh"
+
+
+/* References
+ * [1] B. C. Carlson, "Numerical computation of real or complex elliptic
+ *     integrals," Numer. Algorithm, vol. 10, no. 1, pp. 13-26, 1995.
+ *     https://arxiv.org/abs/math/9409227
+ *     https://doi.org/10.1007/BF02198293
+ * [2] B. C. Carlson, ed., Chapter 19 in "Digital Library of Mathematical
+ *     Functions," NIST, US Dept. of Commerce.
+ *     https://dlmf.nist.gov/19.20.iii
+ * [3] B. C. Carlson, J. FitzSimmons, "Reduction Theorems for Elliptic
+ *     Integrands with the Square Root of Two Quadratic Factors," J.
+ *     Comput. Appl. Math., vol. 118, nos. 1-2, pp. 71-85, 2000.
+ *     https://doi.org/10.1016/S0377-0427(00)00282-X
+ * [4] F. Johansson, "Numerical Evaluation of Elliptic Functions, Elliptic
+ *     Integrals and Modular Forms," in J. Blumlein, C. Schneider, P.
+ *     Paule, eds., "Elliptic Integrals, Elliptic Functions and Modular
+ *     Forms in Quantum Field Theory," pp. 269-293, 2019 (Cham,
+ *     Switzerland: Springer Nature Switzerland)
+ *     https://arxiv.org/abs/1806.06725
+ *     https://doi.org/10.1007/978-3-030-04480-0
+ * [5] B. C. Carlson, J. L. Gustafson, "Asymptotic Approximations for
+ *     Symmetric Elliptic Integrals," SIAM J. Math. Anls., vol. 25, no. 2,
+ *     pp. 288-303, 1994.
+ *     https://arxiv.org/abs/math/9310223
+ *     https://doi.org/10.1137/S0036141092228477
+ * [6] J. L. Gustafson, "Asymptotic Formulas for Elliptic Integrals", Doctoral
+ *     dissertataion, Dept. of Mathematics, Iowa State University, 1982
+ *     http://johngustafson.net/pubs/pub03/JGDissertation.pdf
+ */
+
+
+/* Forward declaration */
+namespace ellint_carlson
+{
+template<typename T>
+ExitStatus
+rj(const T& x, const T& y, const T& z, const T& p, const double& rerr, T& res,
+   bool noasymp = false);
+
+
+template<typename T>
+ExitStatus
+rc(const T& x, const T& y, const double& rerr, T& res);
+
+
+template<typename T>
+ExitStatus
+rg(const T& x, const T& y, const T& z, const double& rerr, T& res);
+}
+
+
+#define ELLINT_RJ_CALC()	\
+do { 	\
+    prm = std::sqrt(pm);	\
+    cct1[0] = cct2[1] = std::sqrt(xm);	\
+    cct1[1] = cct2[2] = std::sqrt(ym);	\
+    cct1[2] = cct2[0] = std::sqrt(zm);	\
+    lam = arithmetic::ndot2(cct1, cct2, 3);	\
+    dm = (prm + cct1[0]) * (prm + cct1[1]) * (prm + cct1[2]);\
+} while ( 0 )
+
+#define ELLINT_RJ_UPDT()	\
+do {	\
+    Am = (Am + lam) * (RT)0.25;	\
+    xm = (xm + lam) * (RT)0.25;	\
+    ym = (ym + lam) * (RT)0.25;	\
+    zm = (zm + lam) * (RT)0.25;	\
+    pm = (pm + lam) * (RT)0.25;	\
+    xxm = xxm * (RT)0.25;	\
+    yym = yym * (RT)0.25;	\
+    zzm = zzm * (RT)0.25;	\
+    d4m *= (RT)0.25;	\
+    fterm *= (RT)0.25;	\
+} while ( 0 )
+
+
+
+namespace ellint_carlson { namespace rjimpl
+{
+
+template<typename T>
+inline constexpr typing::real_only<T, bool>
+asymp_zero(const T& r)
+{
+    return ( (0.0 < r) && (r <= config::asym_zero_ul) );
+}
+
+template<typename T>
+inline constexpr typing::real_only<T, bool>
+abs_close_zero(const T& r)
+{
+    return ( (0.0 < r) && (r <= config::asym_close_ul) );
+}
+
+
+enum class AsymFlag
+{
+    nothing,
+    hugep,	/* x, y, z << p */
+    tinyp,	/* p << geom. mean of x, y, z */
+    hugey,	/* max(x, p) << min(y, z) == y */
+    tinyx,	/* x << min(y, z, p) == min(y, p) */
+    tinyy,	/* max(x, y) == y << min(z, p) */
+    hugez	/* max(x, y, p) == max(y, p) << z */
+};
+
+
+struct ArgCases
+{
+    bool maybe_asymp;	/* might be good for an asympt. case */
+    bool retry_caupv;	/* should use Cauchy principal value */
+    bool good_infinity;	/* the "good" kind of directed infinity */
+    bool hit_pole;	/* singular */
+};
+
+
+/* Comparison function by the real part. */
+template<typename T>
+inline bool rcmp(const T& a, const T& b)
+{
+    return ( std::real(a) < std::real(b) );
+}
+
+
+/* Check whether the input arguments for RJ are out of domain, while set
+ * corresponding flags in the class(ification) variable.
+ *
+ * NOTE: x, y, z must be in-order by real parts.
+ */
+template<typename T>
+bool
+good_args(const T& x, const T& y, const T& z, const T& p,
+          ArgCases& classify)
+{
+    typedef typing::decplx_t<T> RT;
+
+    if ( (classify.hit_pole = ( argcheck::too_small(x) &&
+                                argcheck::too_small(y) &&
+			        argcheck::ph_good(z) &&
+			        !argcheck::too_small(p) )) )
+    {
+	return false;
+    }
+    if ( (classify.good_infinity = ( (argcheck::isinf(x) ||
+				      argcheck::isinf(y) ||
+				      argcheck::isinf(z) ||
+				      argcheck::isinf(p)) &&
+                                     (argcheck::ph_good(x) &&
+				      argcheck::ph_good(y) &&
+				      argcheck::ph_good(z)) )) )
+    {
+	return false;
+    }
+    RT xr = std::real(x);
+    RT xi = std::imag(x);
+
+    RT yr = std::real(y);
+    RT yi = std::imag(y);
+
+    RT zi = std::imag(z);
+
+    RT pr = std::real(p);
+    RT pi = std::imag(p);
+
+    /* In the text above Eq. 2.26 of Ref[1]:
+     * "If x, y, z are real and nonnegative, at most one of them is 0, and the
+     * fourth variable of RJ is negative, the Cauchy principal value ..." */
+    bool xyzreal_nonneg_atmost1z = ( argcheck::too_small(xi) &&
+                                     argcheck::too_small(yi) &&
+                                     argcheck::too_small(zi) &&
+				     (xr >= 0.0) && (yr > 0.0) );
+    if ( argcheck::too_small(pi) && xyzreal_nonneg_atmost1z )
+    {
+	if ( (classify.retry_caupv = ( pr < 0.0 )) )
+	{
+	    return false;
+	}
+	/* Ref[2], Sec. 19.27 <https://dlmf.nist.gov/19.27.iv>:
+	 * "Assume x, y, and z are real and nonnegative, at most one of them is
+	 * 0, and p > 0" */
+	if ( (classify.maybe_asymp = ( pr > 0.0 )) )
+	{
+	    return true;
+	}
+    }
+    /* Ref[1], in text above Eq. 2.17 ("Algorithm for RJ")
+     * "Let x, y, z have nonnegative real part and at most one of them* be
+     * 0, while Re p > 0."
+     *     * By "them", Carlson seems to have meant the numbers x, y, z
+     *       themselves, rather than their "real parts". */
+    bool x0 = argcheck::too_small(x);
+    bool y0 = argcheck::too_small(y);
+    bool z0 = argcheck::too_small(z);
+    if ( ( pr > 0.0 ) && ( xr >= 0.0 ) && !((y0 && (x0 || z0)) || (x0 && z0)) )
+    {
+	return true;
+    }
+    /* "Alternatively, if p != 0 and |ph p| < pi ..." */
+    if ( (!argcheck::too_small(p)) && argcheck::ph_good(p) )
+    {
+	/* "... either let x, y, z be real and nonnegative and at most one of
+	 * them be 0, ..." */
+	unsigned char flag = 0u;
+	if (  xyzreal_nonneg_atmost1z )
+	{
+	    flag ^= 1u;
+	}
+	/* "... or else let two of the variables x, y, z be nonzero and
+	 * conjugate complex with phase less in magnitude than pi and the
+	 * third variable be real and nonnegative." */
+	if ( argcheck::r1conj2(x, y, z) ||
+	     argcheck::r1conj2(y, z, x) ||
+	     argcheck::r1conj2(z, x, y) )
+	{
+	    flag ^= 1u;
+	}
+	return (bool)flag;
+    }
+    return false;
+}
+
+
+/* Cauchy principal value dispatcher
+ * Ref[1], Eq. 2.26 */
+template<typename T, typename Tres>
+ExitStatus
+rj_cpv_dispatch(const T& x, const T& y, const T& z, const T& p,
+		const double& rerr, Tres& res)
+{
+    /* Retry with principal value evaluation, valid for reals. */
+    ExitStatus status, status_tmp;
+    T xct1[4] = {x, y, -p, z};
+    T xct2[4];
+
+    T xy = x * y;
+    xct2[3] = (T)1.0 - p / z;
+    T pn = (arithmetic::nsum2(xct1, 3) - xy / xct1[3]) / xct2[3];
+
+    status = ExitStatus::success;
+    status_tmp = rj(x, y, z, pn, rerr, xct2[0]);
+    if ( is_horrible(status_tmp) )
+    {
+	return status_tmp;
+    } else if ( is_troublesome(status_tmp) ) {
+	status = status_tmp;
+    }
+
+    status_tmp = rf(x, y, z, rerr, xct2[1]);
+    if ( is_horrible(status_tmp) )
+    {
+	return status_tmp;
+    } else if ( is_troublesome(status_tmp) ) {
+	status = status_tmp;
+    }
+
+    T pq = pn * xct1[2];
+    T xypq = xy + pq;
+    status_tmp = rc(xypq, pq, rerr, xct2[2]);
+    if ( is_horrible(status_tmp) )
+    {
+	return status_tmp;
+    } else if ( is_troublesome(status_tmp) ) {
+	status = status_tmp;
+    }
+    xct1[0] = pn - z;
+    xct1[1] = -(T)3.0;
+    xct1[2] = (T)3.0 * std::sqrt(xy * z / xypq);
+
+    T tmpres = arithmetic::ndot2(xct1, xct2, 3);
+    tmpres /= (z - p);
+    res = (Tres)tmpres;
+
+    return status;
+}
+
+
+/* The notation follows the one used in the DLMF:
+ * https://dlmf.nist.gov/19.27.i
+ */
+template<typename T>
+struct AsymConfig
+{
+    T a;
+    T b;
+    T c;
+    T f;
+    T g;
+    T h;
+};
+
+template<typename T>
+typing::real_only<T, AsymFlag>
+rj_asym_conf(const T& x, const T& y, const T& z, const T& p,
+             AsymConfig<T>& conf)
+{
+    T t;
+
+    t = z / p;
+    if ( asymp_zero(t) )
+    {
+	conf.c = (x + y + z) / 3.0;
+	return AsymFlag::hugep;
+    }
+
+    /* this bound is sharp. RJ in this case behaves with logarithmic
+     * singularity as p -> +0 */
+    if ( abs_close_zero(p) || ( (x != 0.0) && asymp_zero(p / x) ) )
+    {
+	conf.f = std::sqrt(x * y * z);
+	return AsymFlag::tinyp;
+    }
+
+    /* XXX until RJ(0, y, z, p) is implemented, this is useless */
+    /*
+    t = (*x) / fmin((*y), (*p));
+    if ( ( 0.0 < (*x) && (*x) <= 1e-26 ) || ASYMP_ZERO(t) )
+    {
+	*h = sqrt((*y) * (*z));
+	if ( (*h) / (*p) + 0.5 * ((*y) + (*z)) / (*h) <= sqrt((*h) / (*x)) )
+	{
+	    return asymp_tinyx;
+	}
+    }
+    */
+
+    t = y / std::fmin(z, p);
+    if ( ( (0.0 < y) && (y <= 1e-26) ) || asymp_zero(t) )
+    {
+	/* bound fairly sharp even if p is large */
+	conf.a = (T)0.5 * (x + y);
+	conf.g = std::sqrt(x * y);
+	if ( (conf.a / z + conf.a / p) * std::abs(std::log(p / conf.a)) <=
+	     1.0 )
+	{
+	    return AsymFlag::tinyy;
+	}
+    }
+
+    if ( (x != 0.0) && asymp_zero(std::fmax(z, p) / x) )
+    {
+	/* bound might not be sharp if x + 2p much larger than (yz) ** 2,
+	 * but this is unlikely to be true anyway. */
+	return AsymFlag::hugey;
+    }
+
+    if ( (z != 0.0) && asymp_zero(std::fmax(y, p) / z) )
+    {
+	conf.b = 0.5 * (x + y);
+	conf.h = std::sqrt(x * y);
+	/* when bounds are sharp */
+	if ( std::abs(std::log(z / (conf.b + conf.h))) <= std::sqrt(z) )
+	{
+	    return AsymFlag::hugez;
+	}
+    }
+
+    return AsymFlag::nothing;
+}
+
+
+/* Prevent division by zero due to underflow in atan(sqrt(z)) / sqrt(z) and
+ * square root of negative number in the real context. */
+template<typename T>
+inline typing::cplx_only<T, T>
+safe_atan_sqrt_div(T z)
+{
+    if ( argcheck::too_small(z) )
+    {
+	return T(1.0);
+    }
+    T s = std::sqrt(z);
+    return std::atan(s) / s;
+}
+
+template<typename T>
+inline typing::real_only<T, T>
+safe_atan_sqrt_div(T x)
+{
+    if ( argcheck::too_small(x) )
+    {
+	return T(1.0);
+    }
+    T s;
+    if ( x < 0.0 )
+    {
+	s = std::sqrt(-x);
+	return std::atanh(s) / s;
+    }
+    s = std::sqrt(x);
+    return std::atan(s) / s;
+}
+
+
+}  /* namespace ellint_carlson::rjimpl */
+
+template<typename T>
+ExitStatus
+rj(const T& x, const T& y, const T& z, const T& p, const double& rerr, T& res,
+   bool noasymp)
+{
+    typedef typing::decplx_t<T> RT;
+
+    rjimpl::ArgCases classify;
+    T cct1[6];
+    T cct2[6];
+
+    ExitStatus status = ExitStatus::success;
+#ifndef ELLINT_NO_VALIDATE_RELATIVE_ERROR_BOUND
+    if ( argcheck::invalid_rerr(rerr, 1.0e-4) )
+    {
+	res = typing::nan<T>();
+	return ExitStatus::bad_rerr;
+    }
+#endif
+
+    /* Put the symmetric arguments in the order of real parts. */
+    cct1[0] = x;
+    cct1[1] = y;
+    cct1[2] = z;
+    auto b = std::begin(cct1);
+    std::sort(b, b + 3, rjimpl::rcmp<T>);
+    T xm = cct1[0];
+    T ym = cct1[1];
+    T zm = cct1[2];
+    std::memset(&classify, 0, sizeof classify);
+    if ( !rjimpl::good_args(xm, ym, zm, p, classify) )
+    {
+	if ( classify.good_infinity )
+	{
+	    res = (T)0.0;
+	    return ExitStatus::success;
+	}
+
+	if ( classify.retry_caupv )
+	{
+	    /* Retry with principal value evaluation, valid for reals. */
+	    RT tmpres;
+	    RT xr(std::real(xm));
+	    RT yr(std::real(ym));
+	    RT zr(std::real(zm));
+	    RT pr(std::real(p));
+	    status = rjimpl::rj_cpv_dispatch(xr, yr, zr, pr, rerr, tmpres);
+	    if ( is_horrible(status) )
+	    {
+		res = typing::nan<T>();
+	    } else {
+		res = T(tmpres);
+	    }
+	    return status;
+	} else if ( classify.hit_pole ) {
+	    res = typing::huge<T>();
+	    return ExitStatus::singular;
+	} else {
+	    res = typing::nan<T>();
+	    return ExitStatus::bad_args;
+	}
+    }
+
+    if ( classify.maybe_asymp && !noasymp )
+    {
+	/* might be dealt with by asymptotic expansion of real-arg RJ */
+	/* Initialize tmpres to avoid the compiler warning */
+	/* "‘tmpres’ may be used uninitialized"            */
+	RT tmpres = 0;
+	rjimpl::AsymConfig<RT> config;
+	RT xr(std::real(xm));
+	RT yr(std::real(ym));
+	RT zr(std::real(zm));
+	RT pr(std::real(p));
+	rjimpl::AsymFlag cres = rjimpl::rj_asym_conf(xr, yr, zr, pr, config);
+	switch ( cres )
+	{
+	    case rjimpl::AsymFlag::nothing : break;
+	    case rjimpl::AsymFlag::hugep :
+	    {
+		/* Ref[2], Eq. 19.27.11 <https://dlmf.nist.gov/19.27.E11> */
+		status = rf(xr, yr, zr, rerr * (RT)0.5, tmpres);
+		tmpres = 3.0 * (tmpres -
+			        0.5 * (RT)(constants::pi) / std::sqrt(pr)) / pr;
+		break;
+	    }
+	    case rjimpl::AsymFlag::tinyp :
+	    {
+		/* Ref[6], Table 2 and Theorem 11 (Eq. 4.12) */
+		ExitStatus status_tmp;
+		RT xct1[3];
+		RT xct2[3];
+		RT xct3[3];
+		double r = rerr * 0.5;
+		xct1[1] = xct2[0] = std::sqrt(xr);
+		xct1[2] = xct2[1] = std::sqrt(yr);
+		xct1[0] = xct2[2] = std::sqrt(zr);
+		RT lamt = arithmetic::dot2(xct1, xct2);
+		xct3[0] = xct3[1] = xct3[2] = pr;
+		RT alpha = arithmetic::dot2(xct1, xct3) + config.f;
+		alpha = alpha * alpha;
+		RT beta = pr + lamt;
+		beta = beta * beta * pr;
+		status_tmp = rc(alpha, beta, r, xct2[0]);
+		status = rj(xr + lamt, yr + lamt, zr + lamt, pr + lamt, r,
+		            xct2[1]);
+		if ( status_tmp != ExitStatus::success )
+		{
+		    status = status_tmp;
+		}
+		xct1[0] = (RT)3.0;
+		xct1[1] = (RT)2.0;
+		tmpres = arithmetic::ndot2(xct1, xct2, 2);
+		break;
+	    }
+	    case rjimpl::AsymFlag::hugey :
+	    {
+		/* Ref[2], Eq. 19.27.14 <https://dlmf.nist.gov/19.27.E14> */
+		ExitStatus status_tmp;
+		RT t1, t2;
+		double r = rerr / 3.0;
+		tmpres = (RT)1.0 / std::sqrt(yr * zr);
+		status_tmp = rc(xr, pr, r, t1);
+		status = rg((RT)0.0, yr, zr, r, t2);
+		if ( status_tmp != ExitStatus::success )
+		{
+		    status = status_tmp;
+		}
+		tmpres *= ((RT)3.0 * t1 - (RT)2.0 * t2 * tmpres);
+		break;
+	    }
+	    case rjimpl::AsymFlag::tinyx :
+	    {
+		/* Ref[2], Eq. 18.27.15 <https://dlmf.nist.gov/19.27.E15> */
+		status = rj((RT)0.0, yr, zr, pr, rerr, tmpres);
+		tmpres -= (RT)3.0 * std::sqrt(xr) / (config.h * pr);
+		break;
+	    }
+	    case rjimpl::AsymFlag::tinyy :
+	    {
+		/* Ref[5], Proposition J3
+		 * The bounds given in the ref is better than the one in
+		 * Ref[6]. */
+		RT tx;
+		status = rc((RT)1.0, pr / zr, rerr, tx);
+		tmpres = std::log((RT)8.0 * zr / (config.a + config.g)) -
+		         (RT)2.0 * tx;
+		tx = std::log((RT)2.0 * pr / (config.a + config.g)) / pr;
+		RT rt_h = tx * config.a *
+		          ((RT)1.0 + (RT)0.5 * pr / zr) / ((RT)1.0 -
+			                                   config.a / pr);
+		tx = (RT)1.5 / (std::sqrt(zr) * pr);
+		tmpres *= tx;
+		tmpres += rt_h * tx;
+		break;
+	    }
+	    case rjimpl::AsymFlag::hugez :
+	    {
+		/* Try to switch between Ref[5], Propositino J6 and direct
+		 * computation without asymptotics */
+		RT tt = config.h + pr;
+		tt *= tt;
+		RT tm = config.b + config.h;
+		status = rc(tt, (RT)2.0 * tm * pr, rerr * (RT)0.5, tmpres);
+		tt = std::log((RT)2.0 * zr / tm);
+		RT rt_h = (RT)0.75 * ((RT)2.0 * pr * tmpres / zr -
+		                      tt / (zr - config.h));
+		tt = (RT)3.0 / std::sqrt(zr);
+		tmpres *= tt;
+		/* Also try if direct computation gives reasonable approx. */
+		RT tmp_direct;
+		ExitStatus status_direct = rj(xr, yr, zr, pr, rerr * (RT)0.5,
+		                              tmp_direct, true);
+		if ( (tmp_direct > tmpres) ||
+		     (tmp_direct < tmpres + rt_h * tt) )
+		{
+		    tmpres += tt * (RT)0.3 * rt_h;
+		} else {
+		    tmpres = tmp_direct;
+		    status = status_direct;
+		}
+		break;
+	    }
+	}  /* end of switch */
+	if ( cres != rjimpl::AsymFlag::nothing )
+	{
+	    res = tmpres;
+	    return status;
+	}
+    }  /* end of condition on whether one should try asymptotic approx. */
+
+    cct1[3] = p;
+    cct1[4] = p;
+    T Am = arithmetic::nsum2(cct1, 5) / (RT)5.0;
+    T delta = (p - xm) * (p - ym) * (p - zm);
+    T xxm = Am - xm;
+    T yym = Am - ym;
+    T zzm = Am - zm;
+    RT fterm = std::max({std::abs(xxm), std::abs(yym), std::abs(zzm),
+			 std::abs(Am - p)}) / arithmetic::ocrt(rerr / 5.0);
+    /* The algorithm is a direct implementation of Ref[3], Theorem A.1., where
+     * a purely arithmetic recurrence relation is used instead of evaluating
+     * special functions in the inner loop. */
+
+    /* m = 0; */
+    RT d4m = 1.0;
+    T pm = p;
+    T prm, lam, dm;
+    ELLINT_RJ_CALC();
+    T sm = dm * (RT)0.5;
+    /* next */
+    ELLINT_RJ_UPDT();
+
+    RT aAm;
+    unsigned int m = 1;
+    while ( (aAm = std::abs(Am)) <= fterm ||
+	    aAm <= std::max({std::abs(xxm), std::abs(yym), std::abs(zzm),
+                             std::abs(Am - pm)}) )  
+    {
+	if ( m > config::max_iter )
+	{
+	    status = ExitStatus::n_iter;
+	    break;
+	}
+	T rm = sm * (std::sqrt((delta * d4m) / (sm * sm) + (RT)1.0) +
+	                 (RT)1.0);
+	ELLINT_RJ_CALC();
+	sm = (rm * dm - delta * (d4m * d4m)) * (RT)0.5 / (dm + rm * d4m);
+
+	/* next */
+	ELLINT_RJ_UPDT();
+	++m;
+    }
+    /* Burn some extra cycles re-balancing Am as the "true" centroid */
+    cct1[0] = xm;
+    cct1[1] = ym;
+    cct1[2] = zm;
+    cct1[3] = pm;
+    cct1[4] = pm;
+    Am = arithmetic::nsum2(cct1, 5) / (RT)5.0;
+    xxm /= Am;
+    yym /= Am;
+    zzm /= Am;
+    /* pp = -0.5 * (xxm + yym + zzm) */
+    cct1[0] = cct2[2] = xxm;
+    cct1[1] = cct2[0] = yym;
+    cct1[2] = cct2[1] = zzm;
+    T pp = arithmetic::nsum2(cct1, 3) * (RT)(-0.5);
+    cct1[3] = cct2[3] = pp;
+    cct1[3] = cct1[3] * (RT)(-3.0);
+    T pp2 = pp * pp;
+    T xyz = yym * zzm * xxm;
+    /* Prepare the "elementary" terms E_n as in Eqs. (31-32) in Ref. [2] */
+    /* e2 = xxm * yym + zzm * xxm + yym * zzm - pp2 * 3.0 */
+    T e2 = arithmetic::ndot2(cct1, cct2, 4);
+    /* e3 = xyz + 2.0 * pp * (e2 + 2.0 * pp2) */
+    T e3 = xyz + pp * (RT)2.0 * (e2 + pp2 * (RT)2.0);
+    /* e4 = (2.0 * xyz + (e2 + 3.0 * pp2) * pp) * pp */
+    T e4 = ((RT)2.0 * xyz + (e2 + (RT)3.0 * pp2) * pp) * pp;
+    T e5 = xyz * pp2;
+    /* tmp = d4m * pow(sqrt(Am), -3) */
+    T t = std::sqrt(Am);
+    T tmp = d4m / (t * t * t);
+    /* Evaluate the 7th-degree expansion using the E_n terms, following
+     * Eq. 19.36.2 of [1], https://dlmf.nist.gov/19.36#E2
+     * The order of expansion is higher than that in Eq. (32) of Ref. [2]. */
+    cct1[0] = arithmetic::comp_horner(e2, constants::RDJ_C1);
+    cct1[1] = arithmetic::comp_horner(e3, constants::RDJ_C2);
+    cct1[2] = arithmetic::comp_horner(e2, constants::RDJ_C3);
+    cct1[3] = arithmetic::comp_horner(e2, constants::RDJ_C4);
+    cct1[4] = arithmetic::comp_horner(e2, constants::RDJ_C5);
+    cct1[5] = e3 * (RT)(constants::RDJ_C5[1]);
+
+    cct2[0] = T(1.0);
+    cct2[1] = T(1.0);
+    cct2[2] = e3;
+    cct2[3] = e4;
+    cct2[4] = e5;
+    cct2[5] = e4;
+    t = arithmetic::dot2(cct1, cct2) / (RT)(constants::RDJ_DENOM) + (RT)1.0;
+    tmp *= t;
+    t = delta * d4m / (sm * sm);
+    /* Use the library atan function, following Ref[4], Sec. 1.6.1. */
+    tmp += rjimpl::safe_atan_sqrt_div(t) * (RT)3.0 / sm;
+
+    res = tmp;
+    return status;
+}
+
+
+}  /* namespace ellint_carlson */
+
+
+#endif /* ELLINT_RJ_GENERIC_GUARD */

--- a/include/xsf/ellint_carlson/ellint_argcheck.hh
+++ b/include/xsf/ellint_carlson/ellint_argcheck.hh
@@ -1,0 +1,105 @@
+#ifndef ELLINT_ARGCHECK_HH_INCLUDED
+#define ELLINT_ARGCHECK_HH_INCLUDED
+
+
+#include <complex>
+#include "ellint_typing.hh"
+#include "ellint_common.hh"
+
+
+namespace ellint_carlson { namespace argcheck
+{
+    template<typename T>
+    inline constexpr typing::real_only<T, bool>
+    invalid_rerr(const T& r, const double upper)
+    {
+	return ( r <= 0.0 ) || ( r > upper );
+    }
+
+
+    template<typename T>
+    inline typing::real_only<T, bool>
+    too_small(const T& x)
+    {
+	return ( (x == 0.0 ) || ( std::fpclassify(x) == FP_SUBNORMAL ) );
+    }
+
+    template<typename T>
+    inline typing::cplx_only<T, bool>
+    too_small(const T& z)
+    {
+	return ( too_small(z.real()) && too_small(z.imag()) );
+    }
+
+
+    /* Argument (phase) angle is NOT +/- pi, and is not indeterminate value,
+     * checked without computing the actual argument. */
+    template<typename T>
+    inline constexpr typing::real_only<T, bool>
+    ph_good(const T& x)
+    {
+	/* also handles x being NaN, which compares to false, hence is the
+	 * correct result. */
+	return ( x >= 0.0 );
+    }
+
+    template<typename T>
+    inline typing::cplx_only<T, bool>
+    ph_good(const T& z)
+    {
+	typedef typing::decplx_t<T> RT;
+	switch ( std::fpclassify(z.imag()) )
+	{
+	    case FP_NORMAL :
+	    case FP_SUBNORMAL :
+	    {
+		RT r = z.real();
+		return ( std::isfinite(r) ||
+			(std::isinf(r) && (r > 0.0)) );
+	    }
+	    case FP_ZERO : return ph_good<RT>(z.real());
+	    case FP_NAN : return false;
+	    case FP_INFINITE : return ( std::isfinite(z.real()) );
+	    default /* other implementations? */ : return false;
+	}
+    }
+
+
+    template<typename T>
+    inline typing::real_only<T, bool>
+    isinf(const T& x)
+    {
+	return std::isinf(x);
+    }
+
+    template<typename T>
+    inline typing::cplx_only<T, bool>
+    isinf(const T& z)
+    {
+	return ( std::isinf(z.real()) || std::isinf(z.imag()) );
+    }
+
+
+    /* Two complex numbers are approximately each other's conjugate */
+    template<typename T0, typename T1>
+    inline bool
+    isconj(const T0& x, const T1& y)
+    {
+	return too_small(x - std::conj(y));
+    }
+
+    /* "let two of the variables x, y, z be nonzero and conjugate complex with
+     * phase less in magnitude than pi and the third variable be real and
+     * nonnegative." */
+    template<typename T0, typename T1, typename T2>
+    inline bool
+    r1conj2(T0 x, T1 y, T2 z)
+    {
+	return ( isconj(x, y) && !(too_small(x) || too_small(y)) &&
+	         too_small(std::imag(z)) && (std::real(z) >= 0.0) &&
+		 ph_good(x) && ph_good(y) );
+    }
+}}  /* namespace ellint_carlson::argcheck */
+
+
+#endif /* ELLINT_ARGCHECK_HH_INCLUDED */

--- a/include/xsf/ellint_carlson/ellint_arith_aux.hh
+++ b/include/xsf/ellint_carlson/ellint_arith_aux.hh
@@ -1,0 +1,195 @@
+#ifndef ELLINT_ARITH_AUX_HH_INCLUDED
+#define ELLINT_ARITH_AUX_HH_INCLUDED
+
+
+#include <cstddef>
+#include "ellint_typing.hh"
+
+
+/* Auxiliary floating-point manipulation utilities.
+ * Ref:
+ *
+ * S. M. Rump, T. Ogita, S. Oishi: Accurate Floating-Point Summation.
+ *      2005-11-13, Tech. Rep. 05.1, Fac. Inf. Commun. Sci, Hambg. Univ.
+ *      Technol., also known as SIAM J. Sci. Comput. Volume 31, Issue 1, pp.
+ *      189-224 (2008),
+ *      http://www.ti3.tuhh.de/paper/rump/RuOgOi07I.pdf
+ *
+ * The main purpose of these templates is to implement Algorithm 6.1 (here as
+ * acc_sum) which is required by compensated complex floating-point polynomial
+ * evaluation.
+ */
+namespace ellint_carlson { namespace arithmetic { namespace aux
+{
+    /* Algorithm 3.6 */
+    template<typename RT>
+    inline typing::real_only<RT, RT>
+    next_power_two(const RT& p)
+    {
+	RT q = p / typing::half_epsilon<RT>();
+	RT L = std::abs((q + p) - q);
+	if ( L == 0.0 )
+	{
+	    L = std::abs(p);
+	}
+	return L;
+    }
+
+
+    /* Algorithm 3.2 */
+    template<typename RT>
+    inline typing::real_only<RT, void>
+    extract_scalar(const RT& sigma, RT& p, RT& q)
+    {
+	q = (sigma + p) - sigma;
+	p -= q;
+    }
+
+
+    /* Algorithm 3.4 */
+    template<typename RT, std::size_t LEN>
+    inline typing::real_only<RT, void>
+    extract_vector(const RT& sigma, RT(& p)[LEN], bool(& mask)[LEN], RT& tau)
+    {
+	RT q;
+	tau = (RT)0.0;
+	for ( std::size_t i = 0; i < LEN; ++i )
+	{
+	    if ( mask[i] )
+	    {
+		extract_scalar(sigma, p[i], q);
+		if ( p[i] == 0.0 )
+		{
+		    mask[i] = false;
+		}
+		tau += q;
+	    }
+	}
+    }
+
+
+    /* The functions make, none, and count implements boolean-array
+     * initialization, test for all-false, and counting for number of true
+     * values. */
+    template<typename RT, std::size_t LEN>
+    inline typing::real_only<RT, void>
+    make(const RT(& buf)[LEN], bool(& mask)[LEN])
+    {
+	for ( std::size_t i = 0; i < LEN; ++i )
+	{
+	    mask[i] = ( buf[i] != 0.0 );
+	}
+    }
+
+
+    template<std::size_t LEN>
+    inline bool
+    none(const bool(& mask)[LEN])
+    {
+	for ( std::size_t i = 0; i < LEN; ++i )
+	{
+	    if ( mask[i] )
+	    {
+		return false;
+	    }
+	}
+	return true;
+    }
+
+
+    template<std::size_t LEN>
+    inline std::size_t
+    count(const bool(& mask)[LEN])
+    {
+	std::size_t r = 0;
+	for ( std::size_t i = 0; i < LEN; ++i )
+	{
+	    if ( mask[i] )
+	    {
+		++r;
+	    }
+	}
+	return r;
+    }
+
+
+    /* Search for maximal absolute value in masked array. */
+    template<typename RT, std::size_t LEN>
+    inline typing::real_only<RT, RT>
+    vmax(const RT(& p)[LEN], const bool(& mask)[LEN])
+    {
+	RT v(0.0);
+	for ( std::size_t i = 0; i < LEN; ++i )
+	{
+	    if ( mask[i] )
+	    {
+		v = std::max(v, std::abs(p[i]));
+	    }
+	}
+	return v;
+    }
+
+
+    /* Summation for masked array */
+    template<typename RT, std::size_t LEN>
+    inline typing::real_only<RT, RT>
+    masked_sum(const RT(& p)[LEN], const bool(& mask)[LEN])
+    {
+	RT v(0.0);
+	for ( std::size_t i = 0; i < LEN; ++i )
+	{
+	    if ( mask[i] )
+	    {
+		v += p[i];
+	    }
+	}
+	return v;
+    }
+
+
+    /* Algorithm 6.1 */
+    template<typename RT, std::size_t LEN>
+    inline typing::real_only<RT, RT>
+    acc_sum(RT(& p)[LEN], bool(& mask)[LEN])
+    {
+	if ( (LEN == 0) || none(mask) )
+	{
+	    return (RT)0.0;
+	}
+
+	RT mu = vmax(p, mask);
+	if ( mu == 0.0 )
+	{
+	    return mu;
+	}
+
+	RT twopM = next_power_two<RT>(RT(count(mask) + 2));
+	RT sigma = twopM * next_power_two<RT>(mu);
+	RT phi = typing::half_epsilon<RT>() * twopM;
+	RT factor = std::numeric_limits<RT>::epsilon() * twopM * twopM;
+
+	RT t = (RT)0.0;
+	while ( true )
+	{
+	    RT tau, tau1, tau2;
+	    extract_vector(sigma, p, mask, tau);
+	    tau1 = t + tau;
+	    if ( ( std::abs(tau1) >= factor * sigma ) ||
+		 ( sigma <= std::numeric_limits<RT>::min() ) )
+	    {
+		/* Dekker "FastTwoSum" algorithm */
+		tau2 = tau - (tau1 - t);
+		return tau1 + (tau2 + masked_sum(p, mask));
+	    }
+	    t = tau1;
+	    if ( t == 0.0 )
+	    {
+		return acc_sum(p, mask);
+	    }
+	    sigma *= phi;
+	}
+    }
+}}}  /* namespace ellint_carlson::arithmetic::aux */
+
+
+#endif /* ELLINT_ARITH_AUX_HH_INCLUDED */

--- a/include/xsf/ellint_carlson/ellint_arithmetic.hh
+++ b/include/xsf/ellint_carlson/ellint_arithmetic.hh
@@ -1,0 +1,311 @@
+#ifndef ELLINT_ARITHMETIC_HH_INCLUDED
+#define ELLINT_ARITHMETIC_HH_INCLUDED
+
+
+/* Algorithms for accurate floating-point summation, dot-product, and
+ * polynomial evaluation.
+ *
+ * Ref:
+ *
+ * [1] S. Gaillat, V. Ménissier-Morain: Compensated Horner scheme in complex
+ *      floating point arithmetic.
+ *      2008-07-07, Proc. 8th Conf. Real Number Comput., pp. 133--146
+ *      https://www-pequan.lip6.fr/~graillat/papers/rnc08.pdf
+ *
+ * [2] S. Gaillat, V. Ménissier-Morain: Accurate summation, dot product and
+ *      polynomial evaluation in complex floating point arithmetic.
+ *      2012-03-30, Inf. Comput., vol. 216 pp. 57--71
+ *      https://doi.org/10.1016/j.ic.2011.09.003
+ *      https://web.stanford.edu/group/SOL/software/qdotdd/IC2012.pdf
+ *
+ * [3] S. Graillat, Ph.Langlois, N.Louve: Compensated Horner Scheme.
+ *      2005-07-24, Report No. RR2005-04, Université de Perpignan « Via
+ *      Domitia »
+ *      https://www-pequan.lip6.fr/~jmc/polycopies/Compensation-horner.pdf
+ */
+
+
+#include <iterator>
+#include <complex>
+#include <cstddef>
+#include <cmath>
+#include "ellint_typing.hh"
+#include "ellint_arith_aux.hh"
+#include "ellint_common.hh"
+
+
+namespace ellint_carlson { namespace arithmetic
+{
+    /* The functions for arithmetic operations get their arguments by reference
+     * (possibly qualified by const) whenever possible. The arguments not
+     * qualified by const are meant to be overwritten in the caller. */
+
+    /* Knuth's TwoSum algorithm, EFT on addition, with the sum written to s
+     * and the correction term to p. This algorithm is generic enough to
+     * write for both real and complex types (because there's no error in the
+     * complex "i").
+     * Algorithms 2.1 and 3.1 in Ref. [1] */
+    template<typename FPT>
+    inline typing::real_or_cplx<FPT, void>
+    eft_sum(const FPT& x, const FPT& y, FPT& s, FPT& corr)
+    {
+	s = x + y;
+	FPT z = s - x;
+	corr = (x - (s - z)) + (y - z);
+    }
+
+
+    /* TwoSum in accumulator style, with sum accumulated to acc and the
+     * correction term to corr
+     * Algorithm 4.1 in Ref. [2] */
+    template<typename FPT>
+    inline typing::real_or_cplx<FPT, void>
+    sum2_acc(const FPT& summand, FPT& acc, FPT& corr)
+    {
+	FPT tmp_s, tmp_e;
+	/* The tmp variables get their values from eft_sum called-by-reference.
+	 */
+	eft_sum(summand, acc, tmp_s, tmp_e);
+	acc = tmp_s;
+	corr += tmp_e;
+    }
+
+
+    /* Sum at most the first n elements of iterable thing, including fixed-size
+     * array passed by reference (both real and complex). */
+    template<typename IterableT>
+    inline auto
+    nsum2(const IterableT& x, std::size_t n) -> JUST_ELEM(std::begin(x))
+    {
+	auto it = std::begin(x);
+	typedef JUST_ELEM(it) FPT;
+	static_assert(typing::is_real_or_complex_fp<FPT>::value,
+		      "the sum2 function only works with real or complex "
+		      "floating-point numbers.");
+	FPT p(0.0), s(0.0);
+
+	for ( std::size_t i = 0; ( it != std::end(x) && i < n ); ++it, ++i )
+	{
+	    sum2_acc(*it, p, s);
+	}
+
+	return p + s;
+    }
+
+    /* Convenient wrapper for summing fixed-size array. */
+    template<typename FPT, std::size_t N>
+    inline typing::real_or_cplx<FPT, FPT>
+    sum2(const FPT(& arr)[N])
+    {
+	return nsum2(arr, N);
+    }
+
+
+    /* EFT for multiplication, with real-type arguments.
+     * NOTE: This implementation uses the FMA function for correct rounding.
+     * (mandated by standard since C++11)
+     * Algorithm 2.5 in Ref. [1] */
+    template<typename RT>
+    inline typing::real_only<RT, void>
+    eft_prod(const RT& x, const RT& y, RT& prod, typing::corrbuf<RT>& corr)
+    {
+	prod = x * y;
+	corr = std::fma(x, y, -prod);
+    }
+
+
+    /* EFT for multiplication, with complex-type arguments.
+     * Algorithm 3.4 in Ref. [1] */
+    template<typename CT>
+    inline typing::cplx_only<CT, void>
+    eft_prod(const CT& x, const CT& y, CT& prod, typing::corrbuf<CT>& corr)
+    {
+	typedef typename typing::is_complex<CT>::rtype RT;
+	RT z1, z2, z3, z4, z5, z6;
+
+	/*  p                  e    f    g
+	 * z5 | value_real : [h1, -h2,  h5, xx]
+	 * z6 | value_imag : [h3,  h4,  h6, xx]
+	 */
+	RT a = x.real();
+	RT b = x.imag();
+	RT c = y.real();
+	RT d = y.imag();
+
+	eft_prod(a, c, z1, corr.value_real[0]);
+	eft_prod(b, d, z2, corr.value_real[1]);
+	eft_prod(a, d, z3, corr.value_imag[0]);
+	eft_prod(b, c, z4, corr.value_imag[1]);
+	eft_sum(z1, -z2, z5, corr.value_real[2]);
+	eft_sum(z3, z4, z6, corr.value_imag[2]);
+
+	corr.value_real[1] = -corr.value_real[1];
+	prod = CT{z5, z6};
+    }
+
+
+    /* Accumulator version of dot-product
+     * Algorithm 4.3 in Ref. [2] */
+    template<typename RT>
+    inline typing::real_only<RT, void>
+    fdot2_acc(const RT& x, const RT& y, RT& acc, RT& corr)
+    {
+	RT h, t, q, r;
+
+	eft_prod(x, y, h, r);
+	eft_sum(acc, h, t, q);
+	acc = t;
+	corr += q + r;
+    }
+
+
+    /* Dot-product of at most first n elements, for real floating type only
+     * (based on what we see by peeking "begin"). */
+    template<typename Iterable>
+    inline auto
+    ndot2(const Iterable& x, const Iterable& y, std::size_t n)
+    -> typename std::enable_if<
+	std::is_floating_point<JUST_ELEM(std::begin(x))>::value,
+	JUST_ELEM(std::begin(x)) >::type
+    {
+	auto itx = std::begin(x);
+	auto ity = std::begin(y);
+	typedef JUST_ELEM(itx) RT;
+	RT p(0.0), s(0.0);
+
+	for ( std::size_t i = 0;
+	      ( (itx != std::end(x)) && (ity != std::end(y)) && (i < n) );
+	      ++itx, ++ity, ++i )
+	{
+	    fdot2_acc((RT)(*itx), (RT)(*ity), p, s);
+	}
+
+	return p + s;
+    }
+
+
+    /* Dot-product, but for complex types.
+     * Algorithm 4.4 in Ref. [2] */
+    template<typename Iterable>
+    inline auto
+    ndot2(const Iterable& x, const Iterable& y, std::size_t n)
+    -> typename std::enable_if<
+	typing::is_complex<JUST_ELEM(std::begin(y))>::value,
+	JUST_ELEM(std::begin(x)) >::type
+    {
+	auto itx = std::begin(x);
+	auto ity = std::begin(y); 
+	typedef JUST_ELEM(itx) CT;
+	typedef typing::decplx_t<CT> RT;
+
+	RT pr, pi, cr, ci;
+
+	pr = pi = cr = ci = (RT)0.0;
+	for ( std::size_t i = 0;
+	      ( itx != std::end(x) && ity != std::end(y) && i < n );
+	      ++itx, ++ity, ++i )
+	{
+	    RT a = itx->real();
+	    RT b = ity->real();
+	    RT c = itx->imag();
+	    RT d = ity->imag();
+
+	    fdot2_acc(a, b, pr, cr);
+	    fdot2_acc(c, -d, pr, cr);
+	    fdot2_acc(a, d, pi, ci);
+	    fdot2_acc(b, c, pi, ci);
+	}
+
+	return CT{pr + cr, pi + ci};
+    }
+
+    /* Convenient wrapper for dot-product */
+    template<typename FPT, std::size_t M, std::size_t N>
+    inline FPT
+    dot2(const FPT(& x)[M], const FPT(& y)[N])
+    {
+	constexpr std::size_t len = (M <= N ? M : N);
+	return ndot2(x, y, len);
+    }
+
+
+    /* Polynomial evaluation with compensated Horner scheme.
+     * This instance for the real-only inputs is essentially the Algorithm 9 in
+     * Ref. [3] */
+    template<typename RT>
+    inline typing::real_only<RT, RT>
+    dcomp_horner(const RT& x, const RT* poly, std::size_t degree)
+    {
+	RT s(poly[degree]), r(0.0);
+
+	for ( std::ptrdiff_t i = (std::ptrdiff_t)degree - 1; i >= 0; --i )
+	{
+	    RT ptmp, pp, ps;
+
+	    eft_prod(s, x, ptmp, pp);
+	    eft_sum(ptmp, poly[i], s, ps);
+	    r = r * x + (pp + ps);
+	}
+	return s + r;
+    }
+
+    /* For complex-valued input: Algorithm 5.4 in Ref. [2].
+     * Notice that this makes use of the aux::acc_sum() algorithm, which is
+     * named "Accsum" in the referenced paper. */
+    template<typename T0, typename T1>
+    inline typename std::enable_if< typing::is_complex<T0>::value ||
+                                    typing::is_complex<T1>::value,
+	                            typing::Promote<T0, T1> >::type
+    dcomp_horner(const T0(& x), const T1* poly, std::size_t degree)
+    {
+	typedef typing::Promote<T0, T1> CT;
+	CT s(poly[degree]), r(0.0);
+
+	for ( std::ptrdiff_t i = (std::ptrdiff_t)degree - 1; i >= 0; --i )
+	{
+	    CT p, tmp;  /* tmp is for copying into the buffer arrays. */
+	    typing::corrbuf<CT> ws;
+	    bool mask_r[NPOLY];
+	    bool mask_i[NPOLY];
+
+	    eft_prod(s, CT(x), p, ws);
+	    eft_sum(p, CT(poly[i]), s, tmp);
+	    ws.value_real[NPOLY - 1] = tmp.real();
+	    ws.value_imag[NPOLY - 1] = tmp.imag();
+	    aux::make(ws.value_real, mask_r);
+	    aux::make(ws.value_imag, mask_i);
+	    r = r * x + CT(aux::acc_sum(ws.value_real, mask_r),
+	                   aux::acc_sum(ws.value_imag, mask_i));
+	}
+
+	return s + r;
+    }
+
+    /* Convenient version for fixed-size array as polynomial coefficients, with
+     * type promotion. */
+    template<typename T, typename U, std::size_t N>
+    inline typing::Promote<T, U>
+    comp_horner(const T& x, const U(& poly)[N])
+    {
+	return dcomp_horner(x, poly, N - 1);
+    }
+
+
+    /* Small integer roots for real types. */
+    template<typename RT>
+    inline typing::real_only<RT, RT>
+    ocrt(const RT& x)  /* 8th (octic) root */
+    {
+	return std::sqrt(std::sqrt(std::sqrt(x)));
+    }
+
+    template<typename RT>
+    inline typing::real_only<RT, RT>
+    sxrt(const RT& x)  /* 6th (sextic) root */
+    {
+	return std::sqrt(std::cbrt(x));
+    }
+}}  /* namespace ellint_carlson::arithmetic  */
+
+
+#endif /* ELLINT_ARITHMETIC_HH_INCLUDED */

--- a/include/xsf/ellint_carlson/ellint_carlson.hh
+++ b/include/xsf/ellint_carlson/ellint_carlson.hh
@@ -1,0 +1,15 @@
+#ifndef ELLINT_CARLSON_HH_INCLUDED
+#define ELLINT_CARLSON_HH_INCLUDED
+
+
+#include "ellint_typing.hh"
+#include "ellint_arithmetic.hh"
+#include "ellint_common.hh"
+#include "_rc.hh"
+#include "_rd.hh"
+#include "_rf.hh"
+#include "_rg.hh"
+#include "_rj.hh"
+
+
+#endif /* ELLINT_CARLSON_HH_INCLUDED */

--- a/include/xsf/ellint_carlson/ellint_common.hh
+++ b/include/xsf/ellint_carlson/ellint_common.hh
@@ -1,0 +1,128 @@
+#ifndef ELLINT_COMMON_HH_INCLUDED
+#define ELLINT_COMMON_HH_INCLUDED
+
+
+#include <cstddef>
+#include <complex>
+
+
+/* Namespace skeletons, to be populated in individual headers. */
+namespace ellint_carlson
+{
+    /* Number of correction terms in polynomial evaluation. */
+    static constexpr std::size_t NPOLY = 4u;
+
+    /* Type-checking support. */
+    namespace typing {}
+
+    /* Arithmetic building blocks. */
+    namespace arithmetic
+    {
+	namespace aux {}
+    }
+
+    /* Argument validation */
+    namespace argcheck {}
+
+    /* Configuration constants */
+    namespace config
+    {
+	static constexpr unsigned int max_iter = 1000u;
+	static constexpr double asym_zero_ul = 5.0e-14;
+	static constexpr double asym_close_ul = 1.0e-9;
+    }
+
+    namespace constants
+    {
+	static constexpr long double pi = 3.14159265358979323846264338327950288419716939937510582097494459230781640628620899863L;
+	static constexpr long double ln4 = 1.38629436111989061883446424291635313615100026872051050824136L;
+
+	static constexpr double RC_C[8] =
+	{
+	    80080.0,
+	    0.0,
+	    24024.0,	/* 3 / 10 */
+	    11440.0,	/* 1 / 7 */
+	    30030.0,	/* 3 / 8 */
+	    32760.0,	/* 9 / 22 */
+	    61215.0,	/* 159 / 208 */
+	    90090.0	/* 9 / 8 */
+	};
+
+	static constexpr double RF_C1[4] =
+	{
+	    0.0,
+	    -24024.0,
+	    10010.0,
+	    -5775.0
+	};
+
+	static constexpr double RF_C2[3] = {17160.0, -16380.0, 15015.0};
+
+	static constexpr double RF_c33 = 6930.0;		/*  3 / 104 */
+
+	static constexpr double RF_DENOM = 240240.0;
+
+	static constexpr double RDJ_C1[4] = {0.0, -875160.0, 417690.0,
+	                                     -255255.0};
+
+	static constexpr double RDJ_C2[3] = {0.0, 680680.0, 306306.0};
+
+	static constexpr double RDJ_C3[3] = {0.0, -706860.0, 675675.0};
+
+	static constexpr double RDJ_C4[2] = {-556920.0, 612612.0};
+
+	static constexpr double RDJ_C5[2] = {471240.0, -540540.0};
+
+	static constexpr double RDJ_DENOM = 4084080.0;
+    }  /* namespace constants */
+
+
+    /* Exit statuses for the library functions. */
+    enum class ExitStatus
+    {
+	success = 0,
+	singular,
+	underflow,
+	overflow,
+	n_iter,
+	prec_loss,
+	no_result,
+	bad_args,
+	bad_rerr,
+	other,
+	memory,
+	unused
+    };
+
+    inline static constexpr bool
+    is_horrible(ExitStatus n)
+    {
+	return ( ( n == ExitStatus::no_result ) ||
+	         ( n == ExitStatus::bad_args ) ||
+		 ( n == ExitStatus::bad_rerr ) ||
+		 ( n == ExitStatus::other ) );
+    }
+
+    inline static constexpr bool
+    is_troublesome(ExitStatus n)
+    {
+	return ( !(( n == ExitStatus::success ) || is_horrible(n)) );
+    }
+
+    /* The upper-most namespace "ellint_carlson" will include the actual
+     * functions (RC, RD, RF, etc.). */
+
+    namespace util
+    {
+	/* Comparison function based on absolute value. */
+	template<typename T>
+	static inline bool abscmp(const T& a, const T& b)
+	{
+	    return ( std::abs(a) < std::abs(b) );
+	}
+    }
+}
+
+
+#endif /* ELLINT_COMMON_HH_INCLUDED */

--- a/include/xsf/ellint_carlson/ellint_typing.hh
+++ b/include/xsf/ellint_carlson/ellint_typing.hh
@@ -1,0 +1,185 @@
+#ifndef ELLINT_TYPING_HH_INCLUDED
+#define ELLINT_TYPING_HH_INCLUDED
+
+
+/* Type-checking support implemented with templates. */
+
+
+#include <type_traits>
+#include <iterator>
+#include <limits>
+#include <complex>
+#include "ellint_common.hh"
+
+
+namespace ellint_carlson { namespace typing
+{
+    /* Constructs for confining template-matching to complex math. */
+    template<typename T>
+    struct is_complex : std::false_type {};
+
+    template<typename RT>
+    struct is_complex< std::complex<RT> > :
+	std::enable_if< std::is_floating_point<RT>::value,
+			std::true_type >::type
+    {
+	typedef RT rtype;
+	typedef std::complex<RT> ctype;
+    };
+
+    template<typename T>
+    struct is_real_or_complex_fp :
+	std::integral_constant< bool,
+				std::is_floating_point<T>::value ||
+				is_complex<T>::value > {};
+
+    /* The decplx struct "de-complexifies" a complex type and obtains the
+     * underlying real type, while doing nothing for an already real type. */
+    template<typename T>
+    struct decplx
+    {
+	typedef typename std::remove_cv<T>::type type;
+    };
+
+    template<typename T>
+    struct decplx< std::complex<T> >
+    {
+	typedef typename std::remove_cv<T>::type type;
+    };
+
+    template<typename T>
+    using decplx_t = typename decplx<T>::type;
+
+
+    template<typename T, typename U>
+    struct pm_impl {};
+
+    template<typename T>
+    struct pm_impl<T, T>
+    {
+	typedef T type;
+    };
+
+    template<typename T>
+    struct pm_impl< T, std::complex<T> >
+    {
+	typedef std::complex<T> type;
+    };
+
+    template<typename T>
+    struct pm_impl< std::complex<T>, T >
+    {
+	typedef std::complex<T> type;
+    };
+
+    /* "Promote" to complex if one and only one of the types is real. */
+    template<typename T, typename U>
+    using Promote = typename pm_impl<T, U>::type;
+
+
+    /* Buffer holding the correction terms for multiplication.  For real
+     * floating-point types, this is just the same type ("just" numeric type).
+     * For complex types, there must be two buffers, each with length 4, for
+     * holding the EFT terms. */
+    namespace fpbuftypes
+    {
+	/* Real type (also primary template), empty struct except for the
+	 * typedef referring to the numeric type. */
+	template<typename RT>
+	struct corrbuf
+	{
+	    typedef RT type;
+	};
+
+	/* Complex type, the typedef refers to the corrbuf type itself.
+	 * This works because complex is more specialised than real float. */
+	template<typename RT>
+	struct corrbuf< std::complex<RT> >
+	{
+	    /* If selected, this "corrbuf" in the typedef necessarily refers to
+	     * the correct type, i.e. this struct with two buffer members. */
+	    typedef corrbuf type;
+	    RT value_real[NPOLY];
+	    RT value_imag[NPOLY];
+	};
+    }
+    /* In the arithmetic functions, "corrbuf" refers to either the bare (and
+     * real) numeric type or the specialised one for complex arithmetic, based
+     * on template matching. This is a convenient type alias referring back to
+     * the (either towards the bare thing or self-referential) type. */
+    template<typename T>
+    using corrbuf = typename fpbuftypes::corrbuf<T>::type;
+
+
+    /* For use in function return type declaration, optional arguments,
+     * template specialisation, inheritance, etc., where std::enable_if is
+     * appropriate. */
+    template<typename arg_t, typename ret_t>
+    using real_only =
+	typename std::enable_if<std::is_floating_point<arg_t>::value,
+                                ret_t>::type;
+
+    template<typename arg_t, typename ret_t>
+    using cplx_only =
+	typename std::enable_if<is_complex<arg_t>::value, ret_t>::type;
+
+    template<typename arg_t, typename ret_t>
+    using real_or_cplx =
+	typename std::enable_if<is_real_or_complex_fp<arg_t>::value,
+                                ret_t>::type;
+
+
+    /* Constants for different sizes of floating-point number.  The struct
+     * simply retrieves the information from the scope of the specialisation
+     * std::numeric_limit<T>. */
+    template<typename T>
+    constexpr real_only<T, T>
+    nan()
+    {
+	return std::numeric_limits<T>::quiet_NaN();
+    }
+
+    template<typename T>
+    constexpr real_only<T, T>
+    huge()
+    {
+	return std::numeric_limits<T>::infinity();
+    }
+
+    template<typename T>
+    constexpr real_only<T, T>
+    half_epsilon()
+    {
+	return std::numeric_limits<T>::epsilon() * (T)0.5;
+    }
+
+    /* Complexified specialisation, with the complex NaN and infinity as
+     * return values. */
+    template<typename T>
+    constexpr cplx_only<T, T>
+    nan()
+    {
+	typedef decplx_t<T> RT;
+	return T{nan<RT>(), nan<RT>()};
+    }
+
+    template<typename T>
+    constexpr cplx_only<T, T>
+    huge()
+    {
+	typedef decplx_t<T> RT;
+	return T{huge<RT>(), (RT)0.0};
+    }
+}}  /* namespace ellint_carlson::typing */
+
+
+/* Helper macros for use elsewhere in the implementation functions. */
+/* For use with iterator expressions. */
+#define PIERCE_ITER_REF(ITEXPR)	\
+typename std::remove_reference<decltype(*ITEXPR)>::type
+
+#define JUST_ELEM(ITEXPR)	\
+typename std::remove_cv<PIERCE_ITER_REF(ITEXPR)>::type
+
+
+#endif /* ELLINT_TYPING_HH_INCLUDED */

--- a/tests/xsf_tests/test_ellint_carlson.cpp
+++ b/tests/xsf_tests/test_ellint_carlson.cpp
@@ -1,0 +1,236 @@
+#include "../testing_utils.h"
+
+#include <xsf/cpu/ellint_carlson.h>
+#include <xsf/ellip.h>
+
+namespace {
+
+using C = std::complex<double>;
+
+} // namespace
+
+TEST_CASE("Carlson RC", "[ellint_carlson][xsf_tests]") {
+    // Mirrors
+    // https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/tests/test_basic.py#L1868-L1886
+    SECTION("real values") {
+        using test_case = std::tuple<double, double, double>;
+        auto [x, y, expected] = GENERATE(
+            test_case{1.0, 1.0, 1.0}, test_case{0.0, 0.25, M_PI}, test_case{2.25, 2.0, std::log(2.0)},
+            test_case{0.25, -2.0, std::log(2.0) / 3.0}
+        );
+        const double result = xsf::cpu::elliprc(x, y);
+        const double error = xsf::extended_relative_error(result, expected);
+        CAPTURE(x, y, result, expected, error);
+        REQUIRE(error <= 1e-13);
+    }
+
+    REQUIRE(xsf::cpu::elliprc(1.0, std::numeric_limits<double>::infinity()) == 0.0);
+    REQUIRE(std::isnan(xsf::cpu::elliprc(1.0, 0.0)));
+    REQUIRE(xsf::cpu::elliprc(C{1.0}, C{1.0, std::numeric_limits<double>::infinity()}) == C{0.0});
+
+    using test_case = std::tuple<C, C, C>;
+    auto [x, y, expected] = GENERATE(
+        test_case{0.0, 0.25, M_PI}, test_case{2.25, 2.0, std::log(2.0)},
+        test_case{0.0, C{0.0, 1.0}, C{1.1107207345396, -1.1107207345396}},
+        test_case{C{0.0, -1.0}, C{0.0, 1.0}, C{1.2260849569072, -0.34471136988768}},
+        test_case{0.25, -2.0, std::log(2.0) / 3.0}, test_case{C{0.0, 1.0}, -1.0, C{0.77778596920447, 0.19832484993429}}
+    );
+    const C result = xsf::cpu::elliprc(x, y);
+    const double error = xsf::extended_relative_error(result, expected);
+    CAPTURE(x, y, result, expected, error);
+    REQUIRE(error <= 1e-13);
+}
+
+TEST_CASE("Carlson RD", "[ellint_carlson][xsf_tests]") {
+    // Mirrors
+    // https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/tests/test_basic.py#L1888-L1910
+    SECTION("real values") {
+        using test_case = std::tuple<double, double, double, double>;
+        auto [x, y, z, expected] = GENERATE(
+            test_case{1.0, 1.0, 1.0, 1.0}, test_case{0.0, 2.0, 1.0, 3.0 * 0.59907011736779610371},
+            test_case{2.0, 3.0, 4.0, 0.16510527294261}
+        );
+        const double result = xsf::cpu::elliprd(x, y, z);
+        const double error = xsf::extended_relative_error(result, expected);
+        CAPTURE(x, y, z, result, expected, error);
+        REQUIRE(error <= 1e-13);
+    }
+
+    REQUIRE(xsf::cpu::elliprd(1.0, 1.0, std::numeric_limits<double>::infinity()) == 0.0);
+    REQUIRE(std::isinf(xsf::cpu::elliprd(1.0, 1.0, 0.0)));
+    REQUIRE(std::isnan(xsf::cpu::elliprd(1.0, 1.0, -1.0)));
+    REQUIRE(std::isinf(xsf::cpu::elliprd(C{1.0}, C{1.0}, C{0.0}).real()));
+    REQUIRE(std::isinf(xsf::cpu::elliprd(C{0.0}, C{1.0}, C{0.0}).real()));
+    REQUIRE(std::isnan(xsf::cpu::elliprd(1.0, 1.0, -std::numeric_limits<double>::min() / 2.0)));
+    REQUIRE(std::isnan(xsf::cpu::elliprd(C{1.0}, C{1.0}, C{-1.0}).real()));
+
+    using test_case = std::tuple<C, C, C, C>;
+    auto [x, y, z, expected] = GENERATE(
+        test_case{0.0, 2.0, 1.0, 1.7972103521034}, test_case{2.0, 3.0, 4.0, 0.16510527294261},
+        test_case{C{0.0, 1.0}, C{0.0, -1.0}, 2.0, 0.65933854154220},
+        test_case{0.0, C{0.0, 1.0}, C{0.0, -1.0}, C{1.2708196271910, 2.7811120159521}},
+        test_case{0.0, C{-1.0, 1.0}, C{0.0, 1.0}, C{-1.8577235439239, -0.96193450888839}},
+        test_case{C{-2.0, -1.0}, C{0.0, -1.0}, C{-1.0, 1.0}, C{1.8249027393704, -1.2218475784827}}
+    );
+    const C result = xsf::cpu::elliprd(x, y, z);
+    const double error = xsf::extended_relative_error(result, expected);
+    CAPTURE(x, y, z, result, expected, error);
+    REQUIRE(error <= 1e-13);
+}
+
+TEST_CASE("Carlson RF", "[ellint_carlson][xsf_tests]") {
+    // Mirrors
+    // https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/tests/test_basic.py#L1912-L1935
+    SECTION("real values") {
+        using test_case = std::tuple<double, double, double, double>;
+        auto [x, y, z, expected] =
+            GENERATE(test_case{1.0, 1.0, 1.0, 1.0}, test_case{0.0, 1.0, 2.0, 1.31102877714605990523});
+        const double result = xsf::cpu::elliprf(x, y, z);
+        const double error = xsf::extended_relative_error(result, expected);
+        CAPTURE(x, y, z, result, expected, error);
+        REQUIRE(error <= 1e-13);
+    }
+
+    REQUIRE(xsf::cpu::elliprf(1.0, std::numeric_limits<double>::infinity(), 1.0) == 0.0);
+    REQUIRE(std::isinf(xsf::cpu::elliprf(0.0, 1.0, 0.0)));
+    REQUIRE(std::isnan(xsf::cpu::elliprf(1.0, 1.0, -1.0)));
+    REQUIRE(xsf::cpu::elliprf(C{std::numeric_limits<double>::infinity()}, C{0.0}, C{1.0}) == C{0.0});
+    REQUIRE(std::isnan(xsf::cpu::elliprf(C{1.0}, C{1.0}, C{-std::numeric_limits<double>::infinity(), 1.0}).real()));
+
+    using test_case = std::tuple<C, C, C, C>;
+    auto [x, y, z, expected] = GENERATE(
+        test_case{1.0, 2.0, 0.0, 1.3110287771461}, test_case{C{0.0, 1.0}, C{0.0, -1.0}, 0.0, 1.8540746773014},
+        test_case{0.5, 1.0, 0.0, 1.8540746773014},
+        test_case{C{-1.0, 1.0}, C{0.0, 1.0}, 0.0, C{0.79612586584234, -1.2138566698365}},
+        test_case{2.0, 3.0, 4.0, 0.58408284167715}, test_case{C{0.0, 1.0}, C{0.0, -1.0}, 2.0, 1.0441445654064},
+        test_case{C{-1.0, 1.0}, C{0.0, 1.0}, C{1.0, -1.0}, C{0.93912050218619, -0.53296252018635}}
+    );
+    const C result = xsf::cpu::elliprf(x, y, z);
+    const double error = xsf::extended_relative_error(result, expected);
+    CAPTURE(x, y, z, result, expected, error);
+    REQUIRE(error <= 1e-13);
+}
+
+TEST_CASE("Carlson RG", "[ellint_carlson][xsf_tests]") {
+    // Mirrors
+    // https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/tests/test_basic.py#L1937-L1956
+    SECTION("real values") {
+        using test_case = std::tuple<double, double, double, double>;
+        auto [x, y, z, expected] =
+            GENERATE(test_case{1.0, 1.0, 1.0, 1.0}, test_case{0.0, 0.0, 1.0, 0.5}, test_case{0.0, 16.0, 16.0, M_PI});
+        const double result = xsf::cpu::elliprg(x, y, z);
+        const double error = xsf::extended_relative_error(result, expected);
+        CAPTURE(x, y, z, result, expected, error);
+        REQUIRE(error <= 1e-13);
+    }
+
+    REQUIRE(xsf::cpu::elliprg(0.0, 0.0, 0.0) == 0.0);
+    REQUIRE(std::isinf(xsf::cpu::elliprg(1.0, std::numeric_limits<double>::infinity(), 1.0)));
+    REQUIRE(std::isinf(xsf::cpu::elliprg(C{std::numeric_limits<double>::infinity()}, C{1.0}, C{1.0}).real()));
+
+    using test_case = std::tuple<C, C, C, C>;
+    auto [x, y, z, expected] = GENERATE(
+        test_case{0.0, 16.0, 16.0, M_PI}, test_case{2.0, 3.0, 4.0, 1.7255030280692},
+        test_case{0.0, C{0.0, 1.0}, C{0.0, -1.0}, 0.42360654239699},
+        test_case{C{-1.0, 1.0}, C{0.0, 1.0}, 0.0, C{0.44660591677018, 0.70768352357515}},
+        test_case{C{0.0, -1.0}, C{-1.0, 1.0}, C{0.0, 1.0}, C{0.36023392184473, 0.40348623401722}},
+        test_case{0.0, 0.0796, 4.0, 1.0284758090288}
+    );
+    const C result = xsf::cpu::elliprg(x, y, z);
+    const double error = xsf::extended_relative_error(result, expected);
+    CAPTURE(x, y, z, result, expected, error);
+    REQUIRE(error <= 1e-13);
+}
+
+TEST_CASE("Carlson RJ", "[ellint_carlson][xsf_tests]") {
+    // Mirrors
+    // https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/tests/test_basic.py#L1958-L1983
+    SECTION("real values") {
+        using test_case = std::tuple<double, double, double, double, double>;
+        auto [x, y, z, p, expected] = GENERATE(
+            test_case{1.0, 1.0, 1.0, 1.0, 1.0}, test_case{0.0, 1.0, 2.0, 3.0, 0.77688623778582},
+            test_case{2.0, 3.0, 4.0, -0.5, 0.24723819703052}, test_case{2.0, 3.0, 4.0, -5.0, -0.12711230042964}
+        );
+        const double result = xsf::cpu::elliprj(x, y, z, p);
+        const double error = xsf::extended_relative_error(result, expected);
+        CAPTURE(x, y, z, p, result, expected, error);
+        REQUIRE(error <= 1e-13);
+    }
+
+    REQUIRE(xsf::cpu::elliprj(1.0, 1.0, 1.0, std::numeric_limits<double>::infinity()) == 0.0);
+    REQUIRE(std::isnan(xsf::cpu::elliprj(-1.0, 1.0, 1.0, 1.0)));
+    REQUIRE(xsf::cpu::elliprj(1.0, 1.0, std::numeric_limits<double>::infinity(), 1.0) == 0.0);
+    REQUIRE(std::isnan(xsf::cpu::elliprj(1.0, 0.0, 0.0, 0.0)));
+
+    using test_case = std::tuple<C, C, C, C, C>;
+    auto [x, y, z, p, expected] = GENERATE(
+        test_case{0.0, 1.0, 2.0, 3.0, 0.77688623778582}, test_case{2.0, 3.0, 4.0, 5.0, 0.14297579667157},
+        test_case{2.0, 3.0, 4.0, C{-1.0, 1.0}, C{0.13613945827771, -0.38207561624427}},
+        test_case{C{0.0, 1.0}, C{0.0, -1.0}, 0.0, 2.0, 1.6490011662711},
+        test_case{C{-1.0, 1.0}, C{-1.0, -1.0}, 1.0, 2.0, 0.94148358841220},
+        test_case{C{0.0, 1.0}, C{0.0, -1.0}, 0.0, C{1.0, -1.0}, C{1.8260115229009, 1.2290661908643}},
+        test_case{C{-1.0, 1.0}, C{-1.0, -1.0}, 1.0, C{-3.0, 1.0}, C{-0.61127970812028, -1.0684038390007}},
+        // Cauchy principal values.
+        test_case{2.0, 3.0, 4.0, -0.5, 0.24723819703052}, test_case{2.0, 3.0, 4.0, -5.0, -0.12711230042964}
+    );
+    const C result = xsf::cpu::elliprj(x, y, z, p);
+    const double error = xsf::extended_relative_error(result, expected);
+    CAPTURE(x, y, z, p, result, expected, error);
+    REQUIRE(error <= 1e-13);
+}
+
+TEST_CASE("Carlson RJ difficult arguments", "[ellint_carlson][xsf_tests]") {
+    // Mirrors
+    // https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/tests/test_basic.py#L1985-L1998
+    // SciPy marks this test xfail for insufficient accuracy on 32-bit.
+    using test_case = std::tuple<double, double, double, double, double>;
+    auto [x, y, z, p, expected] = GENERATE(
+        test_case{
+            6.483625725195452e-08, 1.1649136528196886e-27, 3.6767340167168e13, 0.493704617023468,
+            8.63426920644241857617477551054e-6
+        },
+        test_case{
+            14.375105857849121, 9.993988969725365e-11, 1.72844262269944e-26, 5.898871222598245e-06,
+            829774.1424801627252574054378691828
+        }
+    );
+    const double result = xsf::cpu::elliprj(x, y, z, p);
+    CAPTURE(x, y, z, p, result, expected);
+    REQUIRE(std::abs(result - expected) <= 1e-20 + 5e-15 * std::abs(expected));
+}
+
+TEST_CASE("Legendre-Carlson K and E identities", "[ellint_carlson][xsf_tests]") {
+    // Mirrors
+    // https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/tests/test_basic.py#L2001-L2024
+    // and
+    // https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/tests/test_basic.py#L2037-L2042
+    auto check_identities = [](double m) {
+        const double k = xsf::ellipk(m);
+        const double rf = xsf::cpu::elliprf(0.0, 1.0 - m, 1.0);
+        const double e = xsf::ellipe(m);
+        const double rg = 2.0 * xsf::cpu::elliprg(0.0, 1.0 - m, 1.0);
+        CAPTURE(m, k, rf, e, rg);
+        REQUIRE(xsf::extended_relative_error(k, rf) <= 1e-7);
+        REQUIRE(xsf::extended_relative_error(e, rg) <= 1e-7);
+    };
+    check_identities(std::numeric_limits<double>::lowest());
+    for (int exponent = 1023; exponent > 0; --exponent) {
+        check_identities(-std::ldexp(1.0, exponent));
+    }
+    for (int i = 0; i < 200; ++i) {
+        check_identities(-1.0 + 0.01 * i);
+    }
+}
+
+TEST_CASE("Legendre-Carlson Km1 identity", "[ellint_carlson][xsf_tests]") {
+    // Mirrors
+    // https://github.com/scipy/scipy/blob/v1.18.0/scipy/special/tests/test_basic.py#L2026-L2035
+    for (int exponent = -1022; exponent < 0; ++exponent) {
+        const double m1 = std::ldexp(1.0, exponent);
+        const double result = xsf::ellipkm1(m1);
+        const double expected = xsf::cpu::elliprf(0.0, m1, 1.0);
+        const double error = xsf::extended_relative_error(result, expected);
+        CAPTURE(m1, result, expected, error);
+        REQUIRE(error <= 1e-7);
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
https://github.com/scipy/xsf/issues/170

#### What does this implement/fix?
This PR adds Carlson elliptic integrals. For now, I've moved `ellint_carlson.h` to the CPU folder as this was not obvious this would work with GPU.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

I've worked with Codex on the port, notably the tests and permalinks.