### PR TITLE
MAINT: use CDF instead of SF for bivariate normal

### DIFF
--- a/include/xsf/multivariate_normal.h
+++ b/include/xsf/multivariate_normal.h
@@ -53,19 +53,22 @@ namespace detail {
 
 } // namespace detail
 
-XSF_HOST_DEVICE inline double bivariate_normal_sf(double dh, double dk, double r) {
-    // Survival function of the standard bivariate normal distribution.
+XSF_HOST_DEVICE inline double bivariate_normal_cdf(double dh, double dk, double r) {
+    // Cumulative distribution function of the standard bivariate normal distribution.
     //
-    // Return P(X > dh, Y > dk) for a standard bivariate normal vector
+    // Return P(X <= dh, Y <= dk) for a standard bivariate normal vector
     // (X, Y) with correlation r.
     //
-    // dh, dk are the lower limits of the upper tail, and r must satisfy
+    // dh, dk are the upper limits of the lower tail, and r must satisfy
     // -1 <= r <= 1.
     //
     // Adapted from the MATLAB original implementation by Dr. Alan Genz;
     // see license information in _qmvnt.py
     // In the comments, phid is the CDF of the standard normal distribution.
 
+    // By symmetry, the CDF at (dh, dk) is the upper-tail probability at (-dh, -dk).
+    dh = -dh;
+    dk = -dk;
     double p;
     if (detail::bivariate_normal_sf_boundary(dh, dk, r, p)) {
         return p;
@@ -182,8 +185,8 @@ XSF_HOST_DEVICE inline double bivariate_normal_sf(double dh, double dk, double r
     return bvn < 0.0 ? 0.0 : (bvn > 1.0 ? 1.0 : bvn);
 }
 
-XSF_HOST_DEVICE inline float bivariate_normal_sf(float dh, float dk, float r) {
-    return bivariate_normal_sf(static_cast<double>(dh), static_cast<double>(dk), static_cast<double>(r));
+XSF_HOST_DEVICE inline float bivariate_normal_cdf(float dh, float dk, float r) {
+    return bivariate_normal_cdf(static_cast<double>(dh), static_cast<double>(dk), static_cast<double>(r));
 }
 
 } // namespace xsf

--- a/tests/xsf_tests/test_bivariate_normal_cdf.cpp
+++ b/tests/xsf_tests/test_bivariate_normal_cdf.cpp
@@ -2,52 +2,56 @@
 #include <xsf/multivariate_normal.h>
 #include <xsf/stats.h>
 
-TEST_CASE("bivariate normal SF test", "[bivariate_normal_sf][xsf_tests]") {
+TEST_CASE("bivariate normal CDF test", "[bivariate_normal_cdf][xsf_tests]") {
 
-    SECTION("bivariate normal SF infinite inputs") {
+    SECTION("bivariate normal CDF infinite inputs") {
         // test cases with infinite inputs
         using test_case = std::tuple<double, double, double, double, double>;
         auto [dh, dk, r, expected, rtol] = GENERATE(
-            test_case{std::numeric_limits<double>::infinity(), 0.0, 0.5, 0.0, 1e-13},
+            test_case{-std::numeric_limits<double>::infinity(), 0.0, 0.5, 0.0, 1e-13},
+            test_case{0.0, -std::numeric_limits<double>::infinity(), 0.5, 0.0, 1e-13},
             test_case{
-                -std::numeric_limits<double>::infinity(), -std::numeric_limits<double>::infinity(), 0.5, 1.0, 1e-13
+                -std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity(), 0.5, 0.0, 1e-13
             },
-            test_case{-std::numeric_limits<double>::infinity(), 1.0, 0.5, xsf::ndtr(-1.0), 1e-13},
-            test_case{1.0, -std::numeric_limits<double>::infinity(), 0.5, xsf::ndtr(-1.0), 1e-13}
+            test_case{
+                std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity(), 0.5, 1.0, 1e-13
+            },
+            test_case{std::numeric_limits<double>::infinity(), 1.0, 0.5, xsf::ndtr(1.0), 1e-13},
+            test_case{1.0, std::numeric_limits<double>::infinity(), 0.5, xsf::ndtr(1.0), 1e-13}
         );
-        const double output = xsf::bivariate_normal_sf(dh, dk, r);
+        const double output = xsf::bivariate_normal_cdf(dh, dk, r);
         const auto rel_error = xsf::extended_relative_error(output, expected);
         CAPTURE(dh, dk, r, output, expected, rtol, rel_error);
         REQUIRE(rel_error <= rtol);
     }
 
-    SECTION("bivariate normal SF analytical dh=0, dk=0") {
-        // bivariate_normal_sf(0, 0, r) = 0.25 + asin(r)/(2*pi)
+    SECTION("bivariate normal CDF analytical dh=0, dk=0") {
+        // bivariate_normal_cdf(0, 0, r) = 0.25 + asin(r)/(2*pi)
         double dh = 0.0;
         double dk = 0.0;
         double r = GENERATE(-1.0, -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0);
         double expected = 0.25 + std::asin(r) / (2 * M_PI);
-        const double output = xsf::bivariate_normal_sf(dh, dk, r);
+        const double output = xsf::bivariate_normal_cdf(dh, dk, r);
         const auto rel_error = xsf::extended_relative_error(output, expected);
         double rtol = 1e-13;
         CAPTURE(dh, dk, r, output, expected, rtol, rel_error);
         REQUIRE(rel_error <= rtol);
     }
 
-    SECTION("bivariate normal SF r=0 independence") {
-        // bivariate_normal_sf(h, k, 0) = ndtr(-h) * ndtr(-dk)
+    SECTION("bivariate normal CDF r=0 independence") {
+        // bivariate_normal_cdf(h, k, 0) = ndtr(h) * ndtr(k)
         double dh = GENERATE(-1.0, 0.0, 1.0, 2.0);
         double dk = GENERATE(-1.0, 0.0, 1.0, 2.0);
         double r = 0.0;
-        const double output = xsf::bivariate_normal_sf(dh, dk, r);
-        const double expected = xsf::ndtr(-dh) * xsf::ndtr(-dk);
+        const double output = xsf::bivariate_normal_cdf(dh, dk, r);
+        const double expected = xsf::ndtr(dh) * xsf::ndtr(dk);
         const auto rel_error = xsf::extended_relative_error(output, expected);
         double rtol = 1e-13;
         CAPTURE(dh, dk, r, output, expected, rtol, rel_error);
         REQUIRE(rel_error <= rtol);
     }
 
-    SECTION("bivariate normal SF scipy reference values") {
+    SECTION("bivariate normal CDF scipy reference values") {
         // Reference values computed with scipy.stats._stats_pythran._bvnu using:
         //
         // import numpy as np
@@ -158,7 +162,8 @@ TEST_CASE("bivariate normal SF test", "[bivariate_normal_sf][xsf_tests]") {
 
         constexpr double rtol = 1e-10;
         constexpr double atol = 1e-10;
-        const double output = xsf::bivariate_normal_sf(dh, dk, r);
+        // _bvnu computes upper-tail probabilities; negate both limits for the CDF.
+        const double output = xsf::bivariate_normal_cdf(-dh, -dk, r);
         CAPTURE(dh, dk, r, output, expected, rtol, atol);
         CHECK(output >= 0.0);
         CHECK(output <= 1.0);
@@ -169,18 +174,24 @@ TEST_CASE("bivariate normal SF test", "[bivariate_normal_sf][xsf_tests]") {
         }
     }
 
-    SECTION("bivariate normal SF symmetry h,k") {
-        // bivariate_normal_sf(h, k, r) == bivariate_normal_sf(k, h, r)
-        REQUIRE(xsf::bivariate_normal_sf(1.0, 2.0, 0.5) == xsf::bivariate_normal_sf(2.0, 1.0, 0.5));
+    SECTION("bivariate normal CDF float overload") {
+        const float output = xsf::bivariate_normal_cdf(1.0f, 2.0f, 0.0f);
+        const float expected = xsf::ndtr(1.0) * xsf::ndtr(2.0);
+        REQUIRE(xsf::extended_relative_error(output, expected) <= 1e-6);
     }
 
-    SECTION("bivariate normal SF complementarity") {
-        // bivariate_normal_sf(h, k, r) + bivariate_normal_sf(h, -k, -r) == ndtr(-h)
+    SECTION("bivariate normal CDF symmetry h,k") {
+        // bivariate_normal_cdf(h, k, r) == bivariate_normal_cdf(k, h, r)
+        REQUIRE(xsf::bivariate_normal_cdf(1.0, 2.0, 0.5) == xsf::bivariate_normal_cdf(2.0, 1.0, 0.5));
+    }
+
+    SECTION("bivariate normal CDF complementarity") {
+        // bivariate_normal_cdf(h, k, r) + bivariate_normal_cdf(h, -k, -r) == ndtr(h)
         double dh = GENERATE(-1.0, 0.0, 1.0, 2.0);
         double dk = GENERATE(-1.0, 0.0, 1.0, 2.0);
         double r = GENERATE(-1.0, -0.75, -0.5, -0.25, 0.0, 0.25, 0.5, 0.75, 1.0);
-        double output = xsf::bivariate_normal_sf(dh, dk, r) + xsf::bivariate_normal_sf(dh, -dk, -r);
-        double expected = xsf::ndtr(-dh);
+        double output = xsf::bivariate_normal_cdf(dh, dk, r) + xsf::bivariate_normal_cdf(dh, -dk, -r);
+        double expected = xsf::ndtr(dh);
         const auto rel_error = xsf::extended_relative_error(output, expected);
         double rtol = 1e-13;
         CAPTURE(dh, dk, r, output, expected, rtol, rel_error);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure that
your PR is ready before submitting:

- Run the relevant tests locally. For the full test suite, use
  `pixi run tests`.
- Check formatting with `pixi run format-dry-error`. To fix formatting,
  use `pixi run format`.
- Name and describe your PR as you would write a commit message.

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
<!--Example: Closes gh-WXYZ.-->

#### What does this implement/fix?
As I worked on https://github.com/scipy/xsf/pull/270, it appeared clear (at least to me) that we should only have CDFs. This PR replaces the existing the SF implementation with CDF for the bivariate normal distribution.

#### Additional information
<!--Any additional information you think is important.-->

#### AI Generation Disclosure
<!-- If AI was used in the preparation of this pull request, please disclose
the tool(s) used, how they were used, and specify what code or text is AI generated.
If no AI tools were used, please write "No AI tools used" in this section. Read our
policy on AI generated code at
https://scipy.github.io/devdocs/dev/conduct/ai_policy.html -->

Worked with Codex.